### PR TITLE
MLPerf Storage benchmark script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dlio_benchmark"]
+	path = dlio_benchmark
+	url = https://github.com/argonne-lcf/dlio_benchmark.git

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# MLPerf™ Storage Benchmark Suite
+MLPerf Storage is a benchmark suite to characterize performance of storage systems that support machine learning workloads.
+
+## Overview
+
+Storage benchmark suite uses DLIO as a submodule inorder to 
+
+1. Generate synthetic data
+2. Run the benchmark on the generated data
+3. Create reports from the benchmark results
+
+## Releases
+The benchmark preview package will be released soon. Stay tuned!
+

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Options:
   -c, --category		Benchmark category to be submitted. Possible options are 'closed'(default)
   -w, --workload		Workload dataset to be generated. Possible options are 'unet3d', 'bert'
   -n, --num-parallel		Number of parallel jobs used to generate the dataset
-  -r, --results-dir		Location to the results directory
+  -r, --results-dir		Location to the results directory. Default is ./results/workload.model/DATE-TIME
   -p, --param			DLIO param when set, will override the config file value
 ```
 
@@ -99,7 +99,7 @@ Options:
   -w, --workload		Workload to be run. Possible options are 'unet3d', 'bert'
   -g, --accelerator-type	Simulated accelerator type used for the benchmark. Possible options are 'v100-32gb'(default)
   -n, --num-accelerators	Simulated number of accelerators of same accelerator type
-  -r, --results-dir		Location to the results directory
+  -r, --results-dir		Location to the results directory. Default is ./results/workload.model/DATE-TIME
   -p, --param			DLIO param when set, will override the config file value
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,213 @@
 # MLPerf™ Storage Benchmark Suite
 MLPerf Storage is a benchmark suite to characterize performance of storage systems that support machine learning workloads.
 
+- [Overview](#Overview) 
+- [Installation](#Installation)
+- [Configuration](#Configuration)
+- [Workloads](#Workloads)
+	- [U-Net3D](#U-Net3D)
+	- [BERT](#BERT) 
+	- [DLRM](#DLRM)
+- [Parameters](#Parameters)      
+- [Releases](#Releases)
 ## Overview
 
-Storage benchmark suite uses DLIO as a submodule inorder to 
+To be added
 
-1. Generate synthetic data
-2. Run the benchmark on the generated data
-3. Create reports from the benchmark results
+## Installation 
+
+Install dependencies using your system package manager.
+- `mpich` for MPI package
+- `sysstat` for iostat package
+
+For eg: when running on Ubuntu OS,
+
+```
+sudo apt-get install mpich sysstat
+```
+
+Clone the [MLCommons Storage](https://github.com/mlcommons/storage) repository and install Python dependencies.
+
+```bash
+git clone --recurse-submodules https://github.com/mlcommons/storage.git 
+cd storage
+pip3 install -r dlio_benchmark/requirements.txt
+```
+
+The working directory structure is as follows
+
+```
+|---storage
+       |---benchmark.sh
+       |---dlio_benchmark
+       |---storage-conf
+           |---workload(folder contains configs of all workloads)
+               |---unet3d.yaml
+               |---bert.yaml
+```
+
+The configuration of each workload is specified through a yaml file. You can see the configs of all workloads in `storage-conf` folder.
+
+```bash
+./benchmark.sh -h
+
+Usage: ./benchmark.sh [datagen/run/configview/reportgen] [options]
+Script to launch the MLPerf Storage benchmark.
+```
+## Configuration
+
+The benchmark suite consists of 3 distinct phases
+
+1. Synthetic data is generated based on the workload requested by the user.
+
+```bash
+./benchmark.sh datagen -h
+
+Usage: ./benchmark.sh datagen [options]
+Generate benchmark dataset based on the specified options.
+
+
+Options:
+  -h, --help			Print this message
+  -c, --category		Benchmark category to be submitted. Possible options are 'closed'(default)
+  -w, --workload		Workload dataset to be generated. Possible options are 'unet3d', 'bert'
+  -n, --num-parallel		Number of parallel jobs used to generate the dataset
+  -r, --results-dir		Location to the results directory
+  -p, --param			DLIO param when set, will override the config file value
+```
+
+Example:
+
+For generating training data for `unet3d` workload into `unet3d_data` directory with 10 subfolders using 8 parallel jobs, 
+
+```bash
+./benchmark.sh datagen --workload unet3d --num-parallel 8 --param dataset.num_subfolders_train=10 --param dataset.data_folder=unet3d_data
+```
+
+2. Benchmark is run on the generated data. Device stats are collected continuously using iostat profiler during the benchmark run.
+
+```bash
+./benchmark.sh run -h
+
+Usage: ./benchmark.sh run [options]
+Run benchmark on the generated dataset based on the specified options.
+
+
+Options:
+  -h, --help			Print this message
+  -c, --category		Benchmark category to be submitted. Possible options are 'closed'(default)
+  -w, --workload		Workload to be run. Possible options are 'unet3d', 'bert'
+  -g, --accelerator-type	Simulated accelerator type used for the benchmark. Possible options are 'v100-32gb'(default)
+  -n, --num-accelerators	Simulated number of accelerators of same accelerator type
+  -r, --results-dir		Location to the results directory
+  -p, --param			DLIO param when set, will override the config file value
+```
+
+Example:
+
+For running benchmark on `unet3d` workload with data located in `unet3d_data` directory using 4 accelerators and results on `unet3d_results` directory , 
+
+```bash
+./benchmark.sh run --workload unet3d --num-accelerators 4 --results-dir unet3d_results --param dataset.data_folder=unet3d_data
+```
+
+3. Reports are generated from the benchmark results
+
+```bash
+./benchmark.sh reportgen -h
+
+Usage: ./benchmark.sh reportgen [options]
+Generate a report from the benchmark results.
+
+
+Options:
+  -h, --help			Print this message
+  -r, --results-dir		Location to the results directory
+```
+
+## Workloads
+Currently, the storage benchmark suite supports benchmarking of 3 deep learning workloads
+- Image segmentation using U-Net3D model ([unet3d](./storage-conf/workloads/unet3d.yaml))
+- Natural language processing using BERT model ([bert](./storage-conf/workloads/bert.yaml))
+- Recommendation using DLRM model (TODO)
+
+### U-Net3D Workload
+
+Generate data for the benchmark run
+
+```bash
+./benchmark.sh datagen --workload unet3d --num-parallel 8
+```
+  
+Flush the filesystem caches before benchmark run in order to properly capture device I/O
+
+```bash
+sudo sync && echo 3 | sudo tee /proc/sys/vm/drop_caches
+```
+  
+Run the benchmark.
+
+```bash
+./benchmark.sh run --workload unet3d --num-accelerators 8
+```
+
+All results will be stored in ```results/unet3d/$DATE-$TIME``` folder or in the directory when overriden using `--results-dir`(or `-r`) argument. To generate the final report, one can do
+
+```bash 
+./benchmark.sh reportgen --results-dir results/unet3d/$DATE-$TIME
+```
+This will generate ```DLIO_$model_report.txt``` in the output folder. 
+
+### BERT Workload
+
+Generate data for the benchmark run
+
+```bash
+./benchmark.sh datagen --workload bert --num-parallel 8
+```
+  
+Flush the filesystem caches before benchmark run in order to properly capture device I/O
+```bash
+sudo sync && echo 3 | sudo tee /proc/sys/vm/drop_caches
+```
+  
+Run the benchmark
+```bash
+./benchmark.sh run --workload bert --num-accelerators 8
+```
+
+All results will be stored in ```results/bert/$DATE-$TIME``` folder or in the directory when overriden using `--results-dir`(or `-r`) argument. To generate the final report, one can do
+
+```bash 
+./benchmark.sh reportgen -r results/bert/$DATE-$TIME
+```
+This will generate ```DLIO_$model_report.txt``` in the output folder. 
+
+
+### DLRM Workload
+
+To be added
+
+## Parameters 
+
+Below table displays the list of configurable paramters for the benchmark. 
+
+| Parameter                      | Description                                                 |Default|
+| ------------------------------ | ------------------------------------------------------------ |-------|
+| **Dataset params**		|								|   |
+| dataset.num_files_train       | Number of files for the training set  		        | --|
+| dataset.num_subfolders_train  | Number of subfolders that the training set is stored	        |0|
+| dataset.data_folder           | The path where dataset is stored				| --|
+| dataset.keep_files  		| Flag whether to keep the dataset files afer the run	        |True|
+| **Reader params**				|						|   |
+| reader.read_threads		| Number of threads to load the data                            | --|
+| reader.computation_threads    | Number of threads to preprocess the data(only for bert)       | --|
+| reader.prefetch_size		| Number of batch to prefetch 			                |0|
+| **Checkpoint params**		|								|   |
+| checkpoint.checkpoint_folder	| The folder to save the checkpoints  				| --|
+| **Storage params**		|								|   |
+| storage.storage_root		| The storage root directory  					| ./|
+| storage.storage_type		| The storage type  						|local_fs|
 
 ## Releases
 The benchmark preview package will be released soon. Stay tuned!

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# Defaults
+export PYTHONPATH=${SCRIPT_DIR}/dlio_benchmark
+CONFIG_PATH=${SCRIPT_DIR}/storage-conf
+# Currently only "closed" category is supported
+CATEGORIES=("closed")
+DEFAULT_CATEGORY="closed"
+CLOSED_CATEGORY_PARAMS=(
+	# dataset params
+	"dataset.num_files_train" "dataset.num_subfolders_train" "dataset.data_folder" "dataset.keep_files"
+	# reader params
+	"reader.read_threads" "reader.computation_threads" "reader.prefetch_size"
+	# checkpoint params
+	"checkpoint.checkpoint_folder"
+	#storage params
+	"storage.storage_type" "storage.storage_root")
+
+OPEN_CATEGORY_PARAMS=(
+	# all closed params
+	"${CLOSED_CATEGORY_PARAMS[@]}"
+)
+HYDRA_OUTPUT_CONFIG_DIR="configs"
+EXTRA_PARAMS=(
+	# benchmark do not rely on any profilers
+	++workload.profiling.profiler=none
+	# config directory inside results used during runs
+	++hydra.output_subdir=$HYDRA_OUTPUT_CONFIG_DIR
+)
+# TODO add DLRM when supported
+WORKLOADS=("unet3d" "bert")
+#currently only v100-32gb is supported
+ACCELERATOR_TYPES=("v100-32gb")
+DEFAULT_ACCELERATOR_TYPE="v100-32gb"
+
+
+usage() {
+	echo -e "Usage: $0 [datagen/run/configview/reportgen] [options]"
+	echo -e "Script to launch the MLPerf Storage benchmark.\n"
+}
+
+datagen_usage() {
+	echo -e "Usage: $0 datagen [options]"
+	echo -e "Generate benchmark dataset based on the specified options.\n"
+	echo -e "\nOptions:"
+	echo -e "  -h, --help\t\t\tPrint this message"
+	echo -e "  -c, --category\t\tBenchmark category to be submitted. Possible options are 'closed'(default)"
+	echo -e "  -w, --workload\t\tWorkload dataset to be generated. Possible options are 'unet3d', 'bert' "
+	echo -e "  -n, --num-parallel\t\tNumber of parallel jobs used to generate the dataset"
+	echo -e "  -r, --results-dir\t\tLocation to the results directory"
+	echo -e "  -p, --param\t\t\tDLIO param when set, will override the config file value"
+}
+
+run_usage() {
+	echo -e "Usage: $0 run [options]"
+	echo -e "Run benchmark on the generated dataset based on the specified options.\n"
+	echo -e "\nOptions:"
+	echo -e "  -h, --help\t\t\tPrint this message"
+	echo -e "  -c, --category\t\tBenchmark category to be submitted. Possible options are 'closed'(default)"
+	echo -e "  -w, --workload\t\tWorkload to be run. Possible options are 'unet3d', 'bert' "
+	echo -e "  -g, --accelerator-type\tSimulated accelerator type used for the benchmark. Possible options are 'v100-32gb'(default) "
+	echo -e "  -n, --num-accelerators\tSimulated number of accelerators of same accelerator type"
+	echo -e "  -r, --results-dir\t\tLocation to the results directory"
+	echo -e "  -p, --param\t\t\tDLIO param when set, will override the config file value"
+}
+
+configview_usage() {
+	echo -e "Usage: $0 configview [options]"
+	echo -e "View the final config based on the specified options.\n"
+	echo -e "\nOptions:"
+	echo -e "  -h, --help\t\t\tPrint this message"
+	echo -e "  -w, --workload\t\tWorkload to be viewed. Possible options are 'unet3d', 'bert' "
+	echo -e "  -p, --param\t\t\tDLIO param when set, will override the config file value"
+}
+
+reportgen_usage() {
+	echo -e "Usage: $0 reportgen [options]"
+	echo -e "Generate a report from the benchmark results.\n"
+	echo -e "\nOptions:"
+	echo -e "  -h, --help\t\t\tPrint this message"
+	echo -e "  -r, --results-dir\t\tLocation to the results directory"
+}
+
+
+validate_in_list() {
+	local typ=$1; shift
+	local element=$1; shift
+	list=("$@")
+	if [[ ! " ${list[@]} " =~ " ${element} " ]]; then
+		echo "argument ${element} for ${typ} is invalid. It has be one of (${list[*]})"
+		exit 1
+	fi
+}
+
+validate_category() {
+	validate_in_list "category" $1 "${CATEGORIES[@]}" ;
+}
+
+validate_workload() {
+	validate_in_list "workload" $1 "${WORKLOADS[@]}" ;
+}
+
+validate_accelerator_type() {
+	validate_in_list "accelerator_type" $1 "${ACCELERATOR_TYPES[@]}" ;
+}
+
+validate_params() {
+	local category=$1; shift
+	local params=("$@")
+	for param in "${params[@]}"
+	do
+		param_name=$(echo $param | cut -d '=' -f 1)
+		if [[ " ${category} " =~ " open " ]]; then
+			validate_in_list "params" $param_name "${OPEN_CATEGORY_PARAMS[@]}"
+		elif [[ " ${category} " =~ " closed " ]]; then
+			validate_in_list "params" $param_name "${CLOSED_CATEGORY_PARAMS[@]}"
+		fi
+		param_value=$(echo $param | cut -d '=' -f 2)
+		validate_non_empty $param_name $param_value
+	done
+}
+
+
+
+validate_non_empty() {
+	local name=$1
+	local value=$2
+	if [[ -z "$value" ]]; then
+		echo "${name} should not be empty"
+		exit 1
+	fi
+}
+
+add_prefix_params() {
+	local input_array=( "$@" )
+	local prefixed_array=()
+	# prefix is fixed as per directory structure
+	prefix="++workload."
+	for element in "${input_array[@]}"; do
+		prefixed_array+=("$prefix$element")
+	done
+
+	echo "${prefixed_array[@]}"
+}
+
+datagen() {
+	local category=$1; shift
+	local workload=$1;shift
+	local parallel=$1;shift
+	local results_dir=$1; shift
+	local params=("$@")
+	validate_category $category
+	validate_workload $workload
+	if [[ ! -z "$params" ]]; then
+		validate_params $category "${params[@]}"
+	fi
+	if [[ ! -z "$results_dir" ]]; then
+		EXTRA_PARAMS=(
+			"${EXTRA_PARAMS[@]}" ++hydra.run.dir=$results_dir
+		)
+	fi
+	prefixed_array=$(add_prefix_params ${params[@]})
+	mpirun -np $parallel python3 dlio_benchmark/src/dlio_benchmark.py --config-path=$CONFIG_PATH workload=$workload ++workload.workflow.generate_data=True ++workload.workflow.train=False ${prefixed_array[@]} ${EXTRA_PARAMS[@]}
+}
+
+run() {
+	local category=$1;shift
+	local workload=$1;shift
+	local accelerator_type=$1;shift
+	local num_accelerators=$1;shift
+	local results_dir=$1; shift
+	local params=("$@")
+	validate_category $category
+	validate_workload $workload
+	validate_accelerator_type $accelerator_type
+	if [[ ! -z "$params" ]]; then
+		validate_params $category "${params[@]}"
+	fi
+	if [[ ! -z "$results_dir" ]]; then
+		EXTRA_PARAMS=(
+			"${EXTRA_PARAMS[@]}" ++hydra.run.dir=$results_dir
+		)
+	fi
+	prefixed_array=$(add_prefix_params ${params[@]})
+	mpirun -np $num_accelerators python3 dlio_benchmark/src/dlio_benchmark.py --config-path=$CONFIG_PATH workload=$workload ++workload.workflow.generate_data=False ++workload.workflow.train=True ${prefixed_array[@]} ${EXTRA_PARAMS[@]}
+}
+
+configview() {
+	local workload=$1;shift
+	local params=("$@")
+	validate_workload $workload
+	prefixed_array=$(add_prefix_params ${params[@]})
+	python3 dlio_benchmark/src/dlio_benchmark.py --config-path=$CONFIG_PATH workload=$workload ${prefixed_array[@]} --cfg=job
+}
+
+postprocess() {
+	local results_dir=$1
+	python3 dlio_benchmark/src/dlio_postprocessor.py --output-folder $results_dir --hydra-folder=$HYDRA_OUTPUT_CONFIG_DIR
+}
+
+main() {
+
+	local mode=$1; shift
+	if [ "$mode" = "datagen" ]
+	then
+		params=()
+		while [ $# -gt 0 ]; do
+			case "$1" in
+				-h | --help ) datagen_usage; exit 0 ;;
+				-c | --category ) category="$2"; shift 2 ;;
+				-w | --workload ) workload="$2"; shift 2 ;;
+				-n | --num-parallel ) parallel="$2"; shift 2 ;;
+				-r | --results-dir ) results_dir="$2"; shift 2 ;;
+				-p | --param ) params+=("$2"); shift 2 ;;
+				* ) echo "Invalid option $1"; datagen_usage; exit 1 ;;
+			esac
+		done
+		category=${category:-$DEFAULT_CATEGORY}
+		validate_non_empty "workload" $workload
+		parallel=${parallel:-1}
+		datagen $category $workload $parallel "$results_dir" "${params[@]}"
+	elif [ "$mode" = "run" ]
+	then
+		params=()
+		while [ $# -gt 0 ]; do
+			case "$1" in
+				-h | --help ) run_usage; exit 0 ;;
+				-c | --category ) category="$2"; shift 2 ;;
+				-w | --workload ) workload="$2"; shift 2 ;;
+				-g | --accelerator-type ) accelerator_type="$2"; shift 2 ;;
+				-n | --num-accelerators ) num_accelerators="$2"; shift 2 ;;
+				-r | --results-dir ) results_dir="$2"; shift 2 ;;
+				-p | --param ) params+=("$2"); shift 2 ;;
+				* ) echo "Invalid option $1"; run_usage; exit 1 ;;
+			esac
+		done
+		category=${category:-$DEFAULT_CATEGORY}
+		accelerator_type=${accelerator_type:-$DEFAULT_ACCELERATOR_TYPE}
+		validate_non_empty "workload" $workload
+		validate_non_empty "num-accelerators" $num_accelerators
+		run $category $workload $accelerator_type $num_accelerators "$results_dir" "${params[@]}"
+	elif [ "$mode" = "configview" ]
+	then
+		params=()
+		while [ $# -gt 0 ]; do
+			case "$1" in
+				-h | --help ) configview_usage; exit 0 ;;
+				-w | --workload ) workload="$2"; shift 2 ;;
+				-p | --param ) params+=("$2"); shift 2 ;;
+				* ) echo "Invalid option $1"; configview_usage; exit 1 ;;
+			esac
+		done
+		validate_non_empty "workload" $workload
+		configview $workload "${params[@]}"
+	elif [ "$mode" = "reportgen" ]
+	then
+		while [ $# -gt 0 ]; do
+			case "$1" in
+				-h | --help ) reportgen_usage; exit 0 ;;
+				-r | --results-dir ) results_dir="$2"; shift 2 ;;
+				* ) echo "Invalid option $1"; reportgen_usage; exit 1 ;;
+			esac
+		done
+		validate_non_empty "results-dir" $results_dir
+		postprocess $results_dir
+	else
+		usage; exit 1
+	fi
+
+}
+
+
+main $@

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -47,7 +47,7 @@ datagen_usage() {
 	echo -e "  -c, --category\t\tBenchmark category to be submitted. Possible options are 'closed'(default)"
 	echo -e "  -w, --workload\t\tWorkload dataset to be generated. Possible options are 'unet3d', 'bert' "
 	echo -e "  -n, --num-parallel\t\tNumber of parallel jobs used to generate the dataset"
-	echo -e "  -r, --results-dir\t\tLocation to the results directory"
+	echo -e "  -r, --results-dir\t\tLocation to the results directory. Default is ./results/workload.model/DATE-TIME"
 	echo -e "  -p, --param\t\t\tDLIO param when set, will override the config file value"
 }
 
@@ -60,7 +60,7 @@ run_usage() {
 	echo -e "  -w, --workload\t\tWorkload to be run. Possible options are 'unet3d', 'bert' "
 	echo -e "  -g, --accelerator-type\tSimulated accelerator type used for the benchmark. Possible options are 'v100-32gb'(default) "
 	echo -e "  -n, --num-accelerators\tSimulated number of accelerators of same accelerator type"
-	echo -e "  -r, --results-dir\t\tLocation to the results directory"
+	echo -e "  -r, --results-dir\t\tLocation to the results directory. Default is ./results/workload.model/DATE-TIME"
 	echo -e "  -p, --param\t\t\tDLIO param when set, will override the config file value"
 }
 

--- a/storage-conf/config.yaml
+++ b/storage-conf/config.yaml
@@ -1,0 +1,9 @@
+# A set of configuration
+defaults:
+ - _self_
+ - workload: 
+ - override hydra/job_logging: disabled  
+ - override hydra/hydra_logging: disabled
+hydra:
+  run:
+    dir: ./results/${workload.model}/${now:%Y-%m-%d}-${now:%H-%M-%S}

--- a/storage-conf/hydra/job_logging/custom.yaml
+++ b/storage-conf/hydra/job_logging/custom.yaml
@@ -1,0 +1,13 @@
+version: 1
+formatters:
+  simple:
+    format: '[%(levelname)s] - %(message)s [%(pathname)s:%(lineno)d]'
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: simple
+    stream: ext://sys.stdout
+root:
+  handlers: [console]
+
+disable_existing_loggers: false

--- a/storage-conf/workload/bert.yaml
+++ b/storage-conf/workload/bert.yaml
@@ -1,0 +1,35 @@
+model: bert
+
+framework: tensorflow
+
+workflow:
+  generate_data: False
+  train: True
+  debug: False
+  checkpoint: True
+ 
+dataset: 
+  data_folder: data/bert
+  format: tfrecord
+  num_files_train: 500
+  num_samples_per_file: 313532
+  record_length: 2500
+  file_prefix: part
+
+train:
+  computation_time: 0.968
+  total_training_steps: 5000
+ 
+reader:
+  data_loader: tensorflow
+  read_threads: 1
+  computation_threads: 1
+  transfer_size: 262144
+  batch_size: 48
+  file_shuffle: seed
+  sample_shuffle: seed
+
+checkpoint:
+  checkpoint_folder: checkpoints/bert
+  steps_between_checkpoints: 1250
+  model_size: 4034713312

--- a/storage-conf/workload/unet3d.yaml
+++ b/storage-conf/workload/unet3d.yaml
@@ -1,0 +1,33 @@
+model: unet3d
+
+framework: pytorch
+
+workflow:
+  generate_data: False
+  train: True
+  checkpoint: True
+
+dataset: 
+  data_folder: data/unet3d/
+  format: npz
+  num_files_train: 168
+  num_samples_per_file: 1
+  record_length: 234560851
+  record_length_stdev: 109346892
+  
+reader: 
+  data_loader: pytorch
+  batch_size: 4
+  read_threads: 4
+  file_shuffle: seed
+  sample_shuffle: seed
+
+train:
+  epochs: 10
+  computation_time: 1.3604
+
+checkpoint:
+  checkpoint_folder: checkpoints/unet3d
+  checkpoint_after_epoch: 5
+  epochs_between_checkpoints: 2
+  model_size: 499153191


### PR DESCRIPTION
MLPerf storage benchmark script is added with workload configurations and usage documentation. Currently,  it supports 2 workloads -unet3d and bert. Profiling is turned off for both workload as we are not relying on Iostat anymore. 
