### PR TITLE
Add a rules exception that it's OK to apply DLIO PR #299 in CLOSED

### DIFF
--- a/Submission_guidelines.md
+++ b/Submission_guidelines.md
@@ -479,7 +479,7 @@ CLOSED represents a level playing field where all results are **comparable** acr
 
 In order to accomplish that, most of the optimizations and customizations to the AI/ML algorithms and framework that might typically be applied during benchmarking or even during production use must be disallowed.  Optimizations and customizations to the storage system are allowed in CLOSED.
 
-For CLOSED submissions of this benchmark, the MLPerf Storage codebase takes the place of the AI/ML algorithms and framework, and therefore cannot be changed. 
+For CLOSED submissions of this benchmark, the MLPerf Storage codebase takes the place of the AI/ML algorithms and framework, and therefore cannot be changed. The sole exception to this rule is if the submitter decides to apply the code change identified in PR#299 of the DLIO repo in github, the resulting codebase will be considered "unchanged" for the purposes of this rule. 
 
 A small number of parameters can be configured in CLOSED submissions; listed in the tables below.
 


### PR DESCRIPTION
The following text change was applied: "The sole exception to this rule is if the submitter decides to apply the code change identified in PR#299 of the DLIO repo in github, the resulting codebase will be considered "unchanged" for the purposes of this rule."