### PR TITLE
Wvaske/may 22 2025 fixes

### DIFF
--- a/mlpstorage/benchmarks/dlio.py
+++ b/mlpstorage/benchmarks/dlio.py
@@ -1,5 +1,6 @@
 import abc
 import os
+import os.path
 import pprint
 import sys
 
@@ -18,7 +19,12 @@ class DLIOBenchmark(Benchmark, abc.ABC):
     def __init__(self, args, **kwargs):
         super().__init__(args, **kwargs)
         self._config_name = None
-        self.base_command_path = f"dlio_benchmark"
+        self.base_command = "dlio_benchmark"
+        if args.dlio_bin_path:
+            self.base_path = args.dlio_bin_path
+        else:
+            self.base_path = os.path.dirname(sys.argv[0])
+        self.base_command_path = os.path.join(self.base_path, self.base_command)
 
         # This is the path that DLIO needs. The files are in this self.config_path/workload
         self.config_path = os.path.join(CONFIGS_ROOT_DIR, self.DLIO_CONFIG_PATH)

--- a/mlpstorage/cli.py
+++ b/mlpstorage/cli.py
@@ -283,6 +283,7 @@ def add_training_arguments(training_parsers):
     for _parser in [datasize, datagen, run_benchmark, configview]:
         _parser.add_argument("--data-dir", '-dd', type=str, help="Filesystem location for data")
         _parser.add_argument('--params', '-p', nargs="+", type=str, action="append", help=help_messages['params'])
+        _parser.add_argument('--dlio-bin-path', '-dp', type=str, help="Path to DLIO binary. Default is the same as mlpstorage binary path")
         add_universal_arguments(_parser)
 
 
@@ -307,6 +308,9 @@ def add_checkpointing_arguments(checkpointing_parsers):
     checkpointing_parsers.add_argument('--num-processes', '-np', type=int, default=None, help=help_messages['num_checkpoint_accelerators'])
     checkpointing_parsers.add_argument('--params', '-p', nargs="+", type=str, action="append", help=help_messages['params'])
     checkpointing_parsers.add_argument("--data-dir", '-dd', type=str, help="Filesystem location for data")
+    checkpointing_parsers.add_argument('--dlio-bin-path', '-dp', type=str,
+                                       help="Path to DLIO binary. Default is the same as mlpstorage binary path")
+
     # Since we're not using subparsers, this happens in the main function
     #add_universal_arguments(checkpointing_parsers)
 


### PR DESCRIPTION
Support for comma delimited --hosts
Support to define dlio_benchmark binary path. Default will use the same bin directory as mlpstorage.