### PR TITLE
Remove unnecessary package installations from ansible script

### DIFF
--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -33,6 +33,13 @@
     - name: DEBIAN | Install OS-specific system dependencies
       when: ansible_os_family == 'Debian'
       block:
+        - name: DEBIAN | Remove Open MPI
+          ansible.builtin.package:
+            state: absent
+            name:
+              - libopenmpi-dev
+              - openmpi-bin 
+              - openmpi-common
         - name: DEBIAN | Install Python and MPI packages
           ansible.builtin.package:
             name:
@@ -42,6 +49,12 @@
     - name: RHEL | Install OS-specific system dependencies
       when: ansible_os_family == 'RedHat'
       block:
+        - name: RHEL | Remove Open MPI
+          ansible.builtin.package:
+            state: absent
+            name:
+              - openmpi-devel       
+              - openmpi
         - name: RHEL | Install Python and MPI packages
           ansible.builtin.package:
             name:
@@ -62,6 +75,12 @@
     - name: SLES | Install OS-specific system dependencies
       when: ansible_os_family == 'Suse'
       block:
+        - name: SLES | Remove Open MPI
+          ansible.builtin.package:
+            state: absent
+            name:
+              - openmpi-devel
+              - openmpi
         - name: SLES | Install base system packages
           ansible.builtin.package:
             name:


### PR DESCRIPTION
This PR updates the Ansible playbook to uninstall OpenMPI-related packages (_libopenmpi-dev, openmpi-bin, openmpi-common, openmpi, openmpi-devel_) on Ubuntu, RHEL, and SLES systems.
OpenMPI packages were determined to be unnecessary for our current deployment environment. Removing them will:

- Simplify system configuration
- Reduce installation and setup time
- Minimize potential package conflicts and security risks

**Changes**

- Added an Ansible task using ansible.builtin.package with state: absent to uninstall OpenMPI packages across supported Linux distributions.
- Included package names for Ubuntu/Debian, RHEL, and SLES to ensure cross-distro compatibility.
- Added conditional logic to run this task only on Debian, RedHat, and SUSE family systems.

**Testing**

- Ran the updated playbook on clean Ubuntu, RHEL, and SLES test VMs.
- Confirmed OpenMPI packages are removed successfully.
- Verified no errors or unintended side effects during playbook execution.

