### PR TITLE
Remove the "submodule" for DLIO_local_changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "dlio_benchmark"]
-	path = dlio_benchmark
-        url = https://github.com/mlcommons/DLIO_local_changes
-        branch = main


### PR DESCRIPTION
We will use the dependency created by the uv.lock file to pull in the correct version of DLIO rather than it being a "submodule".