### PR TITLE
Wvaske/june 12 checkpoint rules updates

### DIFF
--- a/Submission_guidelines.md
+++ b/Submission_guidelines.md
@@ -124,6 +124,7 @@ There are two operational modes:
 **Checkpoint write and (read) recovery**
 
 For each submission, one must first perform the checkpoint write, then clear the cache if required, and finally perform the checkpoint read. The required command-line flags are:
+*Note: Clearing caches is done to ensure that no data for the read phase comes from the filesystem cache*
 
 For a submission, the sequence is the following:
 1. Write 10x checkpoints
@@ -145,10 +146,11 @@ In the above example, the write tests would be executed first with this command 
 mlpstorage checkpointing run --client-host-memory-in-gb 512 --model llama3-8b --num-processes 8 --checkpoint-folder /mnt/checkpoint_test --num-checkpoints-read=0
 ```
 
-After the read tests complete, clear the caches on your hosts. A standard linux system would use a command like this:
+After the write tests complete, clear the caches on your hosts. A standard linux system would use a command like this:
 ```bash
 echo 3 > /proc/sys/vm/drop_caches
 ```
+The end result of "clearing caches" is that 100% data for the read phase should come from the storage system under test and not from the client's filesystem cache. 
 
 Finally, with the same example the read tests would be executed with the following command which indicates no writes during this phase:
 ```bash

--- a/Submission_guidelines.md
+++ b/Submission_guidelines.md
@@ -141,9 +141,9 @@ The checkpoints that are written are quite large. If the checkpoint size per cli
 
 Eamples:
 
-| Model (Total Size) | Num Clients & Memory| Size for ranks | Size for 1st and Last Client | Need to Clear Caches? |
-|-----------------------------------------------------------------------------------------|
-| Llama3 405b (912GB) | 8x (64 Ranks / Node)<br>1024GB per Client |  256x 11.8GB<br>256x 8.85GB | First: 755GB<br>Last: 566.4GB | No (556GB x 3 = 1,699GB which is greater than the client memory ())
+| Model (Total Size) | Num Clients & Memory | Size for ranks | Size for 1st and Last Client | Need to Clear Caches? |
+|--------------------|----------------------|----------------|------------------------------|-----------------------|
+| Llama3 405b (912GB) | 8x (64 Ranks / Node)<br>1024GB per Client |  256x 11.8GB<br>256x 8.85GB | First: 755GB<br>Last: 566.4GB | No (556GB x 3 = 1,699GB which is greater than the client memory ()) |
 
 **fsync**
 We enforce ``fsync`` to be applied during checkpoint writes to ensure data is flushed to persistent storage. ``fsync`` is enabled by default in all workload configuration files.

--- a/mlpstorage/benchmarks/dlio.py
+++ b/mlpstorage/benchmarks/dlio.py
@@ -302,7 +302,7 @@ class CheckpointingBenchmark(DLIOBenchmark):
         for rank in range(self.args.num_processes):
             rank_gb.append(0)
             if zero_level == 1:
-                self.logger.debug("Optimizer is written by all ranks, but only first DP rank writes model")
+                self.logger.debug("Optimizer is written by all ranks, but only ranks in the first DP write the model")
                 rank_gb[rank] = optimizer_gb / self.args.num_processes
                 if rank < GPUpDP:
                     rank_gb[rank] += model_gb / GPUpDP

--- a/mlpstorage/benchmarks/dlio.py
+++ b/mlpstorage/benchmarks/dlio.py
@@ -299,15 +299,16 @@ class CheckpointingBenchmark(DLIOBenchmark):
         rank_gb = []
 
         self.logger.verbose(f'Model & optimizer size: {model_gb:.2f} GB, {optimizer_gb:.2f} GB')
+        import pdb
+        pdb.set_trace()
         for rank in range(self.args.num_processes):
             rank_gb.append(0)
             if zero_level == 1:
-                if rank == 0:
-                    rank_gb[rank] = model_gb + (optimizer_gb / self.args.num_processes)
-                    self.logger.debug(f'Rank {rank} writes entire model: {rank_gb[rank]:.2f} GB')
-                else:
-                    rank_gb[rank] = optimizer_gb / self.args.num_processes
-                    self.logger.debug(f'Rank {rank} writes optimizer: {rank_gb[rank]:.2f} GB')
+                self.logger.debug("Optimizer is written by all ranks, but only first DP rank writes model")
+                rank_gb[rank] = optimizer_gb / self.args.num_processes
+                if rank < GPUpDP:
+                    rank_gb[rank] += model_gb / GPUpDP
+                    self.logger.debug(f'First DP rank {rank} writes model: {rank_gb[rank]:.2f} GB')
             elif zero_level == 3:
                 rank_gb[rank] = (model_gb + optimizer_gb) / self.args.num_processes
                 self.logger.debug(f'Rank {rank} writes portion of model and optimizer: {rank_gb[rank]:.2f} GB')

--- a/mlpstorage/benchmarks/dlio.py
+++ b/mlpstorage/benchmarks/dlio.py
@@ -299,8 +299,6 @@ class CheckpointingBenchmark(DLIOBenchmark):
         rank_gb = []
 
         self.logger.verbose(f'Model & optimizer size: {model_gb:.2f} GB, {optimizer_gb:.2f} GB')
-        import pdb
-        pdb.set_trace()
         for rank in range(self.args.num_processes):
             rank_gb.append(0)
             if zero_level == 1:

--- a/mlpstorage/config.py
+++ b/mlpstorage/config.py
@@ -67,10 +67,10 @@ LLM_MODELS = [LLAMA3_70B, LLAMA3_405B, LLAMA3_1T, LLAMA3_8B]
 LLM_SUBSET_PROCS = 8
 # Defined as (MinProcs, ZeroLevel, GPU per Data Parallel Instance, Closed GPU Count)
 LLM_ALLOWED_VALUES = {
-    LLAMA3_1T: (LLM_SUBSET_PROCS, 3, 8*64, 8*64*2),     # 8*64*2 = 1,024 processes
-    LLAMA3_405B: (LLM_SUBSET_PROCS, 3, 8*32, 8*32*2),   # 8*32*2 = 512 processes
-    LLAMA3_70B: (LLM_SUBSET_PROCS, 1, 8, 8*8),          # 8*8*1 = 64 processes
-    LLAMA3_8B: (LLM_SUBSET_PROCS, 1, 8, 8)              # 8*1*1 = 8 processes
+    LLAMA3_1T: (LLM_SUBSET_PROCS, 1, 8*64, 8*64*2),     # 8*64*2 = 1,024 processes
+    LLAMA3_405B: (LLM_SUBSET_PROCS, 1, 8*32, 8*32*2),   # 8*32*2 = 512 processes
+    LLAMA3_70B: (LLM_SUBSET_PROCS, 3, 8, 8*8),          # 8*8*1 = 64 processes
+    LLAMA3_8B: (LLM_SUBSET_PROCS, 3, 8, 8)              # 8*1*1 = 8 processes
 }
 
 # Defined as (Model GB, Optimizer GB)

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -64,7 +64,7 @@ commands=(
     "mlpstorage training datasize --model resnet50 --client-host-memory-in-gb 256 --max-accelerators 80 --num-client-hosts 2 --accelerator-type a100|0"
     "mlpstorage training datasize --model resnet50 --client-host-memory-in-gb 256 --max-accelerators 80 --num-client-hosts 2 --accelerator-type h100|0"
     "mlpstorage training datasize --model cosmoflow --client-host-memory-in-gb 256 --max-accelerators 80 --num-client-hosts 2 --accelerator-type h100|0"
-    "mlpstorage training datasize --model unet3d --client-host-memory-in-gb 256 --max-accelerators 80 --num-client-hosts 2 --accelerator-type h100 --closed|0"
+    "mlpstorage training datasize --model unet3d --client-host-memory-in-gb 256 --max-accelerators 80 --num-client-hosts 2 --accelerator-type h100|0"
 
     "mlpstorage training datagen --hosts 127.0.0.1,127.0.0.1 --model resnet50 --num-processes 96 --param dataset.num_files_train=192 --data-dir /mnt/nvme/test_data --results-dir /root/mlpstorage_test_results --allow-run-as-root|0"
     "mlpstorage training datagen --hosts 127.0.0.1,127.0.0.1 --model cosmoflow --num-processes 96 --param dataset.num_files_train=192 --data-dir /mnt/nvme/test_data --results-dir /root/mlpstorage_test_results --allow-run-as-root|0"
@@ -88,7 +88,7 @@ commands=(
     "mlpstorage checkpointing run --hosts 127.0.0.1 --model llama3-1t --client-host-memory-in-gb 512 --num-processes 8 --checkpoint-folder /mnt/nvme/test_data --results-dir /root/mlpstorage_test_results --num-checkpoints-read 1 --num-checkpoints-write 1 --allow-run-as-root|0"
 
     "mlpstorage reports reportgen --results-dir ./test_results|3"
-#    "mlpstorage reports reportgen --results-dir /root/mlpstorage_test_results|0"
+    "mlpstorage reports reportgen --results-dir /root/mlpstorage_test_results|0"
 )
 
 # Loop through all commands and run them

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -58,13 +58,13 @@ commands=(
     "mlpstorage --version|0"
     "mlpstorage history show|0"
 
-    # Example of a command expected to fail with exit code 2 (INVALID_ARGUMENTS)
+#     Example of a command expected to fail with exit code 2 (INVALID_ARGUMENTS)
     "mlpstorage training datasize --invalid-flag|2"
 
     "mlpstorage training datasize --model resnet50 --client-host-memory-in-gb 256 --max-accelerators 80 --num-client-hosts 2 --accelerator-type a100|0"
     "mlpstorage training datasize --model resnet50 --client-host-memory-in-gb 256 --max-accelerators 80 --num-client-hosts 2 --accelerator-type h100|0"
     "mlpstorage training datasize --model cosmoflow --client-host-memory-in-gb 256 --max-accelerators 80 --num-client-hosts 2 --accelerator-type h100|0"
-    "mlpstorage training datasize --model unet3d --client-host-memory-in-gb 256 --max-accelerators 80 --num-client-hosts 2 --accelerator-type h100|0"
+    "mlpstorage training datasize --model unet3d --client-host-memory-in-gb 256 --max-accelerators 80 --num-client-hosts 2 --accelerator-type h100 --closed|0"
 
     "mlpstorage training datagen --hosts 127.0.0.1,127.0.0.1 --model resnet50 --num-processes 96 --param dataset.num_files_train=192 --data-dir /mnt/nvme/test_data --results-dir /root/mlpstorage_test_results --allow-run-as-root|0"
     "mlpstorage training datagen --hosts 127.0.0.1,127.0.0.1 --model cosmoflow --num-processes 96 --param dataset.num_files_train=192 --data-dir /mnt/nvme/test_data --results-dir /root/mlpstorage_test_results --allow-run-as-root|0"
@@ -88,7 +88,7 @@ commands=(
     "mlpstorage checkpointing run --hosts 127.0.0.1 --model llama3-1t --client-host-memory-in-gb 512 --num-processes 8 --checkpoint-folder /mnt/nvme/test_data --results-dir /root/mlpstorage_test_results --num-checkpoints-read 1 --num-checkpoints-write 1 --allow-run-as-root|0"
 
     "mlpstorage reports reportgen --results-dir ./test_results|3"
-    "mlpstorage reports reportgen --results-dir /root/mlpstorage_test_results|0"
+#    "mlpstorage reports reportgen --results-dir /root/mlpstorage_test_results|0"
 )
 
 # Loop through all commands and run them


### PR DESCRIPTION
Updates to the rules document for a proposal from the WG meeting on June 12th.

Cleared up some language.

Explicitly allow shared  storage solutions that do not allow simultaneous reads and or write access (this was implicitly allowed previously).

In the event that simultaneous read is not possible a submitter must measure the time from finishing a write on one host to the data being available to read on another host and this time must be added to the checkpoint recovery metrics.