### PR TITLE
Add --file and --object arguments

### DIFF
--- a/mlpstorage/cli/common_args.py
+++ b/mlpstorage/cli/common_args.py
@@ -188,6 +188,22 @@ def add_universal_arguments(parser):
         help="Path to YAML file with argument overrides"
     )
 
+    # Create a mutually exclusive group for file/object options
+    access_proto = standard_args.add_mutually_exclusive_group(required=True)
+    access_proto.add_argument(
+        "--file",
+        action="store_true",
+        help="Use POSIX files as the data access method"
+    )
+    access_proto.add_argument(
+        "--object",
+        nargs="?",
+        type=str,
+        const="s3",
+        choices=["s3"],
+        help="Use the given Object API as the data access method, defaults to S3"
+    )
+
     # Create a mutually exclusive group for closed/open options
     submission_group = standard_args.add_mutually_exclusive_group()
     submission_group.add_argument(

--- a/mlpstorage/cli_parser.py
+++ b/mlpstorage/cli_parser.py
@@ -105,7 +105,19 @@ def parse_arguments():
     # Apply YAML config file overrides if specified
     if hasattr(parsed_args, 'config_file') and parsed_args.config_file:
         parsed_args = apply_yaml_config_overrides(parsed_args)
-    
+
+    # Consolidate the data access protocol into a single field
+    if parsed_args.file:
+        parsed_args.data_access_protocol = "file"
+    else:
+        parsed_args.data_access_protocol = parsed_args.object
+    del parsed_args.file
+    del parsed_args.object
+
+    """
+    print(f"Arguments found: {parsed_args}")
+    """
+
     validate_args(parsed_args)
     return parsed_args
 


### PR DESCRIPTION
Add a pair of new arguments to all workloads that specify whether to use files or objects as the data access API.

The --file argument says to use files,
The --object argument is mutually exclusive with --file and takes an optional "=s3" to specify which object API to use.  The code can easily be extended to add more APIs to the list (eg: azure, gcs, minio, etc) as needed in the future.

The result is a new field in the argument dict called "data_access_protocol" which contains one of the following values: "file", "s3".