### PR TITLE
feat: Add new playbooks for Ansible automation

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,42 @@
+# What is this?
+
+This is an ansible playbook for helping set up an MLPerf™ Storage Benchmark Suite.
+
+## How do you use this?
+
+The ansible_user should have sudo privileges.  Preferably, set up password-less
+ssh and password-less sudo for that user, though you can instead instruct
+ansible to ask for passwords using `-k, --ask-pass` from [docs](https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html#cmdoption-ansible-playbook-k).
+
+This is an example how to set password-less:
+
+```bash
+ ssh-copy-id root@172.22.X.X
+```
+
+Install dependencies:
+
+```bash
+python3 -m pip install ansible-pylibssh
+ansible-galaxy collection install -r collections/requirements.yml
+```
+
+Then run the playbook:
+
+```bash
+ansible-playbook -i inventory setup.yml
+```
+
+Run the playbook only on specific host or group:
+
+```bash
+ansible-playbook -i inventory -l worker1 setup.yml
+```
+
+## Example log
+
+```bash
+root@management:~/mlcommons/storage/ansible# ansible-playbook -i inventory setup.yml
+
+TBD...
+```

--- a/ansible/collections/requirements.yml
+++ b/ansible/collections/requirements.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Dell Inc, or its subsidiaries.
+---
+collections:
+  - community.docker
+  - community.general

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Dell Inc, or its subsidiaries.
+---
+- name: Install Docker and other packages
+  hosts: all
+  become: true
+  tasks:
+    - name: Ensure required packages are installed
+      ansible.builtin.package:
+        state: present
+        name:
+          - python3-pip
+          - sshpass
+          - git
+
+    - name: DEBIAN | Custom block of commands
+      when: ansible_os_family == 'Debian'
+      block:
+        - name: DEBIAN | Download Docker GPG key
+          ansible.builtin.get_url:
+            url: https://download.docker.com/linux/ubuntu/gpg
+            dest: /etc/apt/keyrings/docker.asc
+            mode: "0644"
+            force: true
+        - name: DEBIAN | Get architecture
+          ansible.builtin.command: dpkg --print-architecture
+          register: deb_architecture
+          changed_when: false
+        - name: DEBIAN | Add Docker repository
+          ansible.builtin.apt_repository:
+            state: present
+            repo: >
+              deb [arch={{ deb_architecture.stdout }} signed-by=/etc/apt/keyrings/docker.asc]
+              https://download.docker.com/linux/ubuntu
+              {{ ansible_distribution_release }} stable
+        - name: DEBIAN | Remove conflicting Docker packages
+          ansible.builtin.package:
+            state: absent
+            name:
+              - docker.io
+              - docker-doc
+              - docker-compose
+              - docker-compose-v2
+              - podman-docker
+              - containerd
+              - runc
+
+    - name: RHEL | Custom block of commands
+      when: ansible_os_family == "RedHat"
+      block:
+        - name: RHEL | Add Docker repository
+          # https://download.docker.com/linux/rhel/docker-ce.repo
+          ansible.builtin.yum_repository:
+            name: docker-ce-stable
+            description: Docker CE Stable - $basearch
+            baseurl: https://download.docker.com/linux/rhel/$releasever/$basearch/stable
+            gpgkey: https://download.docker.com/linux/rhel/gpg
+            gpgcheck: yes
+            enabled: yes
+        - name: RHEL | Remove conflicting Docker packages
+          ansible.builtin.package:
+            state: absent
+            name:
+              - docker
+              - docker-client
+              - docker-client-latest
+              - docker-common
+              - docker-latest
+              - docker-latest-logrotate
+              - docker-logrotate
+              - docker-engine
+              - podman
+              - runc
+
+    - name: Install Docker and related packages
+      ansible.builtin.package:
+        state: present
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-buildx-plugin
+          - docker-compose-plugin
+
+    - name: Ensure Docker service is started
+      ansible.builtin.systemd:
+        state: started
+        name: docker

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -1,0 +1,4 @@
+[clients]
+worker1 ansible_host=172.22.1.1     ansible_connection=ssh        ansible_user=root
+worker2 ansible_host=172.22.1.2     ansible_connection=ssh        ansible_user=root
+worker3 ansible_host=172.22.1.3     ansible_connection=ssh        ansible_user=root

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Dell Inc, or its subsidiaries.
+---
+- name: Install MLPerf™ Storage Benchmark Suite
+  hosts: clients
+  become: true
+  tasks:
+    - name: COMMON | Ensure common required packages are installed
+      ansible.builtin.package:
+        state: present
+        name:
+          - bc
+          - cmake
+          - curl
+          - git
+          - mpich
+          - sshpass
+          - sysstat
+
+    - name: Download UV installer
+      ansible.builtin.get_url:
+        url: https://astral.sh/uv/0.6.1/install.sh
+        dest: /tmp/install.sh
+        mode: '0755'
+
+    - name: Install UV
+      ansible.builtin.command: "sh /tmp/install.sh"
+
+    - name: Recursively remove directory
+      ansible.builtin.file:
+        path: /root/venv/
+        state: absent
+
+    - name: Create virtual python environment based on 3.12
+      ansible.builtin.command: /root/.local/bin/uv venv --python 3.12 /root/venv/
+
+    - name: DEBIAN | Custom block of commands
+      when: ansible_os_family == 'Debian'
+      block:
+        - name: DEBIAN | Remove Open MPI
+          ansible.builtin.package:
+            state: absent
+            name:
+              - libopenmpi-dev
+        - name: DEBIAN | Install packages
+          ansible.builtin.package:
+            state: present
+            name:
+              - build-essential
+              - libhwloc-dev
+              - libmpich-dev
+              - openssh-client
+
+        - name: DEBIAN | Install mpi4py
+          ansible.builtin.command: /root/.local/bin/uv pip install mpi4py
+          args:
+            chdir: /root/venv/
+
+    - name: RHEL | Custom block of commands
+      when: ansible_os_family == "RedHat"
+      block:
+        - name: RHEL | Remove Open MPI
+          ansible.builtin.package:
+            state: absent
+            name:
+              - openmpi-devel
+        - name: RHEL | Install packages
+          ansible.builtin.package:
+            state: present
+            name:
+              - hwloc-devel
+              - mpich-devel
+              - openssh-clients
+
+        - name: RHEL | Install development tools
+          ansible.builtin.yum:
+            name: "@Development tools"
+            state: present
+
+        - name: RHEL | Install mpi4py
+          ansible.builtin.command: /root/.local/bin/uv pip install mpi4py
+          args:
+            chdir: /root/venv/
+          environment:
+            CC: /usr/lib64/mpich/bin/mpicc
+
+    - name: SLES | Custom block of commands
+      when: ansible_os_family == "Suse"
+      block:
+        - name: SLES | Remove Open MPI
+          ansible.builtin.package:
+            state: absent
+            name:
+              - openmpi-devel
+        - name: SLES | Install packages
+          ansible.builtin.package:
+            state: present
+            name:
+              - hwloc-devel
+              - mpich-devel
+              - openssh-clients
+              - gcc12-c++
+              - gcc12
+              - cpp12
+
+        - name: SLES | Install development tools
+          community.general.zypper:
+            name: devel_basis
+            state: present
+            type: pattern
+
+        - name: SLES | Install mpi4py
+          ansible.builtin.command: /root/.local/bin/uv pip install mpi4py
+          args:
+            chdir: /root/venv/
+          environment:
+            CC: /usr/lib64/mpi/gcc/mpich/bin/mpicc
+
+        - name: SLES | Configure gcc alternatives
+          community.general.alternatives: name={{ item.name }} link={{ item.link }} path={{ item.path }}
+          with_items:
+          - { name: gcc, link: /usr/bin/gcc, path: "/usr/bin/gcc-12", priority: "80" }
+          - { name: cpp, link: /usr/bin/cpp, path: "/usr/bin/cpp-12", priority: "80" }
+          - { name: g++, link: /usr/bin/g++, path: "/usr/bin/g++-12", priority: "80" }
+          - { name: c++, link: /usr/bin/c++, path: "/usr/bin/g++-12", priority: "80" }
+
+        - name: SLES | Install dlio_profiler_py
+          ansible.builtin.command: /root/.local/bin/uv pip install dlio_profiler_py==0.0.3
+          args:
+            chdir: /root/venv/
+
+    - name: Checkout beckchmark code
+      ansible.builtin.git:
+        repo: 'https://github.com/mlcommons/storage.git'
+        dest: /root/storage
+        recursive: true
+        version: v1.0
+
+    - name: Install DLIO python requirements
+      ansible.builtin.command: /root/.local/bin/uv pip install -r /root/storage/dlio_benchmark/requirements.txt
+      args:
+        chdir: /root/venv/


### PR DESCRIPTION
- Introduced initial set of Ansible playbooks to automate the MLPerf storage benchmark tool.
- Playbooks include tasks for environment setup only for now.
- Playbooks install bare metal environment as well as docker engine.
- Added documentation for usage and configuration of the playbooks.

This commit enhances our automation capabilities, streamlining the benchmarking process and ensuring consistent, reproducible results.