### PR TITLE
system-configuration changes & mpi-options

### DIFF
--- a/mlpstorage/benchmarks/dlio.py
+++ b/mlpstorage/benchmarks/dlio.py
@@ -112,7 +112,8 @@ class DLIOBenchmark(Benchmark, abc.ABC):
         if self.args.exec_type == EXEC_TYPE.MPI:
             self.logger.debug(f'Generating MPI Command with binary "{self.args.mpi_bin}"')
             mpi_prefix = generate_mpi_prefix_cmd(self.args.mpi_bin, self.args.hosts, self.args.num_processes,
-                                                 self.args.oversubscribe, self.args.allow_run_as_root, self.logger)
+                                                 self.args.oversubscribe, self.args.allow_run_as_root,
+                                                 self.args.mpi_params, self.logger)
             cmd = f"{mpi_prefix} {cmd}"
 
         return cmd

--- a/mlpstorage/cli.py
+++ b/mlpstorage/cli.py
@@ -253,6 +253,7 @@ def add_mpi_group(parser):
     mpi_options.add_argument('--mpi-bin', choices=MPI_CMDS, default="mpirun", help=help_messages['mpi_bin'])
     mpi_options.add_argument('--oversubscribe', action="store_true")
     mpi_options.add_argument('--allow-run-as-root', action="store_true")
+    mpi_options.add_argument('--mpi-params', nargs="+", type=str, action="append", help="Other MPI parameters that will be passed to MPI")
 
 
 def add_training_arguments(training_parsers):
@@ -449,6 +450,10 @@ def update_args(args):
     if args.params:
         flattened_params = [item for sublist in args.params for item in sublist]
         setattr(args, 'params', flattened_params)
+
+    if args.mpi_params:
+        flattened_mpi_params = [item for sublist in args.mpi_params for item in sublist]
+        setattr(args,'mpi_params', flattened_mpi_params)
 
     if hasattr(args, 'hosts'):
         print(f'Hosts is: {args.hosts}')

--- a/mlpstorage/utils.py
+++ b/mlpstorage/utils.py
@@ -326,7 +326,7 @@ class CommandExecutor:
         self._original_handlers = {}
 
 
-def generate_mpi_prefix_cmd(mpi_cmd, hosts, num_processes, oversubscribe, allow_run_as_root, logger):
+def generate_mpi_prefix_cmd(mpi_cmd, hosts, num_processes, oversubscribe, allow_run_as_root, params, logger):
     # Check if we got slot definitions with the hosts:
     slots_configured = False
     for host in hosts:
@@ -368,5 +368,9 @@ def generate_mpi_prefix_cmd(mpi_cmd, hosts, num_processes, oversubscribe, allow_
 
     if allow_run_as_root:
         prefix += " --allow-run-as-root"
+
+    if params:
+        for param in params:
+            prefix += f" {param}"
 
     return prefix

--- a/system_configuration.yaml
+++ b/system_configuration.yaml
@@ -1,13 +1,9 @@
 System:
   name: FastAmazingAcmeStorage 9000
   description: <text>
-  # Type can be any of:
-  #  - local-storage
-  #  - hyper-converged
-  #  - shared-[file|block|object]
-  #  - cloud-deployment
-  type: local_storage
-  access_protocol: block / file / proprietary / nfs / etc
+  storage_location: [ remote | local | hyper-converged ]
+  client_software: [ in-box | proprietary ]
+  storage_interface: [ block | file | object ]
   required_rack_units:
   shared_capabilities:
     multi_host_support: True            # False is used for local storage


### PR DESCRIPTION
Please test the --mpi-params option. I'm not scaled out so I'm not certain if it works in non-local use-cases properly. It should, it's just passing through from the mlpstorage cli to the mpirun cli.


Added cli option for --mpi-params. It can be used in the following ways:
```python
mlpstorage --mpi-params "--param1=value1 --param2=value2"
mlpstorage --mpi-params "--param1=value1" "--param2=value2"
mlpstorage --mpi-params "--param1-value1" --mpi-params "--param2=value2"
```

If the parameter doesn't begin with a hyphen, you don't need the quotes.

To see if it will work correctly use the `--what-if` flag to print the command that would be executed wtihout actually executing.

I still can't see @FileSystemGuy 's comments on the last issue. There was a 4th item I had to add to the system description that I didn't capture. Here's what I have:

```
System:
  name: FastAmazingAcmeStorage 9000
  description: <text>
  storage_location: [ remote | local | hyper-converged ]
  client_software: [ in-box | proprietary ]
  storage_interface: [ block | file | object ]
  required_rack_units:
  shared_capabilities:
    multi_host_support: True            # False is used for local storage
    ...
```

Let me know what I need to add.