### PR TITLE
Issue Fix: self keyword missing in rules.py

### DIFF
--- a/mlpstorage/rules.py
+++ b/mlpstorage/rules.py
@@ -135,7 +135,7 @@ class BenchmarkVerifier:
         elif self.benchmark.args.closed:
             self.logger.error(f'Number of processes ({num_procs}) should be exactly {LLM_SUBSET_PROCS} or {ClosedGPUs} in closed submission.')
             validations.add(PARAM_VALIDATION.INVALID)
-        elif not benchmark.args.closed:
+        elif not self.benchmark.args.closed:
             # num procs should be a multiple of GPUpDP
             dp_instances = num_procs / GPUpDP
             if not dp_instances.is_integer():


### PR DESCRIPTION
This PR addresses Issue #103 

There is a bug in the checkpointing feature that is causing an error—I couldn't run checkpointing and received the error message "Error occurred during benchmark verification: name 'benchmark' is not defined. Contact the developer."

One of the reasons was that in rules.py line 138, self. was missing in front of benchmark.args.closed

It should be:
elif not self.benchmark.args.closed: 