### PR TITLE
File system guy updated README's

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Following prerequisites must be satisfied
 ## Installation 
 **The following installation steps must be run on every client host that will participate in running the benchmarks.**
 
-### uv (Recommended)
+### uv (Required)
 
-[`uv`](https://docs.astral.sh/uv/) is a fast Python package and project manager that handles virtual environment creation, dependency resolution, and Python version management automatically — no manual `venv` or `pip` steps required.
+[`uv`](https://docs.astral.sh/uv/) is a fast Python package and project manager that handles virtual environment creation, dependency resolution, and Python version management automatically — no manual `venv` or `pip` steps required. It will install into your virutal environment exactly the versions of supporting libraries and tools that the benchmark has been tested with.
 
 **Install uv** (if not already installed):
 
@@ -63,84 +63,26 @@ Install the MPI runtime (still required for distributed execution):
 sudo apt install libopenmpi-dev openmpi-common
 ```
 
-Clone and install:
+Clone the repo:
 
 ```bash
 git clone https://github.com/mlcommons/storage.git
 cd storage
-uv sync
 ```
-
-`uv sync` creates a `.venv` virtual environment and installs all dependencies — including DLIO benchmark — automatically from the lock file.
 
 Verify the installation:
 
 ```bash
-uv run mlpstorage --help
+mlpstorage --help
 ```
 
-> **Note:** All benchmark commands in this README can be prefixed with `uv run` (e.g., `uv run mlpstorage training run ...`), or you can activate the virtual environment first: `source .venv/bin/activate`
+The `mlpstorage` script executes `uv run` every time you invoke the benchmark, keeping your virtual environment up to date.
+`uv` creates a `.venv` virtual environment and installs all dependencies — including DLIO benchmark — automatically based upon the contents of the the `uv.lock` file.
 
-> **Note:** `uv` installs CPU-only PyTorch by default (sufficient for I/O benchmarking). For GPU-accelerated training workloads, install an appropriate CUDA-enabled PyTorch separately after `uv sync`.
+> **Note:** `uv` installs the CPU-only version of PyTorch.
+> GPU-accelerated training or checkpointing workloads are not supported, there is no need to have GPUs in your benchmark test gear, they will not be used.
 
-To install optional extras:
-
-```bash
-uv sync --all-extras
-```
-
----
-
-### pip (Alternative)
-
-The following steps use standard `pip` and are an alternative to the `uv` workflow above.
-
-#### Dependencies
-DLIO requires MPI package. 
-For eg: when running on Ubuntu 24.04, install openmpi tools and libraries. 
-
-```bash
-sudo apt install python3-pip python3-venv libopenmpi-dev openmpi-common
-```
-
-Create a virtual environment for package installations and activate it.
-
-```bash
-python3 -m venv ~/.venvs/myenv
-source ~/.venvs/myenv/bin/activate
-```
-
-#### pip
-Please ensure you have the latest version of pip installed. This will fix the following error where the package is built as "UNKNOWN". Upgrade pip like so:
-
-```bash
-python3 -m pip install --upgrade pip
-```
-
-
-Clone the latest release from [MLCommons Storage](https://github.com/mlcommons/storage) repository and install Python dependencies.
-
-```bash
-git clone -b v2.0 https://github.com/mlcommons/storage.git
-cd storage
-pip3 install -e .
-```
-
-The working directory structure is as follows
-
-```
-|---storage
-       |---mlpstorage
-           |---(folder contains benchmark src files)
-       |---configs
-           |---dlio
-               |---workload
-                   |---(folder contains configs for all checkpoint and training workloads)
-           |---vectordbbench (These configurations are PREVIEW only and not available for submission)
-               |---(folder contains configs for all vectordb workloads)
-```
-
-The benchmark simulation will be performed through the [dlio_benchmark](https://github.com/argonne-lcf/dlio_benchmark) code, a benchmark suite for emulating I/O patterns for deep learning workloads. [dlio_benchmark](https://github.com/argonne-lcf/dlio_benchmark) is listed as a prerequisite to a specific git branch. A future release will update the installer to pull DLIO from PyPi. The DLIO configuration of each workload is specified through a yaml file. You can see the configs of all MLPerf Storage workloads in the `configs` folder. 
+The benchmark simulation will be performed through the [dlio_benchmark](https://github.com/mlcommons/DLIO_local_changes) code, a benchmark suite for emulating I/O patterns for deep learning workloads. The DLIO configuration of each workload is specified through a yaml file. You can see the configs of all MLPerf Storage workloads in the `configs` folder. 
 
 ## Testing and Demos
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,22 @@
 MLPerf® Storage is a benchmark suite to characterize the performance of storage systems that support machine learning workloads.
 
 - [Overview](#overview)
-- [Prerequisite](#prerequisite)
-- [Installation](#installation)
-- [Configuration](#configuration)
-- [Workload Categories](#workload-categories)
 - [Submission Rules](#submission-rules)
+- [Normalizing Factors For Comparisons](#normalizing-factors-for-comparisons)
+- [Usage](#usage)
+  - [Prerequisite](#prerequisite)
+  - [Installation](#installation)
+  - [Configuration](#configuration)
+  - [Workload Categories](#workload-categories)
+- [Theory of Operations](#theory-of-operations)
+  - [General Rules](#general-rules)
+  - [CLOSED: virtually all changes are disallowed](#closed-virtually-all-changes-are-disallowed)
+  - [OPEN: changes are allowed but must be disclosed](#open-changes-are-allowed-but-must-be-disclosed)
+  - [System Description YAML - Structured Description](#system-description-yaml---structured-description)
+  - [System Description PDF - Graphical and Prose Text](#system-description-pdf---graphical-and-prose-text)
 
----
 
-## Documentation
+## Overview
 
 Two README files cover the full project in detail — read both before diving into the
 code or running benchmarks:
@@ -23,12 +30,40 @@ code or running benchmarks:
 The top-level sections below give the official MLCommons parameter reference and
 are retained for submission compliance.
 
----
+## Submission Rules
 
-## Overview
+MLPerf™ Storage Benchmark submission rules are described in the
+[Rules.md](https://github.com/mlcommons/storage/blob/main/Rules.md) file.
+If you have questions, please contact the [Storage WG chairs](https://mlcommons.org/en/groups/research-storage/).
+
+
+## Normalizing Factors For Comparisons
+
+To compare the performance of two storage solutions that have very different architectures,
+we must have a divisor that is independent of the storage system's architecture but is also present for all architectures.
+
+### Rack Units Requirements (Mandatory)
+
+If the system requires the physical deployment of dedicated hardware, ie: is not a cloud-based deployment or a hyperconverged deployment,
+the SystemDescription.yaml will include the total number of rack units (RU's) that will be consumed by the storage system under test,
+including any supporting gear that is required for the configuration being tested.
+That supporting gear could include, for example, network switches for a "backend" or private network that is required for the storage system to operate.
+The rack units measure does not need to include any of the gear that connects the storage system to the ``host nodes``.
+
+This will show GB/s/RU or IOPs/RU.
+
+### Power Requirements (Mandatory)
+
+If the system requires the customer provisioning of power (for example, systems intended to be deployed in on-premises data centers or in co-located data centers)
+the SystemDescription.yaml will include all hardware devices required to operate the storage system.
+Shared network equipment also used for client network communication and optional storage management systems do not need to be included.
+
+This will show GB/s/KW or IOPs/KW.
+
+## Usage
 For an overview of how this benchmark suite is used by submitters to compare the performance of storage systems supporting an AI cluster, see the MLPerf® Storage Benchmark submission rules here: [doc](https://github.com/mlcommons/storage/blob/main/Submission_guidelines.md). 
 
-## Prerequisite
+### Prerequisite
 
 The installation and the configuration steps described in this README are validated against clients running Ubuntu 24.04 server with python 3.12.3. The benchmark script has to be run only in one participating client host(any) which internally calls `mpirun` to launch the distributed workloads across multiple client hosts. The launcher client host also participates in the distributed training process.
 
@@ -37,10 +72,10 @@ Following prerequisites must be satisfied
 1. Pick one host to act as the launcher client host. Passwordless ssh must be setup from the launcher client host to all other participating client hosts.  `ssh-copy-id` is a useful tool.
 2. The code and data location(discussed in further sections) must be exactly same in every client host including the launcher host. This is because, the same benchmark command is automatically triggered in every participating client host during the distributed training process.
 
-## Installation 
+### Installation 
 **The following installation steps must be run on every client host that will participate in running the benchmarks.**
 
-### uv (Required)
+#### uv (Required)
 
 [`uv`](https://docs.astral.sh/uv/) is a fast Python package and project manager that handles virtual environment creation, dependency resolution, and Python version management automatically — no manual `venv` or `pip` steps required. It will install into your virutal environment exactly the versions of supporting libraries and tools that the benchmark has been tested with.
 
@@ -77,7 +112,7 @@ The `mlpstorage` script executes `uv run` every time you invoke the benchmark, k
 
 The benchmark simulation will be performed through the [dlio_benchmark](https://github.com/mlcommons/DLIO_local_changes) code, a benchmark suite for emulating I/O patterns for deep learning workloads. The DLIO configuration of each workload is specified through a yaml file. You can see the configs of all MLPerf Storage workloads in the `configs` folder. 
 
-### Testing the Installation
+#### Testing the Installation
 
 See **[tests/README.md](tests/README.md)** for the complete test guide — environment
 setup, unit tests (no infrastructure required), integration tests, and object-store
@@ -124,30 +159,96 @@ optional arguments:
   --version             show program's version number and exit
 ```
 
-### Training Category
+#### Training Category
 The training category supports emulation of the training of 3 models (FLUX.1, RetinaNet, and DLRMv2).
 
 See [training/README.md](training/README.md) for more details.
 
-### Checkpointing Category
+#### Checkpointing Category
 The checkpointing category supports emulation of taking a checkpoint of an LLM foundation training task,
 specifically the Llama3 LLM at four different scales: 8B, 70B, 405B, and 1250B parameters.
 
 See [checkpointing/README.md](checkpointing/README.md) for more details.
 
-### VectorDB Category
+#### VectorDB Category
 The vectordb category supports emulation of a vector database as used in an LLM RAG pipeline,
 specifically the Milvus VDB using one of three different algorithms: DiskANN, HNSW, and AiSAQ.
 
 See [vdb_benchmark/README.md](vdb_benchmark/README.md) for more details.
 
-### KVCache Category
+#### KVCache Category
 The kvcache category supports emulation of a context cache as used by an LLM.
 
 See [kv_cache_benchmark/README.md](kv_cache_benchmark/README.md) for more details.
 
-## Submission Rules
 
-MLPerf™ Storage Benchmark submission rules are described in the
-[Rules.md](https://github.com/mlcommons/storage/blob/main/Rules.md) file.
-If you have questions, please contact the [Storage WG chairs](https://mlcommons.org/en/groups/research-storage/).
+
+## Theory of Operations
+
+MLPerf™ Storage is a benchmark suite to characterize the performance of storage systems that support machine learning workloads.
+
+This benchmark attempts to balance two goals. First, we aim for **comparability** between benchmark submissions to enable decision making by the AI/ML Community. Second, we aim for **flexibility** to enable experimentation and to show off unique storage system features that will benefit the AI/ML Community. To that end we have defined two classes of submissions: CLOSED and OPEN. 
+
+The MLPerf name and logo are trademarks of the MLCommons® Association ("MLCommons"). In order to refer to a result using the MLPerf name, the result must conform to the letter and spirit of the rules specified in this document. MLCommons reserves the right to solely determine if a use of its name or logos is acceptable.
+
+This version of the benchmark does not include offline or online data pre-processing. We are aware that data pre-processing is an important part of the ML data pipeline and we will include it in a future version of the benchmark.
+
+### General Rules
+ 
+The following apply to all results submitted for this benchmark.
+
+Benchmarking should be conducted to measure the framework and storage system performance as fairly as possible. Ethics and reputation matter.
+
+- **Available Systems**. To be called an ``available system`` all components of the system must be publicly available. If any components of the system are not available at the time of the benchmark results submission, those components must be included in an ``available system`` submission that is submitted in the next round of MLPerf Storage benchmark submissions.  Otherwise, the results for that submission may be retracted from the MLCommons results dashboard.
+- **RDI Systems**. If you are measuring the performance of an experimental framework or system, you must make the system and framework you use available upon demand for replication by MLCommons. This class of systems will be called RDI (research, development, internal). 
+
+The data generator in DLIO uses a fixed random seed that must not be changed, to ensure that all submissions are working with the same dataset. Random number generators may be seeded from the following sources:
+- Clock
+- System source of randomness, e.g. /dev/random or /dev/urandom
+- Another random number generator initialized with an allowed seed
+Random number generators may be initialized repeatedly in multiple processes or threads. For a single run, the same seed may be shared across multiple processes or threads.
+
+The storage system must not be informed of the random seed or the source of randomness.  This is intended to disallow submissions where the storage systen can predict the access pattern of the data samples.
+
+Public results should be rounded normally, to two decimal places.
+
+For all workloads stable storage must be used, but there are some differences in the specifics.
+
+Results that cannot be replicated are not valid results. Replicated results should be within 5% within 5 tries.
+
+Each of the benchmarks described in this document have a requirement for multiple runs. This is to ensure consistency of operation of the system under test as well as ensure statistical significance of the measurements.
+
+Unless otherwise noted, the multiple runs for a workload need to be run consecutively. To ensure this requirement is met, the time between runs (from the stop time of one run and the start time to the next run) needs to be less than the time to execute a single run. This is to discourage cherry-picking of results which is expressly forbidden and against the spirit of the rules.
+
+### CLOSED: virtually all changes are disallowed
+CLOSED represents a level playing field where all results are **comparable** across submissions. CLOSED explicitly forfeits flexibility in order to enable easy comparability. 
+
+In order to accomplish that, most of the optimizations and customizations to the AI/ML algorithms and framework that might typically be applied during benchmarking or even during production use must be disallowed.  Optimizations and customizations to the storage system are allowed in CLOSED.
+
+For CLOSED submissions of this benchmark, the MLPerf Storage codebase takes the place of the AI/ML algorithms and framework, and therefore cannot be changed. The sole exception to this rule is if the submitter decides to apply the code change identified in PR#299 of the DLIO repo in github, the resulting codebase will be considered "unchanged" for the purposes of this rule. 
+
+### OPEN: changes are allowed but must be disclosed
+
+OPEN allows more **flexibility** to tune and change both the benchmark and the storage system configuration to show off new approaches or new features that will benefit the AI/ML Community. OPEN explicitly forfeits comparability to allow showcasing innovation.
+
+The essence of OPEN division results is that for a given benchmark area, they are “best case” results if optimizations and customizations are allowed.  The submitter has the opportunity to show the performance of the storage system if an arbitrary, but documented, set of changes are made to the data storage environment or algorithms.
+
+Changes to DLIO itself are allowed in OPEN division submissions.  Any changes to DLIO code or command line options must be disclosed. 
+
+While changes to DLIO are allowed, changing the workload itself is not.  Ie: how the workload is processed can be changed, but those changes cannot fundamentally change the purpose and result of the training.  For example, changing the workload imposed upon storage by a ResNet-50 training task into 3D-Unet training task is not allowed.
+
+### System Description YAML - Structured Description
+
+The purpose of the system description is to provide sufficient detail on the storage system under test, and the ``host nodes`` running the test, plus the network connecting them, to enable full reproduction of the benchmark results by a third party. 
+
+Each submission must contain a ``<system-name>.yaml`` file and a ``<system-name>.pdf`` file.  If you submit more than one benchmark result, each submission must have a unique ``<system-name>.yaml`` file and a ``<system-name>.pdf`` file that documents the system under test and the environment that generated that result, including any configuration options in effect.
+
+The system description yaml is a hybrid human-readable and machine-readable description of the total system under test. It contains fields for the System overall, the Nodes that make up the solution (clients and storage), as well as Power information of the nodes.
+
+An example can be found [HERE](https://github.com/mlcommons/storage/blob/main/system_configuration.yaml)
+
+### System Description PDF - Graphical and Prose Text
+
+The goal of the pdf is to complement the YAML file, providing additional detail on the system to enable full reproduction by a third party. We encourage submitters to add details that are more easily captured by diagrams and text description, rather than a YAML.
+
+This file is should include everything that a third party would need in order to recreate the results in the submission, including product model numbers or hardware config details, unit counts of drives and/or components, system and network topologies, software used with version numbers, and any non-default configuration options used by any of the above.

--- a/README.md
+++ b/README.md
@@ -104,10 +104,11 @@ The first argument is the workload category:
  - training
  - checkpointing
  - vectordb
+ - kvcache
 
 ```bash
 [root@localhost ]#  mlpstorage -h
-usage: mlpstorage [-h] [--version] {training,checkpointing,vectordb,reports,history} ...
+usage: mlpstorage [-h] [--version] {training,checkpointing,vectordb,kvcache} ...
 
 Script to launch the MLPerf Storage benchmark
 
@@ -125,25 +126,25 @@ optional arguments:
 
 ### Training Category
 The training category supports emulation of the training of 3 models (FLUX.1, RetinaNet, and DLRMv2).
-The details on those models and how to invoke the benchmark for training workloads can be found in
-[training/README.md](training/README.md).
+
+See [training/README.md](training/README.md) for more details.
 
 ### Checkpointing Category
 The checkpointing category supports emulation of taking a checkpoint of an LLM foundation training task,
 specifically the Llama3 LLM at four different scales: 8B, 70B, 405B, and 1250B parameters.
-The details of how to invoke the benchmark for checkpointing workloads can be found in
-[checkpointing/README.md](checkpointing/README.md).
+
+See [checkpointing/README.md](checkpointing/README.md) for more details.
 
 ### VectorDB Category
 The vectordb category supports emulation of a vector database as used in an LLM RAG pipeline,
 specifically the Milvus VDB using one of three different algorithms: DiskANN, HNSW, and AiSAQ.
-The details of how to invoke the benchmark for vectordb workloads can be found in
-[vdb_benchmark/README.md](vdb_benchmark/README.md).
+
+See [vdb_benchmark/README.md](vdb_benchmark/README.md) for more details.
 
 ### KVCache Category
 The kvcache category supports emulation of a context cache as used by an LLM.
-The details of how to invoke the benchmark for kvcache workloads can be found in
-[kvcache/README.md](kvcache/README.md)
+
+See [kv_cache_benchmark/README.md](kv_cache_benchmark/README.md) for more details.
 
 ## Submission Rules
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,8 @@ MLPerf® Storage is a benchmark suite to characterize the performance of storage
 - [Overview](#overview)
 - [Prerequisite](#prerequisite)
 - [Installation](#installation)
-- [Testing and Demos](#testing-and-demos)
 - [Configuration](#configuration)
-- [Workloads](#workloads)
-	- [U-Net3D](#u-net3d)
-   	- [ResNet-50](#resnet-50)
-   	- [CosmoFlow](#cosmoflow)
-- [Parameters](#parameters)
-	- [CLOSED](#closed)
-	- [OPEN](#open)
+- [Workload Categories](#workload-categories)
 - [Submission Rules](#submission-rules)
 
 ---
@@ -84,13 +77,11 @@ The `mlpstorage` script executes `uv run` every time you invoke the benchmark, k
 
 The benchmark simulation will be performed through the [dlio_benchmark](https://github.com/mlcommons/DLIO_local_changes) code, a benchmark suite for emulating I/O patterns for deep learning workloads. The DLIO configuration of each workload is specified through a yaml file. You can see the configs of all MLPerf Storage workloads in the `configs` folder. 
 
-## Testing and Demos
+### Testing the Installation
 
 See **[tests/README.md](tests/README.md)** for the complete test guide — environment
 setup, unit tests (no infrastructure required), integration tests, and object-store
 performance scripts for all three supported object storage libraries.
-
-### Quick Demos
 
 - **StreamingCheckpointing Demo**: Run `./tests/checkpointing/demo_checkpoint_methods.sh` to see:
   - dgen-py integration (155× faster data generation)
@@ -107,14 +98,12 @@ performance scripts for all three supported object storage libraries.
   pytest tests/unit/
   ```
 
-## Operation
-The benchmarks uses nested commands to select the workload category, workload, and workload parameters.
-
 ### Workload Categories
-The first argument is the workload category
+The benchmark uses nested commands to select the workload category, workload, and workload parameters.
+The first argument is the workload category:
  - training
  - checkpointing
- - vectordb (PREVIEW)
+ - vectordb
 
 ```bash
 [root@localhost ]#  mlpstorage -h
@@ -123,12 +112,11 @@ usage: mlpstorage [-h] [--version] {training,checkpointing,vectordb,reports,hist
 Script to launch the MLPerf Storage benchmark
 
 positional arguments:
-  {training,checkpointing,vectordb,reports,history}
+  {training,checkpointing,vectordb,kvcache}
     training            Training benchmark options
     checkpointing       Checkpointing benchmark options
     vectordb            VectorDB benchmark options
-    reports             Generate a report from benchmark results
-    history             Display benchmark history
+    kvcache             KVCcache benchmark options
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -136,473 +124,29 @@ optional arguments:
 ```
 
 ### Training Category
-The training category supports 3 models (unet3d, resnet50, cosmoflow). The benchmark execution process requires these steps:
-1. Datasize - Calculate required number of samples for a given client configuration
-2. Datagen - Generate the required dataset
-3. Run - Execute the benchmark
-
-```bash
-[root@localhost ]# mlpstorage training --help
-usage: mlpstorage training [-h] [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug] [--verbose]
-                           [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params] [--what-if]
-                           {datasize,datagen,run,configview} ...
-
-Run the MLPerf Storage training benchmark
-
-positional arguments:
-  {datasize,datagen,run,configview}
-    datasize            The datasize command calculates the number of samples needed for a given workload, accelerator
-                        type, number of accelerators, and client host memory.
-    datagen             The datagen command generates a dataset for a given workload and number of parallel generation
-                        processes.
-    run                 Run the benchmark with the specified parameters.
-    configview          View the final config based on the specified options.
-
-optional arguments:
-  -h, --help            show this help message and exit
-
-Standard Arguments:
-  --results-dir RESULTS_DIR, -rd RESULTS_DIR
-                        Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
-
-Output Control:
-  --debug               Enable debug mode
-  --verbose             Enable verbose mode
-  --stream-log-level STREAM_LOG_LEVEL
-  --allow-invalid-params, -aip
-                        Do not fail on invalid parameters.
-
-View Only:
-  --what-if             View the configuration that would execute and the associated command.
-```
-
-Use ```mlpstorage training {command} --help``` for the full list of parameters for each command.
-
-#### Data Sizing and Generation
-
-**Note**: Steps described in this section must be run only in one client host(launcher client).
-
-The datasize command relies on the accelerator being emulated, the max number of accelerators to support, the system memory in the benchmark clients, and the number of benchmark clients.
-
-The two rules that generally dictate the datasize are:
-1. The datasize on disk must be 5x the cumulative system memory of the benchmark clients
-2. The benchmark must run for 500 iterations of the given batch size for all GPUs
-
-If the list of clients is passed in for this command the amount of memory is found programmatically. Otherwise, the user can provide the number of clients and the amount of memory per client for the calculation.
-
-```bash
-[root@localhost ]# mlpstorage training datasize --help
-usage: mlpstorage training datasize [-h] [--hosts HOSTS [HOSTS ...]] --model {cosmoflow,resnet50,unet3d}
-                                    --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB [--exec-type {mpi,docker}]
-                                    [--mpi-bin {mpirun,mpiexec}] [--oversubscribe] [--allow-run-as-root]
-                                    --max-accelerators MAX_ACCELERATORS --accelerator-type {h100,a100,b200,mi355}
-                                    --num-client-hosts NUM_CLIENT_HOSTS [--data-dir DATA_DIR]
-                                    [--params PARAMS [PARAMS ...]]
-                                    [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug]
-                                    [--verbose] [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params]
-                                    [--what-if]
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --hosts HOSTS [HOSTS ...], -s HOSTS [HOSTS ...]
-                        Space-separated list of IP addresses or hostnames of the participating hosts. Example: '--
-                        hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'
-  --model {cosmoflow,resnet50,unet3d}, -m {cosmoflow,resnet50,unet3d}
-                        Model to emulate. A specific model defines the sample size, sample container format, and data
-                        rates for each supported accelerator.
-  --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB, -cm CLIENT_HOST_MEMORY_IN_GB
-                        Memory available in the client where the benchmark is run. The dataset needs to be 5x the
-                        available memory for closed submissions.
-  --exec-type {mpi,docker}, -et {mpi,docker}
-                        Execution type for benchmark commands. Supported options: [<EXEC_TYPE.MPI: 'mpi'>,
-                        <EXEC_TYPE.DOCKER: 'docker'>]
-  --max-accelerators MAX_ACCELERATORS, -ma MAX_ACCELERATORS
-                        Max number of simulated accelerators. In multi-host configurations the accelerators will be
-                        initiated in a round-robin fashion to ensure equal distribution of simulated accelerator
-                        processes
-  --accelerator-type {h100,a100,b200,mi355}, -g {h100,a100,b200,mi355}
-                        Accelerator to simulate for the benchmark. A specific accelerator defines the data access
-                        sizes and rates for each supported workload
-  --num-client-hosts NUM_CLIENT_HOSTS, -nc NUM_CLIENT_HOSTS
-                        Number of participating client hosts. Simulated accelerators will be initiated on these hosts
-                        in a round-robin fashion
-  --data-dir DATA_DIR, -dd DATA_DIR
-                        Filesystem location for data
-  --params PARAMS [PARAMS ...], -p PARAMS [PARAMS ...]
-                        Additional parameters to be passed to the benchmark. These will override the config file. For
-                        a closed submission only a subset of params are supported. Multiple values allowed in the
-                        form: --params key1=value1 key2=value2 key3=value3
-  --dlio-bin-path DLIO_BIN_PATH, -dp DLIO_BIN_PATH
-                        Path to DLIO binary. Default is the same as mlpstorage binary path
-
-MPI:
-  --mpi-bin {mpirun,mpiexec}
-                        Execution type for MPI commands. Supported options: ['mpirun', 'mpiexec']
-  --oversubscribe
-  --allow-run-as-root
-
-Standard Arguments:
-  --results-dir RESULTS_DIR, -rd RESULTS_DIR
-                        Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
-
-Output Control:
-  --debug               Enable debug mode
-  --verbose             Enable verbose mode
-  --stream-log-level STREAM_LOG_LEVEL
-  --allow-invalid-params, -aip
-                        Do not fail on invalid parameters.
-
-View Only:
-  --what-if             View the configuration that would execute and the associated command.
-```
-
-Example:
-
-To calculate minimum dataset size for a `unet3d` model running on 2 client machines with 128 GB each with overall 8 simulated a100 accelerators
-
-```bash
-mlpstorage training datasize -m unet3d --client-host-memory-in-gb 128 --max-accelerators 16 --num-client-hosts 2 --accelerator-type a100  --results-dir ~/mlps-results
-```
-
-2. Synthetic data is generated based on the workload requested by the user.
-
-```bash
-[root@localhost ]# mlpstorage training datagen --help
-usage: mlpstorage training datagen [-h] [--hosts HOSTS [HOSTS ...]] --model {cosmoflow,resnet50,unet3d}
-                                   [--exec-type {mpi,docker}] [--mpi-bin {mpirun,mpiexec}] [--oversubscribe]
-                                   [--allow-run-as-root] --num-processes NUM_PROCESSES [--data-dir DATA_DIR]
-                                   [--ssh-username SSH_USERNAME] [--params PARAMS [PARAMS ...]]
-                                   [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug]
-                                   [--verbose] [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params]
-                                   [--what-if]
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --hosts HOSTS [HOSTS ...], -s HOSTS [HOSTS ...]
-                        Space-separated list of IP addresses or hostnames of the participating hosts. Example: '--
-                        hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'
-  --model {cosmoflow,resnet50,unet3d}, -m {cosmoflow,resnet50,unet3d}
-                        Model to emulate. A specific model defines the sample size, sample container format, and data
-                        rates for each supported accelerator.
-  --exec-type {mpi,docker}, -et {mpi,docker}
-                        Execution type for benchmark commands. Supported options: [<EXEC_TYPE.MPI: 'mpi'>,
-                        <EXEC_TYPE.DOCKER: 'docker'>]
-  --num-processes NUM_PROCESSES, -np NUM_PROCESSES
-                        Number of parallel processes to use for dataset generation. Processes will be initiated in a
-                        round-robin fashion across the configured client hosts
-  --data-dir DATA_DIR, -dd DATA_DIR
-                        Filesystem location for data
-  --params PARAMS [PARAMS ...], -p PARAMS [PARAMS ...]
-                        Additional parameters to be passed to the benchmark. These will override the config file. For
-                        a closed submission only a subset of params are supported. Multiple values allowed in the
-                        form: --params key1=value1 key2=value2 key3=value3
-  --dlio-bin-path DLIO_BIN_PATH, -dp DLIO_BIN_PATH
-                        Path to DLIO binary. Default is the same as mlpstorage binary path
-
-MPI:
-  --mpi-bin {mpirun,mpiexec}
-                        Execution type for MPI commands. Supported options: ['mpirun', 'mpiexec']
-  --oversubscribe
-  --allow-run-as-root
-
-Standard Arguments:
-  --results-dir RESULTS_DIR, -rd RESULTS_DIR
-                        Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
-
-Output Control:
-  --debug               Enable debug mode
-  --verbose             Enable verbose mode
-  --stream-log-level STREAM_LOG_LEVEL
-  --allow-invalid-params, -aip
-                        Do not fail on invalid parameters.
-
-View Only:
-  --what-if             View the configuration that would execute and the associated command.
-```
-
-Example:
-
-For generating training data of 56,000 files for `unet3d` workload into `unet3d_data` directory using 8 parallel jobs distributed on 2 nodes.
-
-```bash
-mlpstorage training datagen --hosts 10.117.61.121,10.117.61.165 --model unet3d --num-processes 8 --data-dir /mnt/unet3d_data --param dataset.num_files_train=56000
-```
-
-#### Running a Training Benchmark
-
-```bash
-[root@localhost ]# mlpstorage training run --help
-usage: mlpstorage training run [-h] [--hosts HOSTS [HOSTS ...]] --model {cosmoflow,resnet50,unet3d}
-                               --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB [--exec-type {mpi,docker}]
-                               [--mpi-bin {mpirun,mpiexec}] [--oversubscribe] [--allow-run-as-root] --num-accelerators
-                               NUM_ACCELERATORS --accelerator-type {h100,a100,b200,mi355} --num-client-hosts NUM_CLIENT_HOSTS
-                               [--data-dir DATA_DIR] [--ssh-username SSH_USERNAME] [--params PARAMS [PARAMS ...]]
-                               [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug] [--verbose]
-                               [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params] [--what-if]
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --hosts HOSTS [HOSTS ...], -s HOSTS [HOSTS ...]
-                        Space-separated list of IP addresses or hostnames of the participating hosts. Example: '--
-                        hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'
-  --model {cosmoflow,resnet50,unet3d}, -m {cosmoflow,resnet50,unet3d}
-                        Model to emulate. A specific model defines the sample size, sample container format, and data
-                        rates for each supported accelerator.
-  --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB, -cm CLIENT_HOST_MEMORY_IN_GB
-                        Memory available in the client where the benchmark is run. The dataset needs to be 5x the
-                        available memory for closed submissions.
-  --exec-type {mpi,docker}, -et {mpi,docker}
-                        Execution type for benchmark commands. Supported options: [<EXEC_TYPE.MPI: 'mpi'>,
-                        <EXEC_TYPE.DOCKER: 'docker'>]
-  --num-accelerators NUM_ACCELERATORS, -na NUM_ACCELERATORS
-                        Number of simulated accelerators. In multi-host configurations the accelerators will be
-                        initiated in a round-robin fashion to ensure equal distribution of simulated accelerator
-                        processes
-  --accelerator-type {h100,a100,b200,mi355}, -g {h100,a100,b200,mi355}
-                        Accelerator to simulate for the benchmark. A specific accelerator defines the data access
-                        sizes and rates for each supported workload
-  --num-client-hosts NUM_CLIENT_HOSTS, -nc NUM_CLIENT_HOSTS
-                        Number of participating client hosts. Simulated accelerators will be initiated on these hosts
-                        in a round-robin fashion
-  --data-dir DATA_DIR, -dd DATA_DIR
-                        Filesystem location for data
-  --params PARAMS [PARAMS ...], -p PARAMS [PARAMS ...]
-                        Additional parameters to be passed to the benchmark. These will override the config file. For
-                        a closed submission only a subset of params are supported. Multiple values allowed in the
-                        form: --params key1=value1 key2=value2 key3=value3
-  --dlio-bin-path DLIO_BIN_PATH, -dp DLIO_BIN_PATH
-                        Path to DLIO binary. Default is the same as mlpstorage binary path
-
-MPI:
-  --mpi-bin {mpirun,mpiexec}
-                        Execution type for MPI commands. Supported options: ['mpirun', 'mpiexec']
-  --oversubscribe
-  --allow-run-as-root
-
-Standard Arguments:
-  --results-dir RESULTS_DIR, -rd RESULTS_DIR
-                        Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
-
-Output Control:
-  --debug               Enable debug mode
-  --verbose             Enable verbose mode
-  --stream-log-level STREAM_LOG_LEVEL
-  --allow-invalid-params, -aip
-                        Do not fail on invalid parameters.
-
-View Only:
-  --what-if             View the configuration that would execute and the associated command.
-
-```
-
-Example:
-
-For running benchmark on `unet3d` workload with data located in `unet3d_data` directory using 2 h100 accelerators spread across 2 client hosts(with IPs 10.117.61.121,10.117.61.165) and results on `unet3d_results` directory, 
-
-```bash
-mlpstorage training run --hosts 10.117.61.121,10.117.61.165 --num-client-hosts 2 --client-host-memory-in-gb 64 --num-accelerators 2 --accelerator-type h100 --model unet3d  --data-dir unet3d_data --results-dir unet3d_results    --param dataset.num_files_train=400 
-```
-
-4. Benchmark submission report is generated by aggregating the individual run results. The reporting command provides the associated functions to generate a report for a given results directory
-
-```bash
-# TODO: Update
-[root@localhost]# mlpstorage reports --help
-usage: mlpstorage reports [-h] [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug] [--verbose]
-                          [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params] [--what-if]
-                          {reportgen} ...
-
-positional arguments:
-  {reportgen}           Sub-commands
-    reportgen           Generate a report from the benchmark results.
-
-optional arguments:
-  -h, --help            show this help message and exit
-
-Standard Arguments:
-  --results-dir RESULTS_DIR, -rd RESULTS_DIR
-                        Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
-
-Output Control:
-  --debug               Enable debug mode
-  --verbose             Enable verbose mode
-  --stream-log-level STREAM_LOG_LEVEL
-  --allow-invalid-params, -aip
-                        Do not fail on invalid parameters.
-
-View Only:
-  --what-if             View the configuration that would execute and the associated command.
-```
-
-To generate the benchmark report,
-
-```bash
-[root@localhost]# mlpstorage reports reportgen --help
-usage: mlpstorage reports reportgen [-h] [--output-dir OUTPUT_DIR] [--results-dir RESULTS_DIR] [--loops LOOPS]
-                                    [--open | --closed] [--debug] [--verbose] [--stream-log-level STREAM_LOG_LEVEL]
-                                    [--allow-invalid-params] [--what-if]
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --output-dir OUTPUT_DIR
-                        Directory where the benchmark report will be saved.
-
-Standard Arguments:
-  --results-dir RESULTS_DIR, -rd RESULTS_DIR
-                        Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
-
-Output Control:
-  --debug               Enable debug mode
-  --verbose             Enable verbose mode
-  --stream-log-level STREAM_LOG_LEVEL
-  --allow-invalid-params, -aip
-                        Do not fail on invalid parameters.
-
-View Only:
-  --what-if             View the configuration that would execute and the associated command.
-```
-
-Note: The `reportgen` script must be run in the launcher client host. 
-
-## Training Models
-Currently, the storage benchmark suite supports benchmarking of 3 deep learning workloads
-- Image segmentation using U-Net3D model 
-- Image classification using Resnet-50 model
-- Cosmology parameter prediction using CosmoFlow model
-
-### U-Net3D
-
-Calculate minimum dataset size required for the benchmark run based on your client configuration
-
-```bash
-mlpstorage training datasize --model unet3d --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 4 --accelerator-type h100
-```
-
-Generate data for the benchmark run based on the minimum files
-
-```bash
-mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model unet3d --data-dir unet3d_data --results-dir unet3d_results  --param dataset.num_files_train=42000
-```
-  
-Run the benchmark.
-
-```bash
-mlpstorage training run --hosts 127.0.0.1 --num-client-hosts 1 --client-host-memory-in-gb 64 --num-accelerators 4 --accelerator-type h100 --model unet3d  --data-dir unet3d_data --results-dir unet3d_results --param dataset.num_files_train=42000
-```
-
-All results will be stored in the directory configured using `--results-dir`(or `-r`) argument. To generate the final report, run the following in the launcher client host. 
-
-```bash 
-mlpstorage reports reportgen --results-dir unet3d_results
-```
-
-### ResNet-50
-
-Calculate minimum dataset size required for the benchmark run based on your client configuration
-
-```bash
- mlpstorage training datasize --model resnet50 --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 16 --accelerator-type h100
-```
-
-Generate data for the benchmark run
-
-```bash
-mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model resnet50 --data-dir resnet50_data --results-dir resnet50_results  --param dataset.num_files_train=2557
-```
-  
-Run the benchmark.
-
-```bash
-mlpstorage training run --hosts 127.0.0.1 --num-client-hosts 1  --client-host-memory-in-gb 64  --num-accelerators 16 --accelerator-type h100  --model resnet50  --data-dir resnet50_data --results-dir resnet50_results --param dataset.num_files_train=2557
-```
-
-All results will be stored in the directory configured using `--results-dir`(or `-r`) argument. To generate the final report, run the following in the launcher client host. 
-
-```bash 
-mlpstorage reports reportgen --results-dir resnet50_results
-```
-
-### CosmoFlow
-
-Calculate minimum dataset size required for the benchmark run based on your client configuration
-
-```bash
-mlpstorage training datasize --model cosmoflow --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 16 --accelerator-type h100 
-```
-
-Generate data for the benchmark run
-
-```bash
-mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model cosmoflow --data-dir cosmoflow_data --results-dir=cosmoflow_results  --param dataset.num_files_train=121477
-```
-  
-Run the benchmark.
-
-```bash
-mlpstorage training run  --hosts 127.0.0.1 --num-client-hosts 1  --client-host-memory-in-gb 64 --num-accelerators 16  --accelerator-type h100  --model cosmoflow --data-dir cosmoflow_data --results-dir cosmoflow_results --param dataset.num_files_train=121477 
-```
-
-All results will be stored in the directory configured using `--results-dir`(or `-r`) argument. To generate the final report, run the following in the launcher client host. 
-
-```bash 
-mlpstorage reports reportgen --results-dir cosmoflow_results
-```
-
-## Parameters 
-
-### CLOSED
-Below table displays the list of configurable parameters for the benchmark in the closed category.
-
-| Parameter                      | Description                                                 |Default|
-| ------------------------------ | ------------------------------------------------------------ |-------|
-| **Dataset params**		|								|   |
-| dataset.num_files_train       | Number of files for the training set  		        | --|
-| dataset.num_subfolders_train  | Number of subfolders that the training set is stored	        |0|
-| dataset.data_folder           | The path where dataset is stored				| --|
-| **Reader params**				|						|   |
-| reader.read_threads		| Number of threads to load the data                            | --|
-| reader.computation_threads    | Number of threads to preprocess the data(for TensorFlow)      |1|
-| reader.prefetch_size    | Number of batches to prefetch      |2|
-| reader.transfer_size       | Number of bytes in the read buffer(only for Tensorflow)  		        | |
-| reader.odirect                  | Whether to use direct I/O for reader (currectly applicable to UNet3D)   | False | 
-| **Checkpoint params**		|								|   |
-| checkpoint.checkpoint_folder	| The folder to save the checkpoints  				| --|
-| **Storage params**		|								|   |
-| storage.storage_root		| The storage root directory  					| ./|
-| storage.storage_type		| The storage type  						|local_fs|
-
-
-### OPEN
-In addition to what can be changed in the CLOSED category, the following parameters can be changed in the OPEN category.
-
-| Parameter                      | Description                                                 |Default|
-| ------------------------------ | ------------------------------------------------------------ |-------|
-| framework		| The machine learning framework		|Pytorch for 3D U-Net |
-| **Dataset params**		|								|   |
-| dataset.format       | Format of the dataset  		        | .npz for 3D U-Net |
-| dataset.num_samples_per_file       | Number of samples per file(only for Tensorflow using tfrecord datasets)  		        | 1 for 3D U-Net |
-| **Reader params**		|
-| reader.data_loader       | Data loader type(Tensorflow or PyTorch or custom) 		        | PyTorch for 3D U-Net |
-
+The training category supports emulation of the training of 3 models (FLUX.1, RetinaNet, and DLRMv2).
+The details on those models and how to invoke the benchmark for training workloads can be found in
+[training/README.md](training/README.md).
+
+### Checkpointing Category
+The checkpointing category supports emulation of taking a checkpoint of an LLM foundation training task,
+specifically the Llama3 LLM at four different scales: 8B, 70B, 405B, and 1250B parameters.
+The details of how to invoke the benchmark for checkpointing workloads can be found in
+[checkpointing/README.md](checkpointing/README.md).
+
+### VectorDB Category
+The vectordb category supports emulation of a vector database as used in an LLM RAG pipeline,
+specifically the Milvus VDB using one of three different algorithms: DiskANN, HNSW, and AiSAQ.
+The details of how to invoke the benchmark for vectordb workloads can be found in
+[vdb_benchmark/README.md](vdb_benchmark/README.md).
+
+### KVCache Category
+The kvcache category supports emulation of a context cache as used by an LLM.
+The details of how to invoke the benchmark for kvcache workloads can be found in
+[kvcache/README.md](kvcache/README.md)
 
 ## Submission Rules
 
-MLPerf™ Storage Benchmark submission rules are described in this [doc](https://github.com/mlcommons/storage/blob/main/Submission_guidelines.md). If you have questions, please contact [Storage WG chairs](https://mlcommons.org/en/groups/research-storage/).
+MLPerf™ Storage Benchmark submission rules are described in the
+[Rules.md](https://github.com/mlcommons/storage/blob/main/Rules.md) file.
+If you have questions, please contact the [Storage WG chairs](https://mlcommons.org/en/groups/research-storage/).

--- a/Submission_guidelines.md
+++ b/Submission_guidelines.md
@@ -42,27 +42,18 @@
 
 ## 1. Introduction
 
-MLPerf™ Storage is a benchmark suite to characterize the performance of storage systems that support machine learning workloads. The suite consists of 2 workload categories:
+MLPerf™ Storage is a benchmark suite to characterize the performance of storage systems that support machine learning workloads. The suite consists of 4 workload categories:
 
 1. Training
 2. Checkpointing
+3. Vector Database
+4. KVCache
 
 This benchmark attempts to balance two goals. First, we aim for **comparability** between benchmark submissions to enable decision making by the AI/ML Community. Second, we aim for **flexibility** to enable experimentation and to show off unique storage system features that will benefit the AI/ML Community. To that end we have defined two classes of submissions: CLOSED and OPEN. 
 
 Published results for the 3D-Unet, ResNet-50, and Cosmoflow Training workloads are comparable across v1.0 and v2.0 of the MLPerf Storage benchmark.  A [full listing of comparability is available](https://github.com/mlcommons/policies/blob/master/MLPerf_Compatibility_Table.adoc).
 
 The MLPerf name and logo are trademarks of the MLCommons® Association ("MLCommons"). In order to refer to a result using the MLPerf name, the result must conform to the letter and spirit of the rules specified in this document. MLCommons reserves the right to solely determine if a use of its name or logos is acceptable.
-
-### 1.1 Timeline
-
-| Date | Description |
-| ---- | ----------- |
-| Jun 18, 2025 | Freeze rules & benchmark code. |
-| Jun 24, 2025 | Open benchmark for submissions. |
-| Jul 7, 2025 | **Submissions due.** |
-| Jul 7, 2025 - Aug 4, 2025 | Review period. |
-| Aug 4, 2025 | **Benchmark competition results are published.** |
-
 
 ## 2. Benchmark Overview
 

--- a/checkpointing/README.md
+++ b/checkpointing/README.md
@@ -1,10 +1,290 @@
 # MLPerf Storage Benchmark Suite - Checkpointing Workloads
 MLPerf® Storage is a benchmark suite to characterize the performance of storage systems that support machine learning workloads.
 
-- [Overview](#overview)
-- [Configuration](#configuration)
+- [Usage](#usage)
+  - [Models](#models)
+  - [Benchmark Execution](#benchmark-execution)
+  - [Clearing Caches](#clearing-caches)
+  - [Metrics and Results Reporting](#metrics-and-results-reporting)
+  - [Requirements for Simultaneously Readable and Writable](#requirements-for-simultaneously-readable-and-writable)
+  - [OPEN vs CLOSED submissions](#open-vs-closed-submissions)
+- [Theory of Operations](#theory-of-operations)
+  - [Definitions](#definitions)
+  - [Performance Metrics](#performance-metrics)
+  - [CLOSED: virtually all changes are disallowed](#closed-virtually-all-changes-are-disallowed)
+  - [OPEN: changes are allowed but must be disclosed](#open-changes-are-allowed-but-must-be-disclosed)
 
 ---
 
-## Overview
+## Usage
 
+This version of the benchmark does not include offline or online data pre-processing. We are aware that data pre-processing is an important part of the ML data pipeline and we will include it in a future version of the benchmark.
+
+### Checkpointing
+#### Models
+Benchmark results may be submitted for the following four model configurations. The associated model architectures and parallelism settings are listed below. The number of MPI processes must be set to 8, 64, 512, and 1024 for the respective models for CLOSED submission. 
+
+For CLOSED submissions, participants are not permitted to change the total number of simulated accelerators. However, they may adjust the number of simulated accelerators per host, as long as each host uses more than 4 simulated accelerators. This allows the use of nodes with higher simulated accelerator density and fewer total nodes. Note: the aggregate simulated accelerator memory across all nodes must be sufficient to accommodate the model’s checkpoint size.
+
+**Table 2 LLM models**
+
+| Model                  | 8B     | 70B    | 405B    | 1T     |
+|------------------------|--------|--------|---------|--------|
+| Hidden dimension       | 4096   | 8192   | 16384   | 25872  |
+| FFN size               | 14336  | 28672  | 53248   | 98304  |
+| num_attention_heads    | 32     | 128    | 128     | 192    |
+| num_kv_heads           | 8      | 8      | 8       | 32     |
+| Num layers             | 32     | 80     | 126     | 128    |
+| Parallelism (TPxPPxDP) | 1×1×8  | 8×1x8  | 8×32×2  | 8×64×2 |
+| Total Processes        | 8      | 64     | 512     | 1024   |
+| ZeRO                   | 3      | 3      | 1       | 1      |
+| Checkpoint size        | 105 GB | 912 GB | 5.29 TB | 18 TB  |
+| Subset: 8-Process Size | 105 GB | 114 GB | 94 GB   | 161 GB |
+
+
+#### Benchmark Execution
+**Checkpoint Modes (global storage vs local storage)** 
+
+There are two operational modes:
+
+* ``default``: Used for shared storage systems. In this mode, the benchmark runs on multiple hosts to write/read the entire checkpoint dataset. The total number of processes (emulated accelerators) must match the number listed in Table 2 (TP×PP×DP = Total Processes).
+
+* ``subset``: Intended for node local storage systems. In this mode, checkpointing is simulated on a single host by writing/reading only a fraction (``num_gpus/TP/PP/DP``) of the checkpoint data, where ``num_gpus`` is the number of simulated accelerators on the host. The only allowed value for number of processes in a subset submission is 8 (the 8B model does not support subset mode as it is already set to 8 processes).
+
+**Checkpoint write and (read) recovery**
+
+For each submission, one must first perform the checkpoint write, then clear the cache if required, and finally perform the checkpoint read. The required command-line flags are:
+*Note: Clearing caches is done to ensure that no data for the read phase comes from the filesystem cache*
+
+For a submission, the sequence is the following:
+1. Write 10x checkpoints
+2. Clear filesystem caches if necessary
+3. Read 10x checkpoints
+
+The default options will run the read and write checkpoints in a single mlpstorage call. For example, the following command will execute a sequence of writing 10 checkpoints and reading those same 10 checkpoints.
+```bash
+mlpstorage checkpointing run --client-host-memory-in-gb 512 --model llama3-8b --num-processes 8 --checkpoint-folder /mnt/checkpoint_test
+```
+
+If caches need to be cleared use the following parameters for the WRITE and READ tests. 
+
+* WRITE: ``--num-checkpoints-read=0``
+* READ: ``--num-checkpoints-write=0``
+
+
+In the above example, the write tests would be executed first with this command which will do the writes but no reads.
+```bash
+mlpstorage checkpointing run --client-host-memory-in-gb 512 --model llama3-8b --num-processes 8 --checkpoint-folder /mnt/checkpoint_test --num-checkpoints-read=0
+```
+
+After the write tests complete, clear the caches on your hosts. A standard linux system would use a command like this:
+```bash
+echo 3 > /proc/sys/vm/drop_caches
+```
+The end result of "clearing caches" is that 100% data for the read phase should come from the storage system under test and not from the client's filesystem cache. 
+
+Finally, with the same example the read tests would be executed with the following command which indicates no writes during this phase:
+```bash
+mlpstorage checkpointing run --client-host-memory-in-gb 512 --model llama3-8b --num-processes 8 --checkpoint-folder /mnt/checkpoint_test --num-checkpoints-write=0
+```
+
+Caches need to be cleared by the user outside of the mlpstorage tool.
+
+##### Clearing Caches
+
+The checkpoints that are written are quite large. **If the checkpoint size per client node is less than 3x the client node's memory capacity, then the filesystem cache needs to be cleared between the write and read phases.**
+
+Examples:
+
+| Model (Total Size)  | Num Clients & Memory                      | Size for ranks             | Size for 1st and Last Client                             | Need to Clear Caches?                                            |
+|---------------------|-------------------------------------------|----------------------------|----------------------------------------------------------|------------------------------------------------------------------|
+| Llama3 405b (5.2TB) | 8x (64 Ranks / Node)<br>1024GB per Client | 256x 11.8GB<br>256x 8.85GB | First: 755GB (64x 11.8GB)<br>Last: 566.4GB (64x 8.85GB)  | No (556GB x 3 = 1,699GB which is greater than the client memory) |
+| Llama3 70b (912GB)  | 8x (8x Ranks / Node)<br>1024GB per Client | 64x 11.23GB                | First: 89.8GB (8x 14.23GB)<br>Last: Same as First (DP=1) | Yes (89.8 x 3 = 269.5GB which is less than the client memory)    |
+
+In the first case, after 2x checkpoints data that has been written is being flushed from the filesystem cache. This means that after 10x checkpoints a standard Linux system will not have any data in the filesystem cache that would be read for a checkpoint recovery starting back at the first written checkpoint.
+
+In the second case, after 10x checkpoints, 898GB of data will have been written per client with each client having 1024GB of memory. Without clearing caches this data would be read from the filesystem cache
+
+**fsync**
+
+We enforce ``fsync`` to be applied during checkpoint writes to ensure data is flushed to persistent storage. ``fsync`` is enabled by default in all workload configuration files.
+
+**Example Execution Commands**
+
+* ``default`` mode (``WORLD_SIZE = TP*PP*DP`` as listed in Table 2): 
+  ```bash
+  # Perform checkpoint writes  (make sure the number of hosts is WORLD_SIZE/num_processes_per_host)
+  mlpstorage checkpointing run --model llama3-405b \
+    --hosts ip1 ip2 .... \
+    --num-processes 512 \
+    --num-checkpoints-read 0 \
+    --checkpoint-folder ./checkpoint_data1 \
+    --results-dir ./mlpstorage_results \
+    --client-host-memory-in-gb 64
+
+  # Clear the cache (This might require admin access to the system)
+  ... 
+
+  # perform checkpoint reads
+  mlpstorage checkpointing run --model llama3-405b \
+    --hosts ip1 ip2 .... \
+    --num-processes 512 \
+    --num-checkpoints-write 0 \
+    --checkpoint-folder ./checkpoint_data1 \
+    --results-dir ./mlpstorage_results \
+    --client-host-memory-in-gb 64
+  ```
+* ``subset`` mode (on a single host with **8 simulated accelerators**)
+  ```bash
+  # Perform checkpoint writes (data parallelism must match Table 2)
+  mlpstorage checkpointing run --model llama3-405b \
+    --hosts ip1 \
+    --num-processes 8 \
+    --num-checkpoints-read 0 \
+    --checkpoint-folder ./checkpoint_data1 \
+    --results-dir ./mlpstorage_results \
+    --client-host-memory-in-gb 64
+  # Clear the cache 
+  ... 
+  # Perform checkpoint read (data parallelism must match Table 2)
+  mlpstorage checkpointing run --model llama3-405b \
+    --hosts ip1 \
+    --num-processes 8 \
+    --num-checkpoints-write 0 \
+    --checkpoint-folder ./checkpoint_data1 \
+    --results-dir ./mlpstorage_results \
+    --client-host-memory-in-gb 64
+  ```
+
+#### Metrics and Results Reporting
+We report the checkpoint time per write / read and I/O throughput from each rank. For each run: 
+
+	* The metric for duration is the maximum time across all processes.
+	* The metric for throughput is the minimum across all processes.
+
+A checkpoint workload submission must include 10 checkpoints written and 10 checkpoints read as well as the logs for any optional processes as outlined in section 2.2.5 (clearing caches, storage remapping, etc)
+
+#### Requirements for Simultaneously Readable and Writable
+
+Checkpoint recovery is intended to mimic an environment where a failure has occurred and the data needs to be read by different hosts than wrote the data. 
+
+For storage systems where all hosts can read and write all data simultaneously, the process described above satisfies the requirements.
+
+For storage systems where 1 host has write access to a volume but all hosts have read access, the above process also satisfies the requirements so long as reads can be fulfilled immediately following a write.
+
+For storage systems where 1 host has write access to a volume and a "remapping" process is required for other hosts to read the same data, the time to remap must be measured and included in the submission. 
+
+When a checkpoint is taken/written, it must be written to stable storage, but that checkpoint does not need to be readable by other other hosts yet.  If it is not readable by other hosts immediately after the checkpoint write is complete, if it requires some additional processing or reconfiguration before the checkpoint is readable by other hosts, the time duration between the checkpoint being completed and the earliest time that that checkpoint could be read by a different ``host node`` must be reported in the SystemDescription.yaml file.  That duration between write completion and availability for reading will be added to the time to read/recover from the benchmark.
+
+**Any processes between the write and read phases of checkpointing that are required before data can be read by a different host than wrote the data must be measured and included in the submission. The time for these processes will be added to the recovery time and throughput calculation for submitted scores** 
+
+The system_configuration.yaml document must list whether the solution support simultaneous reads and/or writes as such:
+```yaml
+System:
+  shared_capabilities:
+    multi_host_support: True            # False is used for local storage
+    simultaneous_write_support: False   # Are simultaneous writes by multiple hosts supported in the submitted configuration
+    simultaneous_read__support: True    # Are simultaneous reads by multiple hosts supported in the submitted configuration
+```
+
+#### OPEN vs CLOSED submissions
+For CLOSED submissions, the total number of processes must be fixed according to Table 2.
+
+For OPEN submissions, the total number of processes may be increased in multiples of (TP×PP) to showcase the scalability of the storage solution.
+
+**Table 3: Configuration parameters and their mutability in CLOSED and OPEN divisions**
+
+| Parameter                          | Meaning                                      | Default value                                 | Changeable in CLOSED | Changeable in OPEN |
+|------------------------------------|----------------------------------------------|-----------------------------------------------|----------------------|--------------------|
+| --ppn **(USE HOST:SLOTS INSTEAD)**     | Number of processes per node                 | N/A                                           | YES (minimal 4)      | YES (minimal 4)    |
+| --num-processes                    | Total number of processes                    | Node local: 8<br>Global: the value in Table 1 | NO                   | YES                |
+| --checkpoint-folder                | The folder to save the checkpoint data       | checkpoint/{workload}                         | YES                  | YES                |
+| --num-checkpoints-write            | Number of write checkpoints                  | 10 or 0**                                     | NO                   | NO                 |
+| --num-checkpoints-read             | Number of write checkpoints                  | 10 or 0**                                     | NO                   | NO                 |
+
+**The ``--ppn`` syntax above was incorrect for the MPI package the benchmark uses, please use the syntax ``hostname:slotcount`` for the hosts listed in the ``--hosts`` argument.  The ``slotcount`` value has the same meaning as the ``ppn`` value, the number of processes per node to run.**
+
+** By default, --num-checkpoints-read and --num-checkpoints-write are set to be 10. To perform write only, one has to turn off read by explicitly setting ``--num-checkpoints-read=0``; to perform read only, one has to turn off write by explicitly set  ``--num-checkpoints-write=0``
+
+For an OPEN or CLOSED submission, the process must follow:
+1. Write 10 checkpoints
+2. Clearing Caches or Remapping Volumes if required
+3. Read 10 checkpoint
+
+DLIO and mlpstorage both support options to run 10 checkpoints with a single call or run 10 checkpoints as separate invokations of the tools. So long as the process is followed, checkpoints can be executed as a 10 checkpoint batch or individually. 
+
+## Definitions 
+The following definitions are used throughout this document:
+
+- A **sample** is the unit of data on which training is run, e.g., an image, or a sentence.
+- A **step** is defined to be the first batch of data loaded into the (emulated) accelerator.
+- **Accelerator Utilization (AU)** is defined as the percentage of time taken by the simulated accelerators, relative to the total benchmark running time. Higher is better.
+- **Design power** is defined to be the minimum measurement of electrical power that must be capable of being supplied to a single or collection of power supply units (PSUs) in order to avoid violating regulatory and safety requirements. For individual PSUs, the design power equals the nameplate rated power. For groups of redundant PSUs, the design power is equal to the sum of the nameplate rated power of the minimum number of PSUs required to be simultaneously operational.
+- A **division** is a set of rules for implementing benchmarks from a suite to produce a class of comparable results. MLPerf Storage allows CLOSED and OPEN divisions, detailed in Section 6.
+- **DLIO ([code link](https://github.com/argonne-lcf/dlio_benchmark), [paper link](https://ieeexplore.ieee.org/document/9499416))** is a benchmarking tool for deep learning applications. DLIO is the core of the MLPerf Storage benchmark and with specified configurations will emulate the I/O pattern for the workloads listed in Table 1.  MLPerf Storage provides wrapper scripts to launch DLIO. There is no need to know the internals of DLIO to do a CLOSED submission, as the wrapper scripts provided by MLPerf Storage will suffice. However, for OPEN submissions changes to the DLIO code might be required (e.g., to add custom data loaders). 
+- **Dataset content** refers to the data and the total capacity of the data, not the format of how the data is stored. Specific information on dataset content can be found [here](https://github.com/mlcommons/storage/tree/main/storage-conf/workload). 
+- **Dataset format** refers to the format in which the training data is stored (e.g., npz, hdf5, csv, png, tfrecord, etc.), not the content or total capacity of the dataset.
+
+  *NOTE: we plan to add support for Object storage in a future version of the benchmark, so OPEN submissions that include benchmark application changes and a description of how the original MLPerf Training benchmark dataset was mapped into Objects will be appreciated.*
+- A **storage system** consists of a defined set of hardware and software resources that provide storage services to one or more ``host nodes``. Storage systems can be hardware based, software-defined, virtualized, hyperconverged, or cloud based, and must be capable of providing the minimum storage services required to run the benchmark.  If the storage system requires a dedicated network, then the hardware required for that network must be included in the ``storage system``.  If the storage system is hyperconverged, then it will probably share hardware (eg: CPU and/or networking) with the ``host nodes``.
+- A **storage scaling unit** is defined as the minimum unit by which the performance and scale of a storage system can be increased. Examples of storage scaling units are “nodes”, “controllers”, “virtual machines” or “shelves”. Benchmark runs with different numbers of storage scaling units allow a reviewer to evaluate how well a given storage solution is able to scale as more scaling units are added.
+- A **host node** is defined as the minimum unit by which the load upon the storage system under test can be increased.  Every ``host node`` must run the same number of simulated accelerators.  A ``host node`` can be instantiated by running the MLPerf Storage benchmark code within a Container or within a VM guest image or natively within an entire physical system.  The number of Containers or VM guest images per physical system and the CPU resources per ``host node`` is up to the submitter. Note that the maximum DRAM available to any ``host node`` must be used when calculating the dataset size to be generated for the test. 
+- An **ML framework** is a specific version of a software library or set of related libraries for training ML models using a system. Examples include specific versions of Caffe2, MXNet, PaddlePaddle, PyTorch, or TensorFlow.
+- A **benchmark** is an abstract problem that can be solved using ML by training a model based on a specific dataset or simulation environment to a target quality level.
+- A **reference implementation** is a specific implementation of a benchmark provided by the MLPerf organization.
+- A **benchmark implementation** is an implementation of a benchmark in a particular framework by a user under the rules of a specific division.
+- A **run** is a complete execution of a benchmark implementation on a system.
+- A **benchmark result** is the mean of 5 run results, executed consecutively. The dataset is generated only once for the 5 runs, prior to those runs. The 5 runs must be done on the same machine(s).
+- **Nameplate rated power** is defined as the maximum power capacity that can be provided by a power supply unit (PSU), as declared to a certification authority. The nameplate rated power can typically be obtained from the PSU datasheet.
+- A **Power Supply Unit (PSU)** is a component which converts an AC or DC voltage input to one or more DC voltage outputs for the purpose of powering a system or subsystem. Power supply units may be redundant and hot swappable.
+- **SPEC PTDaemon® Interface (PTDaemon®)** is a software component created by the Standard Performance Evaluation Corporation (SPEC) designed to simplify the measurement of power consumption by abstracting the interface between benchmarking software and supported power analyzers.
+- A **Supported power analyzer** is a test device supported by the PTDaemon® software that measures the instantaneous voltage and multiplies it by the instantaneous current, then accumulates these values over a specific time period to provide a cumulative measurement of consumed electrical power. For a listing of supported power analyzers, see https://www.spec.org/power/docs/SPECpower-Device_List.html
+- A **System Under Test (SUT)** is the storage system being benchmarked.
+
+
+- The storage system under test must be described via one of the following **storage system access types**.  The overall solution might support more than one of the below types, but any given benchmark submission must be described by the access type that was actually used during that submission.  An optional vendor-specified qualifier may be specified. This will be displayed in the results table after the storage system access type, for example, “NAS - RDMA”.
+  - **Direct-attached media** – any solution using local media on the ``host node``(s); eg: NVMe-attached storage with a local filesystem layered over it.  This will be abbreviated “**Local**” in the results table.
+  - **Remotely-attached block device** – any solution using remote block storage; eg: a SAN using FibreChannel, iSCSI, NVMeoF, NVMeoF over RDMA, etc, with a local filesystem implementation layered over it.  This will be abbreviated “**Remote Block**” in the results table.
+  - **Shared filesystem using a standards-defined access protocol** – any solution using a version of standard NFS or CIFS/SMB to access storage.  This will be abbreviated “**NAS**” in the results table.
+  - **Shared filesystem using a proprietary access protocol** – any network-shared filesystem solution that requires a unique/proprietary protocol implementation to be installed on the ``host node``(s) to access storage; eg: an HPC parallel filesystem.  This will be abbreviated “**Proprietary**” in the results table.
+  - **Object** – any solution accessed using an object protocol such as S3,  RADOS, etc.  This will be abbreviated “**Object**” in the results table.
+  - **Other** – any solution whose access is not sufficiently described by the above categories.  This will be abbreviated “**Other**” in the results table.
+
+## Performance Metrics
+
+The metrics reported by the benchmark are different for different types of workloads.  They are broken out below.
+
+The benchmark performance metrics for Checkpoint workloads (write/take, and read/recover) are **bandwidth while writing, and bandwidth while reading**, plus an additional data point which is the amount of time required, if any, between the completion of writing a checkpoint and the first point at which that checkpoint can be read from a different ``host node``.  That duration between write completeion and availability for reading will be added to the time to read/recover from the benchmark.
+
+**Submitters do not need to use hardware accelerators (e.g., GPUs, TPUs, and other ASICs) when running MLPerf Storage - Checkpointing.**
+
+## CLOSED and OPEN Divisions
+
+### CLOSED: virtually all changes are disallowed
+CLOSED represents a level playing field where all results are **comparable** across submissions. CLOSED explicitly forfeits flexibility in order to enable easy comparability. 
+
+In order to accomplish that, most of the optimizations and customizations to the AI/ML algorithms and framework that might typically be applied during benchmarking or even during production use must be disallowed.  Optimizations and customizations to the storage system are allowed in CLOSED.
+
+For CLOSED submissions of this benchmark, the MLPerf Storage codebase takes the place of the AI/ML algorithms and framework, and therefore cannot be changed. The sole exception to this rule is if the submitter decides to apply the code change identified in PR#299 of the DLIO repo in github, the resulting codebase will be considered "unchanged" for the purposes of this rule. 
+
+A small number of parameters can be configured in CLOSED submissions; listed in the tables below.
+
+**Table: Checkpoint Workload Tunable Parameters for CLOSED**
+
+| Parameter                        | Description                                                 | Default               |
+|----------------------------------|-------------------------------------------------------------|-----------------------|
+| checkpoint.checkpoint_folder     | The storage directory for writing and reading checkpoints   | ./checkpoints/<model> |
+| checkpoint.num_checkpoints_write | The number of checkpoint writes to do in a single dlio call | 10                    |
+| checkpoint.num_checkpoints_read  | The number of checkpoint reads to do in a single dlio call  | 10                    |
+
+CLOSED division benchmarks must be referred to using the benchmark name plus the term CLOSED, e.g. “The system was able to support *N ACME X100* accelerators running a CLOSED division 3D U-Net workload at only 8% less than optimal performance.”
+
+### OPEN: changes are allowed but must be disclosed
+
+OPEN allows more **flexibility** to tune and change both the benchmark and the storage system configuration to show off new approaches or new features that will benefit the AI/ML Community. OPEN explicitly forfeits comparability to allow showcasing innovation.
+
+The essence of OPEN division results is that for a given benchmark area, they are “best case” results if optimizations and customizations are allowed.  The submitter has the opportunity to show the performance of the storage system if an arbitrary, but documented, set of changes are made to the data storage environment or algorithms.
+
+Changes to DLIO itself are allowed in OPEN division submissions.  Any changes to DLIO code or command line options must be disclosed. 
+
+While changes to DLIO are allowed, changing the workload itself is not.  Ie: how the workload is processed can be changed, but those changes cannot fundamentally change the purpose and result of the training.  For example, changing the workload imposed upon storage by a ResNet-50 training task into 3D-Unet training task is not allowed.

--- a/checkpointing/README.md
+++ b/checkpointing/README.md
@@ -1,0 +1,10 @@
+# MLPerf Storage Benchmark Suite - Checkpointing Workloads
+MLPerf® Storage is a benchmark suite to characterize the performance of storage systems that support machine learning workloads.
+
+- [Overview](#overview)
+- [Configuration](#configuration)
+
+---
+
+## Overview
+

--- a/training/README.md
+++ b/training/README.md
@@ -1,0 +1,481 @@
+# MLPerf Storage Benchmark Suite - Training Workloads
+MLPerf® Storage is a benchmark suite to characterize the performance of storage systems that support machine learning workloads.
+
+- [Overview](#overview)
+- [Workloads](#workloads)
+	- [FLUX.1](#flux-1)
+   	- [RetinaNet](#retinanet)
+   	- [DLRMv2](#dlrmv2)
+- [Parameters](#parameters)
+	- [CLOSED](#closed)
+	- [OPEN](#open)
+
+---
+
+## Overview
+The training category supports 3 models (FLUX.1, RetinaNet, DLRMv2).
+The benchmark execution process requires these steps:
+1. Datasize - Calculate required number of samples for a given client configuration
+2. Datagen - Generate the required dataset
+3. Run - Execute the benchmark
+
+```bash
+[root@localhost ]# mlpstorage training --help
+usage: mlpstorage training [-h] [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug] [--verbose]
+                           [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params] [--what-if]
+                           {datasize,datagen,run,configview} ...
+
+Run the MLPerf Storage training benchmark
+
+positional arguments:
+  {datasize,datagen,run,configview}
+    datasize            The datasize command calculates the number of samples needed for a given workload, accelerator
+                        type, number of accelerators, and client host memory.
+    datagen             The datagen command generates a dataset for a given workload and number of parallel generation
+                        processes.
+    run                 Run the benchmark with the specified parameters.
+    configview          View the final config based on the specified options.
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+Standard Arguments:
+  --results-dir RESULTS_DIR, -rd RESULTS_DIR
+                        Directory where the benchmark results will be saved.
+  --loops LOOPS         Number of times to run the benchmark
+  --open                Run as an open submission
+  --closed              Run as a closed submission
+
+Output Control:
+  --debug               Enable debug mode
+  --verbose             Enable verbose mode
+  --stream-log-level STREAM_LOG_LEVEL
+  --allow-invalid-params, -aip
+                        Do not fail on invalid parameters.
+
+View Only:
+  --what-if             View the configuration that would execute and the associated command.
+```
+
+Use ```mlpstorage training {command} --help``` for the full list of parameters for each command.
+
+#### Data Sizing and Generation
+
+**Note**: Steps described in this section must be run only in one client host(launcher client).
+
+The datasize command relies on the accelerator being emulated, the max number of accelerators to support, the system memory in the benchmark clients, and the number of benchmark clients.
+
+The two rules that generally dictate the datasize are:
+1. The datasize on disk must be 5x the cumulative system memory of the benchmark clients
+2. The benchmark must run for 500 iterations of the given batch size for all GPUs
+
+If the list of clients is passed in for this command the amount of memory is found programmatically. Otherwise, the user can provide the number of clients and the amount of memory per client for the calculation.
+
+```bash
+[root@localhost ]# mlpstorage training datasize --help
+usage: mlpstorage training datasize [-h] [--hosts HOSTS [HOSTS ...]] --model {cosmoflow,resnet50,unet3d}
+                                    --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB [--exec-type {mpi,docker}]
+                                    [--mpi-bin {mpirun,mpiexec}] [--oversubscribe] [--allow-run-as-root]
+                                    --max-accelerators MAX_ACCELERATORS --accelerator-type {h100,a100,b200,mi355}
+                                    --num-client-hosts NUM_CLIENT_HOSTS [--data-dir DATA_DIR]
+                                    [--params PARAMS [PARAMS ...]]
+                                    [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug]
+                                    [--verbose] [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params]
+                                    [--what-if]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --hosts HOSTS [HOSTS ...], -s HOSTS [HOSTS ...]
+                        Space-separated list of IP addresses or hostnames of the participating hosts. Example: '--
+                        hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'
+  --model {cosmoflow,resnet50,unet3d}, -m {cosmoflow,resnet50,unet3d}
+                        Model to emulate. A specific model defines the sample size, sample container format, and data
+                        rates for each supported accelerator.
+  --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB, -cm CLIENT_HOST_MEMORY_IN_GB
+                        Memory available in the client where the benchmark is run. The dataset needs to be 5x the
+                        available memory for closed submissions.
+  --exec-type {mpi,docker}, -et {mpi,docker}
+                        Execution type for benchmark commands. Supported options: [<EXEC_TYPE.MPI: 'mpi'>,
+                        <EXEC_TYPE.DOCKER: 'docker'>]
+  --max-accelerators MAX_ACCELERATORS, -ma MAX_ACCELERATORS
+                        Max number of simulated accelerators. In multi-host configurations the accelerators will be
+                        initiated in a round-robin fashion to ensure equal distribution of simulated accelerator
+                        processes
+  --accelerator-type {h100,a100,b200,mi355}, -g {h100,a100,b200,mi355}
+                        Accelerator to simulate for the benchmark. A specific accelerator defines the data access
+                        sizes and rates for each supported workload
+  --num-client-hosts NUM_CLIENT_HOSTS, -nc NUM_CLIENT_HOSTS
+                        Number of participating client hosts. Simulated accelerators will be initiated on these hosts
+                        in a round-robin fashion
+  --data-dir DATA_DIR, -dd DATA_DIR
+                        Filesystem location for data
+  --params PARAMS [PARAMS ...], -p PARAMS [PARAMS ...]
+                        Additional parameters to be passed to the benchmark. These will override the config file. For
+                        a closed submission only a subset of params are supported. Multiple values allowed in the
+                        form: --params key1=value1 key2=value2 key3=value3
+  --dlio-bin-path DLIO_BIN_PATH, -dp DLIO_BIN_PATH
+                        Path to DLIO binary. Default is the same as mlpstorage binary path
+
+MPI:
+  --mpi-bin {mpirun,mpiexec}
+                        Execution type for MPI commands. Supported options: ['mpirun', 'mpiexec']
+  --oversubscribe
+  --allow-run-as-root
+
+Standard Arguments:
+  --results-dir RESULTS_DIR, -rd RESULTS_DIR
+                        Directory where the benchmark results will be saved.
+  --loops LOOPS         Number of times to run the benchmark
+  --open                Run as an open submission
+  --closed              Run as a closed submission
+
+Output Control:
+  --debug               Enable debug mode
+  --verbose             Enable verbose mode
+  --stream-log-level STREAM_LOG_LEVEL
+  --allow-invalid-params, -aip
+                        Do not fail on invalid parameters.
+
+View Only:
+  --what-if             View the configuration that would execute and the associated command.
+```
+
+Example:
+
+To calculate minimum dataset size for a `unet3d` model running on 2 client machines with 128 GB each with overall 8 simulated a100 accelerators
+
+```bash
+mlpstorage training datasize -m unet3d --client-host-memory-in-gb 128 --max-accelerators 16 --num-client-hosts 2 --accelerator-type a100  --results-dir ~/mlps-results
+```
+
+2. Synthetic data is generated based on the workload requested by the user.
+
+```bash
+[root@localhost ]# mlpstorage training datagen --help
+usage: mlpstorage training datagen [-h] [--hosts HOSTS [HOSTS ...]] --model {cosmoflow,resnet50,unet3d}
+                                   [--exec-type {mpi,docker}] [--mpi-bin {mpirun,mpiexec}] [--oversubscribe]
+                                   [--allow-run-as-root] --num-processes NUM_PROCESSES [--data-dir DATA_DIR]
+                                   [--ssh-username SSH_USERNAME] [--params PARAMS [PARAMS ...]]
+                                   [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug]
+                                   [--verbose] [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params]
+                                   [--what-if]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --hosts HOSTS [HOSTS ...], -s HOSTS [HOSTS ...]
+                        Space-separated list of IP addresses or hostnames of the participating hosts. Example: '--
+                        hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'
+  --model {cosmoflow,resnet50,unet3d}, -m {cosmoflow,resnet50,unet3d}
+                        Model to emulate. A specific model defines the sample size, sample container format, and data
+                        rates for each supported accelerator.
+  --exec-type {mpi,docker}, -et {mpi,docker}
+                        Execution type for benchmark commands. Supported options: [<EXEC_TYPE.MPI: 'mpi'>,
+                        <EXEC_TYPE.DOCKER: 'docker'>]
+  --num-processes NUM_PROCESSES, -np NUM_PROCESSES
+                        Number of parallel processes to use for dataset generation. Processes will be initiated in a
+                        round-robin fashion across the configured client hosts
+  --data-dir DATA_DIR, -dd DATA_DIR
+                        Filesystem location for data
+  --params PARAMS [PARAMS ...], -p PARAMS [PARAMS ...]
+                        Additional parameters to be passed to the benchmark. These will override the config file. For
+                        a closed submission only a subset of params are supported. Multiple values allowed in the
+                        form: --params key1=value1 key2=value2 key3=value3
+  --dlio-bin-path DLIO_BIN_PATH, -dp DLIO_BIN_PATH
+                        Path to DLIO binary. Default is the same as mlpstorage binary path
+
+MPI:
+  --mpi-bin {mpirun,mpiexec}
+                        Execution type for MPI commands. Supported options: ['mpirun', 'mpiexec']
+  --oversubscribe
+  --allow-run-as-root
+
+Standard Arguments:
+  --results-dir RESULTS_DIR, -rd RESULTS_DIR
+                        Directory where the benchmark results will be saved.
+  --loops LOOPS         Number of times to run the benchmark
+  --open                Run as an open submission
+  --closed              Run as a closed submission
+
+Output Control:
+  --debug               Enable debug mode
+  --verbose             Enable verbose mode
+  --stream-log-level STREAM_LOG_LEVEL
+  --allow-invalid-params, -aip
+                        Do not fail on invalid parameters.
+
+View Only:
+  --what-if             View the configuration that would execute and the associated command.
+```
+
+Example:
+
+For generating training data of 56,000 files for `unet3d` workload into `unet3d_data` directory using 8 parallel jobs distributed on 2 nodes.
+
+```bash
+mlpstorage training datagen --hosts 10.117.61.121,10.117.61.165 --model unet3d --num-processes 8 --data-dir /mnt/unet3d_data --param dataset.num_files_train=56000
+```
+
+#### Running a Training Benchmark
+
+```bash
+[root@localhost ]# mlpstorage training run --help
+usage: mlpstorage training run [-h] [--hosts HOSTS [HOSTS ...]] --model {cosmoflow,resnet50,unet3d}
+                               --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB [--exec-type {mpi,docker}]
+                               [--mpi-bin {mpirun,mpiexec}] [--oversubscribe] [--allow-run-as-root] --num-accelerators
+                               NUM_ACCELERATORS --accelerator-type {h100,a100,b200,mi355} --num-client-hosts NUM_CLIENT_HOSTS
+                               [--data-dir DATA_DIR] [--ssh-username SSH_USERNAME] [--params PARAMS [PARAMS ...]]
+                               [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug] [--verbose]
+                               [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params] [--what-if]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --hosts HOSTS [HOSTS ...], -s HOSTS [HOSTS ...]
+                        Space-separated list of IP addresses or hostnames of the participating hosts. Example: '--
+                        hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'
+  --model {cosmoflow,resnet50,unet3d}, -m {cosmoflow,resnet50,unet3d}
+                        Model to emulate. A specific model defines the sample size, sample container format, and data
+                        rates for each supported accelerator.
+  --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB, -cm CLIENT_HOST_MEMORY_IN_GB
+                        Memory available in the client where the benchmark is run. The dataset needs to be 5x the
+                        available memory for closed submissions.
+  --exec-type {mpi,docker}, -et {mpi,docker}
+                        Execution type for benchmark commands. Supported options: [<EXEC_TYPE.MPI: 'mpi'>,
+                        <EXEC_TYPE.DOCKER: 'docker'>]
+  --num-accelerators NUM_ACCELERATORS, -na NUM_ACCELERATORS
+                        Number of simulated accelerators. In multi-host configurations the accelerators will be
+                        initiated in a round-robin fashion to ensure equal distribution of simulated accelerator
+                        processes
+  --accelerator-type {h100,a100,b200,mi355}, -g {h100,a100,b200,mi355}
+                        Accelerator to simulate for the benchmark. A specific accelerator defines the data access
+                        sizes and rates for each supported workload
+  --num-client-hosts NUM_CLIENT_HOSTS, -nc NUM_CLIENT_HOSTS
+                        Number of participating client hosts. Simulated accelerators will be initiated on these hosts
+                        in a round-robin fashion
+  --data-dir DATA_DIR, -dd DATA_DIR
+                        Filesystem location for data
+  --params PARAMS [PARAMS ...], -p PARAMS [PARAMS ...]
+                        Additional parameters to be passed to the benchmark. These will override the config file. For
+                        a closed submission only a subset of params are supported. Multiple values allowed in the
+                        form: --params key1=value1 key2=value2 key3=value3
+  --dlio-bin-path DLIO_BIN_PATH, -dp DLIO_BIN_PATH
+                        Path to DLIO binary. Default is the same as mlpstorage binary path
+
+MPI:
+  --mpi-bin {mpirun,mpiexec}
+                        Execution type for MPI commands. Supported options: ['mpirun', 'mpiexec']
+  --oversubscribe
+  --allow-run-as-root
+
+Standard Arguments:
+  --results-dir RESULTS_DIR, -rd RESULTS_DIR
+                        Directory where the benchmark results will be saved.
+  --loops LOOPS         Number of times to run the benchmark
+  --open                Run as an open submission
+  --closed              Run as a closed submission
+
+Output Control:
+  --debug               Enable debug mode
+  --verbose             Enable verbose mode
+  --stream-log-level STREAM_LOG_LEVEL
+  --allow-invalid-params, -aip
+                        Do not fail on invalid parameters.
+
+View Only:
+  --what-if             View the configuration that would execute and the associated command.
+
+```
+
+Example:
+
+For running benchmark on `unet3d` workload with data located in `unet3d_data` directory using 2 h100 accelerators spread across 2 client hosts(with IPs 10.117.61.121,10.117.61.165) and results on `unet3d_results` directory, 
+
+```bash
+mlpstorage training run --hosts 10.117.61.121,10.117.61.165 --num-client-hosts 2 --client-host-memory-in-gb 64 --num-accelerators 2 --accelerator-type h100 --model unet3d  --data-dir unet3d_data --results-dir unet3d_results    --param dataset.num_files_train=400 
+```
+
+4. Benchmark submission report is generated by aggregating the individual run results. The reporting command provides the associated functions to generate a report for a given results directory
+
+```bash
+# TODO: Update
+[root@localhost]# mlpstorage reports --help
+usage: mlpstorage reports [-h] [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug] [--verbose]
+                          [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params] [--what-if]
+                          {reportgen} ...
+
+positional arguments:
+  {reportgen}           Sub-commands
+    reportgen           Generate a report from the benchmark results.
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+Standard Arguments:
+  --results-dir RESULTS_DIR, -rd RESULTS_DIR
+                        Directory where the benchmark results will be saved.
+  --loops LOOPS         Number of times to run the benchmark
+  --open                Run as an open submission
+  --closed              Run as a closed submission
+
+Output Control:
+  --debug               Enable debug mode
+  --verbose             Enable verbose mode
+  --stream-log-level STREAM_LOG_LEVEL
+  --allow-invalid-params, -aip
+                        Do not fail on invalid parameters.
+
+View Only:
+  --what-if             View the configuration that would execute and the associated command.
+```
+
+To generate the benchmark report,
+
+```bash
+[root@localhost]# mlpstorage reports reportgen --help
+usage: mlpstorage reports reportgen [-h] [--output-dir OUTPUT_DIR] [--results-dir RESULTS_DIR] [--loops LOOPS]
+                                    [--open | --closed] [--debug] [--verbose] [--stream-log-level STREAM_LOG_LEVEL]
+                                    [--allow-invalid-params] [--what-if]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --output-dir OUTPUT_DIR
+                        Directory where the benchmark report will be saved.
+
+Standard Arguments:
+  --results-dir RESULTS_DIR, -rd RESULTS_DIR
+                        Directory where the benchmark results will be saved.
+  --loops LOOPS         Number of times to run the benchmark
+  --open                Run as an open submission
+  --closed              Run as a closed submission
+
+Output Control:
+  --debug               Enable debug mode
+  --verbose             Enable verbose mode
+  --stream-log-level STREAM_LOG_LEVEL
+  --allow-invalid-params, -aip
+                        Do not fail on invalid parameters.
+
+View Only:
+  --what-if             View the configuration that would execute and the associated command.
+```
+
+Note: The `reportgen` script must be run in the launcher client host. 
+
+## Training Models
+Currently, the storage benchmark suite supports benchmarking of 3 deep learning workloads
+- Image segmentation using U-Net3D model 
+- Image classification using Resnet-50 model
+- Cosmology parameter prediction using CosmoFlow model
+
+### FLUX.1
+
+Calculate minimum dataset size required for the benchmark run based on your client configuration
+
+```bash
+mlpstorage training datasize --model unet3d --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 4 --accelerator-type h100
+```
+
+Generate data for the benchmark run based on the minimum files
+
+```bash
+mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model unet3d --data-dir unet3d_data --results-dir unet3d_results  --param dataset.num_files_train=42000
+```
+  
+Run the benchmark.
+
+```bash
+mlpstorage training run --hosts 127.0.0.1 --num-client-hosts 1 --client-host-memory-in-gb 64 --num-accelerators 4 --accelerator-type h100 --model unet3d  --data-dir unet3d_data --results-dir unet3d_results --param dataset.num_files_train=42000
+```
+
+All results will be stored in the directory configured using `--results-dir`(or `-r`) argument. To generate the final report, run the following in the launcher client host. 
+
+```bash 
+mlpstorage reports reportgen --results-dir unet3d_results
+```
+
+### RetinaNet
+
+Calculate minimum dataset size required for the benchmark run based on your client configuration
+
+```bash
+ mlpstorage training datasize --model resnet50 --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 16 --accelerator-type h100
+```
+
+Generate data for the benchmark run
+
+```bash
+mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model resnet50 --data-dir resnet50_data --results-dir resnet50_results  --param dataset.num_files_train=2557
+```
+  
+Run the benchmark.
+
+```bash
+mlpstorage training run --hosts 127.0.0.1 --num-client-hosts 1  --client-host-memory-in-gb 64  --num-accelerators 16 --accelerator-type h100  --model resnet50  --data-dir resnet50_data --results-dir resnet50_results --param dataset.num_files_train=2557
+```
+
+All results will be stored in the directory configured using `--results-dir`(or `-r`) argument. To generate the final report, run the following in the launcher client host. 
+
+```bash 
+mlpstorage reports reportgen --results-dir resnet50_results
+```
+
+### DLRMv2
+
+Calculate minimum dataset size required for the benchmark run based on your client configuration
+
+```bash
+mlpstorage training datasize --model cosmoflow --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 16 --accelerator-type h100 
+```
+
+Generate data for the benchmark run
+
+```bash
+mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model cosmoflow --data-dir cosmoflow_data --results-dir=cosmoflow_results  --param dataset.num_files_train=121477
+```
+  
+Run the benchmark.
+
+```bash
+mlpstorage training run  --hosts 127.0.0.1 --num-client-hosts 1  --client-host-memory-in-gb 64 --num-accelerators 16  --accelerator-type h100  --model cosmoflow --data-dir cosmoflow_data --results-dir cosmoflow_results --param dataset.num_files_train=121477 
+```
+
+All results will be stored in the directory configured using `--results-dir`(or `-r`) argument. To generate the final report, run the following in the launcher client host. 
+
+```bash 
+mlpstorage reports reportgen --results-dir cosmoflow_results
+```
+
+## Parameters 
+
+### CLOSED
+Below table displays the list of configurable parameters for the benchmark in the closed category.
+
+| Parameter                      | Description                                                 |Default|
+| ------------------------------ | ------------------------------------------------------------ |-------|
+| **Dataset params**		|								|   |
+| dataset.num_files_train       | Number of files for the training set  		        | --|
+| dataset.num_subfolders_train  | Number of subfolders that the training set is stored	        |0|
+| dataset.data_folder           | The path where dataset is stored				| --|
+| **Reader params**				|						|   |
+| reader.read_threads		| Number of threads to load the data                            | --|
+| reader.computation_threads    | Number of threads to preprocess the data(for TensorFlow)      |1|
+| reader.prefetch_size    | Number of batches to prefetch      |2|
+| reader.transfer_size       | Number of bytes in the read buffer(only for Tensorflow)  		        | |
+| reader.odirect                  | Whether to use direct I/O for reader (currectly applicable to UNet3D)   | False | 
+| **Checkpoint params**		|								|   |
+| checkpoint.checkpoint_folder	| The folder to save the checkpoints  				| --|
+| **Storage params**		|								|   |
+| storage.storage_root		| The storage root directory  					| ./|
+| storage.storage_type		| The storage type  						|local_fs|
+
+
+### OPEN
+In addition to what can be changed in the CLOSED category, the following parameters can be changed in the OPEN category.
+
+| Parameter                      | Description                                                 |Default|
+| ------------------------------ | ------------------------------------------------------------ |-------|
+| framework		| The machine learning framework		|Pytorch for 3D U-Net |
+| **Dataset params**		|								|   |
+| dataset.format       | Format of the dataset  		        | .npz for 3D U-Net |
+| dataset.num_samples_per_file       | Number of samples per file(only for Tensorflow using tfrecord datasets)  		        | 1 for 3D U-Net |
+| **Reader params**		|
+| reader.data_loader       | Data loader type(Tensorflow or PyTorch or custom) 		        | PyTorch for 3D U-Net |

--- a/training/README.md
+++ b/training/README.md
@@ -1,18 +1,26 @@
 # MLPerf Storage Benchmark Suite - Training Workloads
 MLPerf® Storage is a benchmark suite to characterize the performance of storage systems that support machine learning workloads.
 
-- [Overview](#overview)
-- [Workloads](#workloads)
-	- [FLUX.1](#flux-1)
-   	- [RetinaNet](#retinanet)
-   	- [DLRMv2](#dlrmv2)
-- [Parameters](#parameters)
-	- [CLOSED](#closed)
-	- [OPEN](#open)
+- [Usage](#Usage)
+  - [Workloads](#workloads)
+	  - [FLUX.1](#flux-1)
+    - [RetinaNet](#retinanet)
+    - [DLRMv2](#dlrmv2)
+  - [Parameters](#parameters)
+  	- [CLOSED](#closed)
+  	- [OPEN](#open)
+- [Theory of Operations](#theory-of-operations)
+  - [Benchmark Overview](#benchmark-overview)
+  - [Definitions](#definitions)
+  - [Performance Metrics](#performance-metrics)
+  - [Dataset Generation](#dataset-generation)
+  - [Single-host Submissions](#single-host-submissions)
+  - [Multi-host (Distributed) Training Submissions](#multi-host-distributed-training-submissions)
+  - [CLOSED and OPEN Divisions](#closed-and-open-divisions)
 
 ---
 
-## Overview
+# Usage
 The training category supports 3 models (FLUX.1, RetinaNet, DLRMv2).
 The benchmark execution process requires these steps:
 1. Datasize - Calculate required number of samples for a given client configuration
@@ -473,9 +481,244 @@ In addition to what can be changed in the CLOSED category, the following paramet
 
 | Parameter                      | Description                                                 |Default|
 | ------------------------------ | ------------------------------------------------------------ |-------|
-| framework		| The machine learning framework		|Pytorch for 3D U-Net |
-| **Dataset params**		|								|   |
-| dataset.format       | Format of the dataset  		        | .npz for 3D U-Net |
-| dataset.num_samples_per_file       | Number of samples per file(only for Tensorflow using tfrecord datasets)  		        | 1 for 3D U-Net |
-| **Reader params**		|
-| reader.data_loader       | Data loader type(Tensorflow or PyTorch or custom) 		        | PyTorch for 3D U-Net |
+| framework		                   | The machine learning framework		|Pytorch for 3D U-Net |
+| **Dataset params**	        	 |								|   |
+| dataset.format                 | Format of the dataset  		      | .npz for 3D U-Net |
+| dataset.num_samples_per_file   | Number of samples per file(only for Tensorflow using tfrecord datasets)  		        | 1 for 3D U-Net |
+| **Reader params**		           |
+| reader.data_loader             | Data loader type(Tensorflow or PyTorch or custom) 		        | PyTorch for 3D U-Net |
+
+
+
+# Theory of Operations
+MLPerf™ Storage is a benchmark suite to characterize the performance of storage systems that support machine learning workloads. The suite consists of 4 workload categories:
+
+1. Training
+2. Checkpointing
+3. Vector Database
+4. KVCache
+
+This benchmark attempts to balance two goals. First, we aim for **comparability** between benchmark submissions to enable decision making by the AI/ML Community. Second, we aim for **flexibility** to enable experimentation and to show off unique storage system features that will benefit the AI/ML Community. To that end we have defined two classes of submissions: CLOSED and OPEN. 
+
+Published results for the 3D-Unet, ResNet-50, and Cosmoflow Training workloads are comparable across v1.0 and v2.0 of the MLPerf Storage benchmark.  A [full listing of comparability is available](https://github.com/mlcommons/policies/blob/master/MLPerf_Compatibility_Table.adoc).
+
+The MLPerf name and logo are trademarks of the MLCommons® Association ("MLCommons"). In order to refer to a result using the MLPerf name, the result must conform to the letter and spirit of the rules specified in this document. MLCommons reserves the right to solely determine if a use of its name or logos is acceptable.
+
+## Benchmark Overview
+
+This version of the benchmark does not include offline or online data pre-processing. We are aware that data pre-processing is an important part of the ML data pipeline and we will include it in a future version of the benchmark.
+
+MLPerf Storage emulates (or "simulates", the terms are used interchangably in this document) accelerators for the training workloads with the tool DLIO developed by Argonne National Labs. DLIO uses the standard AI frameworks (PyTorch, Tensorflow, Numpy, etc) to load data from storage to memory at the same intensity as a given accelerator.
+
+**This emulation means that submitters do not need to use hardware accelerators (e.g., GPUs, TPUs, and other ASICs) when running MLPerf Storage - Training.**
+
+Instead, our benchmark tool replaces the training on the accelerator for a single batch of data with a ``sleep()`` call. The ``sleep()`` interval depends on the batch size and accelerator type and has been determined through measurement on a system running the real training workload. The rest of the data ingestion pipeline (data loading, caching, checkpointing) is unchanged and runs in the same way as when the actual training is performed.
+
+There are two main advantages to accelerator emulation. First, MLPerf Storage allows testing different storage systems with different types of accelerators. To change the type of accelerator that the benchmark emulates (e.g., to switch to a system with NVIDIA H100 GPUs instead of A100 GPUs), it is enough to adjust the batch size and ``sleep()`` parameter. The second advantage is that MLPerf Storage can put a high load on the storage system simply by increasing the number of emulated accelerators. This allows for testing the behavior of the storage system in large-scale scenarios without purchasing/renting the AI compute infrastructure.
+
+The benchmark suite provides workload [configurations](https://github.com/mlcommons/storage/tree/main/storage-conf/workload) that simulate the I/O patterns of selected workloads listed in Table 1. The I/O patterns for each MLPerf Storage benchmark correspond to the I/O patterns of the MLPerf Training and MLPerf HPC benchmarks (i.e., the I/O generated by our tool for 3D U-Net closely follows the I/O generated by actually running the 3D U-Net training workload). The benchmark suite can also generate synthetic datasets which show the same I/O load as the actual datasets listed in Table 1. 
+
+| Area | Problem | Model | Data Loader | Dataset seed | Minimum AU% |
+| ---- | ------- | ----- | ----------- | ------------ | ----------- |
+| Vision | Image segmentation (medical) | 3D U-Net | PyTorch | KiTS 19 (140MB/sample) | 90% |
+| Vision | Image classification | ResNet-50 | TensorFlow | ImageNet (150KB/sample) | 90% |
+| Scientific | Cosmology | parameter prediction | TensorFlow | CosmoFlow N-body simulation (2MB/sample) | 70% |
+
+Table 1: Benchmark description
+
+- Benchmark start point: The dataset is in **shared persistent storage**. 
+- Benchmark end point: The measurement ends after a predetermined number of epochs. *Note: data transfers from storage in this test terminate with the data in host DRAM; transfering data into the accelerator memory is not included in this benchmark.*
+- Configuration files for the workloads and dataset content can be found [here](https://github.com/mlcommons/storage/tree/main/storage-conf/workload).
+
+## Definitions 
+The following definitions are used throughout this document:
+
+- A **sample** is the unit of data on which training is run, e.g., an image, or a sentence.
+- A **step** is defined to be the first batch of data loaded into the (emulated) accelerator.
+- **Accelerator Utilization (AU)** is defined as the percentage of time taken by the simulated accelerators, relative to the total benchmark running time. Higher is better.
+- **Design power** is defined to be the minimum measurement of electrical power that must be capable of being supplied to a single or collection of power supply units (PSUs) in order to avoid violating regulatory and safety requirements. For individual PSUs, the design power equals the nameplate rated power. For groups of redundant PSUs, the design power is equal to the sum of the nameplate rated power of the minimum number of PSUs required to be simultaneously operational.
+- A **division** is a set of rules for implementing benchmarks from a suite to produce a class of comparable results. MLPerf Storage allows CLOSED and OPEN divisions, detailed in Section 6.
+- **DLIO ([code link](https://github.com/argonne-lcf/dlio_benchmark), [paper link](https://ieeexplore.ieee.org/document/9499416))** is a benchmarking tool for deep learning applications. DLIO is the core of the MLPerf Storage benchmark and with specified configurations will emulate the I/O pattern for the workloads listed in Table 1.  MLPerf Storage provides wrapper scripts to launch DLIO. There is no need to know the internals of DLIO to do a CLOSED submission, as the wrapper scripts provided by MLPerf Storage will suffice. However, for OPEN submissions changes to the DLIO code might be required (e.g., to add custom data loaders). 
+- **Dataset content** refers to the data and the total capacity of the data, not the format of how the data is stored. Specific information on dataset content can be found [here](https://github.com/mlcommons/storage/tree/main/storage-conf/workload). 
+- **Dataset format** refers to the format in which the training data is stored (e.g., npz, hdf5, csv, png, tfrecord, etc.), not the content or total capacity of the dataset.
+
+  *NOTE: we plan to add support for Object storage in a future version of the benchmark, so OPEN submissions that include benchmark application changes and a description of how the original MLPerf Training benchmark dataset was mapped into Objects will be appreciated.*
+- A **storage system** consists of a defined set of hardware and software resources that provide storage services to one or more ``host nodes``. Storage systems can be hardware based, software-defined, virtualized, hyperconverged, or cloud based, and must be capable of providing the minimum storage services required to run the benchmark.  If the storage system requires a dedicated network, then the hardware required for that network must be included in the ``storage system``.  If the storage system is hyperconverged, then it will probably share hardware (eg: CPU and/or networking) with the ``host nodes``.
+- A **storage scaling unit** is defined as the minimum unit by which the performance and scale of a storage system can be increased. Examples of storage scaling units are “nodes”, “controllers”, “virtual machines” or “shelves”. Benchmark runs with different numbers of storage scaling units allow a reviewer to evaluate how well a given storage solution is able to scale as more scaling units are added.
+- A **host node** is defined as the minimum unit by which the load upon the storage system under test can be increased.  Every ``host node`` must run the same number of simulated accelerators.  A ``host node`` can be instantiated by running the MLPerf Storage benchmark code within a Container or within a VM guest image or natively within an entire physical system.  The number of Containers or VM guest images per physical system and the CPU resources per ``host node`` is up to the submitter. Note that the maximum DRAM available to any ``host node`` must be used when calculating the dataset size to be generated for the test. 
+- An **ML framework** is a specific version of a software library or set of related libraries for training ML models using a system. Examples include specific versions of Caffe2, MXNet, PaddlePaddle, PyTorch, or TensorFlow.
+- A **benchmark** is an abstract problem that can be solved using ML by training a model based on a specific dataset or simulation environment to a target quality level.
+- A **reference implementation** is a specific implementation of a benchmark provided by the MLPerf organization.
+- A **benchmark implementation** is an implementation of a benchmark in a particular framework by a user under the rules of a specific division.
+- A **run** is a complete execution of a benchmark implementation on a system.
+- A **benchmark result** is the mean of 5 run results, executed consecutively. The dataset is generated only once for the 5 runs, prior to those runs. The 5 runs must be done on the same machine(s).
+- **Nameplate rated power** is defined as the maximum power capacity that can be provided by a power supply unit (PSU), as declared to a certification authority. The nameplate rated power can typically be obtained from the PSU datasheet.
+- A **Power Supply Unit (PSU)** is a component which converts an AC or DC voltage input to one or more DC voltage outputs for the purpose of powering a system or subsystem. Power supply units may be redundant and hot swappable.
+- **SPEC PTDaemon® Interface (PTDaemon®)** is a software component created by the Standard Performance Evaluation Corporation (SPEC) designed to simplify the measurement of power consumption by abstracting the interface between benchmarking software and supported power analyzers.
+- A **Supported power analyzer** is a test device supported by the PTDaemon® software that measures the instantaneous voltage and multiplies it by the instantaneous current, then accumulates these values over a specific time period to provide a cumulative measurement of consumed electrical power. For a listing of supported power analyzers, see https://www.spec.org/power/docs/SPECpower-Device_List.html
+- A **System Under Test (SUT)** is the storage system being benchmarked.
+
+
+- The storage system under test must be described via one of the following **storage system access types**.  The overall solution might support more than one of the below types, but any given benchmark submission must be described by the access type that was actually used during that submission.  An optional vendor-specified qualifier may be specified. This will be displayed in the results table after the storage system access type, for example, “NAS - RDMA”.
+  - **Direct-attached media** – any solution using local media on the ``host node``(s); eg: NVMe-attached storage with a local filesystem layered over it.  This will be abbreviated “**Local**” in the results table.
+  - **Remotely-attached block device** – any solution using remote block storage; eg: a SAN using FibreChannel, iSCSI, NVMeoF, NVMeoF over RDMA, etc, with a local filesystem implementation layered over it.  This will be abbreviated “**Remote Block**” in the results table.
+  - **Shared filesystem using a standards-defined access protocol** – any solution using a version of standard NFS or CIFS/SMB to access storage.  This will be abbreviated “**NAS**” in the results table.
+  - **Shared filesystem using a proprietary access protocol** – any network-shared filesystem solution that requires a unique/proprietary protocol implementation to be installed on the ``host node``(s) to access storage; eg: an HPC parallel filesystem.  This will be abbreviated “**Proprietary**” in the results table.
+  - **Object** – any solution accessed using an object protocol such as S3,  RADOS, etc.  This will be abbreviated “**Object**” in the results table.
+  - **Other** – any solution whose access is not sufficiently described by the above categories.  This will be abbreviated “**Other**” in the results table.
+
+## Performance Metrics
+
+The metrics reported by the benchmark are different for different types of workloads.  They are broken out below.
+
+The benchmark performance metric for Training workloads (3D-Unet, ResNet-50, and Cosmflow) is **samples per second, subject to a minimum accelerator utilization (AU) defined for that workload**. Higher samples per second is better. 
+
+To pass a benchmark run, the AU should be equal to or greater than the minimum value, and is computed as follows:
+```
+AU (percentage) = (total_compute_time/total_benchmark_running_time) * 100
+```
+
+All the I/O operations from the first **step** are excluded from the AU calculation in order to avoid the disturbance in the averages caused by the startup costs of the data processing pipeline, allowing the AU to more-quickly converge on the steady-state performance of the pipeline.  The I/O operations that are excluded from the AU calculation **are** included in the samples/second reported by the benchmark, however.
+
+If all I/O operations are hidden by compute time, then the `total_compute_time` will equal the `total_benchmark_running_time` and the AU will be 100%.
+
+The total compute time can be derived from the batch size, total dataset size, number of simulated accelerators, and sleep time: 
+```
+total_compute_time = (records_per_file * total_files) / simulated_accelerators / batch_size * computation_time * epochs.
+```
+
+*NOTE: The sleep time has been determined by running the actual MLPerf training workloads including the compute step on real hardware and is dependent on the accelerator type. In this version of the benchmark we include sleep times for **NVIDIA A100, H100, and B200 GPUs, as well as AMD MI355 accelerators**. We plan on expanding the measurements to different accelerator types in future releases.*
+
+## Dataset Generation
+
+This section only describes the dataset generation methodology and requirements for Training workloads, the equivalent topic is covered in section 2.2, Checkpointing.
+
+MLPerf Storage uses DLIO to generate synthetic data. Instructions on how to generate the datasets for each benchmark are available [here](https://github.com/mlcommons/storage). The datasets are generated following the sample size distribution and structure of the dataset seeds (see Table 1) for each of the benchmarks. 
+
+**Minimum dataset size**. The MLPerf Storage benchmark script **must be used** to run the benchmarks since it calculates the minimum dataset size for each benchmark.  It does so using the provided number of simulated accelerators and the size of all of the ``host node``’s memory in GB. The minimum dataset size computation is as follows:
+
+- Calculate required minimum samples given number of steps per epoch *(NB:  num_steps_per_epoch is a minimum of 500)*:
+```
+   min_samples_steps_per_epoch = num_steps_per_epoch * batch_size * num_accelerators_across_all_nodes
+```
+- Calculate required minimum samples given host memory to eliminate client-side caching effects; *(NB: HOST_MEMORY_MULTIPLIER = 5)*:
+```
+   min_samples_host_memory_across_all_nodes = number_of_hosts * memory_per_host_in_GB * HOST_MEMORY_MULTIPLIER * 1024 * 1024 * 1024 / record_length
+```
+- Ensure we meet both constraints:
+```
+   min_samples = max(min_samples_steps_per_epoch, min_samples_host_memory_across_all_nodes)
+```
+- Calculate minimum files to generate
+```
+   min_total_files= min_samples / num_samples_per_file
+   min_files_size = min_samples * record_length / 1024 / 1024 / 1024
+```
+
+A minimum of ``min_total_files`` files are required which will consume ``min_files_size`` GB of storage.
+
+**Running the benchmark on a subset of a larger dataset**. We support running the benchmark on a subset of the synthetically generated dataset. One can generate a large dataset and then run the benchmark on a subset of that dataset by setting ``num_files_train`` or ``num_files_eval`` smaller than the number of files available in the dataset folder. Note that if the dataset is stored in multiple subfolders, the subset actually used by this run will be evenly selected from all the subfolders. In this case, ``num_subfolders_train`` and ``num_subfolders_eval`` need to be equal to the actual number of subfolders inside the dataset folder in order to generate valid results.
+
+Please note that the log file(s) output during the generation step needs to be included in the benchmark results submission package.
+
+## Single-host Submissions
+
+This section only applies to Training workloads, the equivalent topic is covered in section 2.2.2, "subset mode".
+
+Submitters can add load to the storage system in two orthogonal ways: (1) increase the number of simulated accelerators inside one ``host node`` (i.e., one machine), and/or (2) increase the number of ``host nodes`` connected to the storage system.
+
+For single-host submissions, increase the number of simulated accelerators by changing the ``--num-accelerators`` parameter to the ``benchmark.sh script``. Note that the benchmarking tool requires approximately 0.5GB of host memory per simulated accelerator.
+
+For **single-host submissions**, CLOSED and OPEN division results must include benchmark runs for the maximum simulated accelerators that can be run on ONE HOST NODE, in ONE MLPerf Storage job, without going below the 90% accelerator utilization threshold.
+
+## Multi-host (Distributed) Training Submissions
+
+This setup simulates distributed training of a single training task, spread across multiple ``host nodes``, on a shared dataset. The current version of the benchmark only supports data parallelism, not model parallelism.
+
+Submitters must respect the following for multi-host node submissions:
+- All the data must be accessible to all the ``host nodes``. 
+- The number of simulated accelerators in each ``host node`` must be identical.
+
+While it is recommended that all ``host nodes`` be as close as possible to identical, that is not required by these Rules.  The fact that distributed training uses a pool-wide common barrier to synchronize the transition from one step to the next of all ``host nodes`` results in the overall performance of the cluster being determined by the slowest ``host node``.
+
+Here are a few practical suggestions on how to leverage a set of non-identical hardware, but these are not requirements of these Rules.  It is possible to leverage very large physical nodes by using multiple Containers or VM guest images per node, each with dedicated affinity to given CPUs cores and where DRAM capacity and NUMA locality have been configured.  Alternatively, larger physical nodes that have higher numbers of cores or additional memory than the others may have those additional cores or memory disabled.
+
+For **distributed training submissions**, CLOSED and OPEN division results must include benchmark runs for the maximum number of simulated accelerators across all ``host nodes`` that can be run in the distributed training setup, without going below the 90% accelerator utilization threshold. Each ``host node`` must run the same number of simulated accelerators for the submission to be valid.
+
+## CLOSED and OPEN Divisions
+
+### CLOSED: virtually all changes are disallowed
+CLOSED represents a level playing field where all results are **comparable** across submissions. CLOSED explicitly forfeits flexibility in order to enable easy comparability. 
+
+In order to accomplish that, most of the optimizations and customizations to the AI/ML algorithms and framework that might typically be applied during benchmarking or even during production use must be disallowed.  Optimizations and customizations to the storage system are allowed in CLOSED.
+
+For CLOSED submissions of this benchmark, the MLPerf Storage codebase takes the place of the AI/ML algorithms and framework, and therefore cannot be changed. The sole exception to this rule is if the submitter decides to apply the code change identified in PR#299 of the DLIO repo in github, the resulting codebase will be considered "unchanged" for the purposes of this rule. 
+
+A small number of parameters can be configured in CLOSED submissions; listed in the tables below.
+
+**Table: Training Workload Tunable Parameters for CLOSED**
+
+| Parameter                    | Description                                                                                                                         | Default  |
+|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|----------|
+| *Dataset parameters*         |                                                                                                                                     |          |
+| dataset.num_files_train      | Number of files for the training set                                                                                                | --       |
+| dataset.num_subfolders_train | Number of subfolders that the training set is stored                                                                                | 0        |
+| dataset.data_folder          | The path where dataset is stored                                                                                                    | --       |
+|                              |                                                                                                                                     |          |
+| *Reader parameters*          |                                                                                                                                     |          |
+| reader.read_threads          | Number of threads to load the data                                                                                                  | --       |
+| reader.computation_threads   | Number of threads to preprocess the data (only for resnet)                                                                          | --       |
+| reader.transfer_size         | An int64 scalar representing the number of bytes in the read buffer. (only supported for Tensorflow models -- Resnet and Cosmoflow) |          |
+| reader.prefetch_size         | An int64 scalar representing the amount of prefetching done, with values of 0, 1, or 2.                                             |          |
+| reader.odirect               | Enable ODIRECT mode for Unet3D Training                                                                                             | False    |
+|                              |                                                                                                                                     |          |
+| *Checkpoint parameters*      |                                                                                                                                     |          |
+| checkpoint.checkpoint_folder | The folder to save the checkpoints                                                                                                  | --       |
+|                              |                                                                                                                                     |          |
+| *Storage parameters*         |                                                                                                                                     |          |
+| storage.storage_root         | The storage root directory                                                                                                          | ./       |
+| storage.storage_type         | The storage type                                                                                                                    | local_fs |
+
+**Table: Checkpoint Workload Tunable Parameters for CLOSED**
+
+| Parameter                        | Description                                                 | Default               |
+|----------------------------------|-------------------------------------------------------------|-----------------------|
+| checkpoint.checkpoint_folder     | The storage directory for writing and reading checkpoints   | ./checkpoints/<model> |
+| checkpoint.num_checkpoints_write | The number of checkpoint writes to do in a single dlio call | 10                    |
+| checkpoint.num_checkpoints_read  | The number of checkpoint reads to do in a single dlio call  | 10                    |
+
+
+CLOSED division benchmarks must be referred to using the benchmark name plus the term CLOSED, e.g. “The system was able to support *N ACME X100* accelerators running a CLOSED division 3D U-Net workload at only 8% less than optimal performance.”
+
+### OPEN: changes are allowed but must be disclosed
+
+OPEN allows more **flexibility** to tune and change both the benchmark and the storage system configuration to show off new approaches or new features that will benefit the AI/ML Community. OPEN explicitly forfeits comparability to allow showcasing innovation.
+
+The essence of OPEN division results is that for a given benchmark area, they are “best case” results if optimizations and customizations are allowed.  The submitter has the opportunity to show the performance of the storage system if an arbitrary, but documented, set of changes are made to the data storage environment or algorithms.
+
+Changes to DLIO itself are allowed in OPEN division submissions.  Any changes to DLIO code or command line options must be disclosed. 
+
+While changes to DLIO are allowed, changing the workload itself is not.  Ie: how the workload is processed can be changed, but those changes cannot fundamentally change the purpose and result of the training.  For example, changing the workload imposed upon storage by a ResNet-50 training task into 3D-Unet training task is not allowed.
+
+In addition to what can be changed in the CLOSED submission, the following parameters can be changed in the benchmark.sh script:
+
+| Parameter                    | Description                                | Default                                                             |
+|------------------------------|--------------------------------------------|---------------------------------------------------------------------|
+| framework                    | The machine learning framework.            | 3D U-Net: PyTorch<br>ResNet-50: Tensorflow<br>Cosmoflow: Tensorflow |
+|                              |                                            |                                                                     |
+| *Dataset parameters*         |                                            |                                                                     |
+| dataset.format               | Format of the dataset.                     | 3D U-Net: .npz<br>ResNet-50: .tfrecord<br>Cosmoflow: .tfrecord      |
+| dataset.num_samples_per_file |                                            | 3D U-Net: 1<br>ResNet-50: 1251<br>Cosmoflow: 1                      |
+|                              |                                            |                                                                     |
+| *Reader parameters*          |                                            |                                                                     |
+| reader.data_loader           | Supported options: Tensorflow or PyTorch.  | 3D U-Net: PyTorch<br>ResNet-50: Tensorflow<br>Cosmoflow: Tensorflow |
+
+
+#### OPEN: num_samples_per_file
+Changing this parameter is supported only with Tensorflow, using tfrecord datasets. Currently, the benchmark code only supports num_samples_per_file = 1 for Pytorch data loader. To support other values, the data loader needs to be adjusted.
+
+#### OPEN: data_loader
+OPEN submissions can have custom data loaders. If a new data loader is added, or an existing data loader is changed, the DLIO code will need to be modified.
+
+#### Execution of OPEN submissions
+OPEN division benchmarks must be referred to using the benchmark name plus the term OPEN, e.g. “The system was able to support N ACME X100 accelerators running an OPEN division 3D U-Net workload at only 8% less than optimal performance.”

--- a/training/README.md
+++ b/training/README.md
@@ -81,10 +81,10 @@ If the list of clients is passed in for this command the amount of memory is fou
 
 ```bash
 [root@localhost ]# mlpstorage training datasize --help
-usage: mlpstorage training datasize [-h] [--hosts HOSTS [HOSTS ...]] --model {cosmoflow,resnet50,unet3d}
+usage: mlpstorage training datasize [-h] [--hosts HOSTS [HOSTS ...]] --model {FLUX.1,RetinaNet,DLRMv2}
                                     --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB [--exec-type {mpi,docker}]
                                     [--mpi-bin {mpirun,mpiexec}] [--oversubscribe] [--allow-run-as-root]
-                                    --max-accelerators MAX_ACCELERATORS --accelerator-type {h100,a100,b200,mi355}
+                                    --max-accelerators MAX_ACCELERATORS --accelerator-type {b200,mi355}
                                     --num-client-hosts NUM_CLIENT_HOSTS [--data-dir DATA_DIR]
                                     [--params PARAMS [PARAMS ...]]
                                     [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug]
@@ -96,7 +96,7 @@ optional arguments:
   --hosts HOSTS [HOSTS ...], -s HOSTS [HOSTS ...]
                         Space-separated list of IP addresses or hostnames of the participating hosts. Example: '--
                         hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'
-  --model {cosmoflow,resnet50,unet3d}, -m {cosmoflow,resnet50,unet3d}
+  --model {FLUX.1,RetinaNet,DLRMv2}, -m {FLUX.1,RetinaNet,DLRMv2}
                         Model to emulate. A specific model defines the sample size, sample container format, and data
                         rates for each supported accelerator.
   --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB, -cm CLIENT_HOST_MEMORY_IN_GB
@@ -109,7 +109,7 @@ optional arguments:
                         Max number of simulated accelerators. In multi-host configurations the accelerators will be
                         initiated in a round-robin fashion to ensure equal distribution of simulated accelerator
                         processes
-  --accelerator-type {h100,a100,b200,mi355}, -g {h100,a100,b200,mi355}
+  --accelerator-type {b200,mi355}, -g {b200,mi355}
                         Accelerator to simulate for the benchmark. A specific accelerator defines the data access
                         sizes and rates for each supported workload
   --num-client-hosts NUM_CLIENT_HOSTS, -nc NUM_CLIENT_HOSTS
@@ -150,17 +150,17 @@ View Only:
 
 Example:
 
-To calculate minimum dataset size for a `unet3d` model running on 2 client machines with 128 GB each with overall 8 simulated a100 accelerators
+To calculate minimum dataset size for a `retinanet` model running on 2 client machines with 128 GB each with overall 8 simulated b200 accelerators
 
 ```bash
-mlpstorage training datasize -m unet3d --client-host-memory-in-gb 128 --max-accelerators 16 --num-client-hosts 2 --accelerator-type a100  --results-dir ~/mlps-results
+mlpstorage training datasize -m retinanet --client-host-memory-in-gb 128 --max-accelerators 16 --num-client-hosts 2 --accelerator-type a100  --results-dir ~/mlps-results
 ```
 
 2. Synthetic data is generated based on the workload requested by the user.
 
 ```bash
 [root@localhost ]# mlpstorage training datagen --help
-usage: mlpstorage training datagen [-h] [--hosts HOSTS [HOSTS ...]] --model {cosmoflow,resnet50,unet3d}
+usage: mlpstorage training datagen [-h] [--hosts HOSTS [HOSTS ...]] --model {flux1,dlrmv2,retinanet}
                                    [--exec-type {mpi,docker}] [--mpi-bin {mpirun,mpiexec}] [--oversubscribe]
                                    [--allow-run-as-root] --num-processes NUM_PROCESSES [--data-dir DATA_DIR]
                                    [--ssh-username SSH_USERNAME] [--params PARAMS [PARAMS ...]]
@@ -173,7 +173,7 @@ optional arguments:
   --hosts HOSTS [HOSTS ...], -s HOSTS [HOSTS ...]
                         Space-separated list of IP addresses or hostnames of the participating hosts. Example: '--
                         hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'
-  --model {cosmoflow,resnet50,unet3d}, -m {cosmoflow,resnet50,unet3d}
+  --model {flux1,dlrmv2,retinanet}, -m {flux1,dlrmv2,retinanet}
                         Model to emulate. A specific model defines the sample size, sample container format, and data
                         rates for each supported accelerator.
   --exec-type {mpi,docker}, -et {mpi,docker}
@@ -217,20 +217,20 @@ View Only:
 
 Example:
 
-For generating training data of 56,000 files for `unet3d` workload into `unet3d_data` directory using 8 parallel jobs distributed on 2 nodes.
+For generating training data of 56,000 files for `retinanet` workload into `unet3d_data` directory using 8 parallel jobs distributed on 2 nodes.
 
 ```bash
-mlpstorage training datagen --hosts 10.117.61.121,10.117.61.165 --model unet3d --num-processes 8 --data-dir /mnt/unet3d_data --param dataset.num_files_train=56000
+mlpstorage training datagen --hosts 10.117.61.121,10.117.61.165 --model retinanet --num-processes 8 --data-dir /mnt/unet3d_data --param dataset.num_files_train=56000
 ```
 
 #### Running a Training Benchmark
 
 ```bash
 [root@localhost ]# mlpstorage training run --help
-usage: mlpstorage training run [-h] [--hosts HOSTS [HOSTS ...]] --model {cosmoflow,resnet50,unet3d}
+usage: mlpstorage training run [-h] [--hosts HOSTS [HOSTS ...]] --model {flux1,dlrmv2,retinanet}
                                --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB [--exec-type {mpi,docker}]
                                [--mpi-bin {mpirun,mpiexec}] [--oversubscribe] [--allow-run-as-root] --num-accelerators
-                               NUM_ACCELERATORS --accelerator-type {h100,a100,b200,mi355} --num-client-hosts NUM_CLIENT_HOSTS
+                               NUM_ACCELERATORS --accelerator-type {b200,mi355} --num-client-hosts NUM_CLIENT_HOSTS
                                [--data-dir DATA_DIR] [--ssh-username SSH_USERNAME] [--params PARAMS [PARAMS ...]]
                                [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug] [--verbose]
                                [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params] [--what-if]
@@ -240,7 +240,7 @@ optional arguments:
   --hosts HOSTS [HOSTS ...], -s HOSTS [HOSTS ...]
                         Space-separated list of IP addresses or hostnames of the participating hosts. Example: '--
                         hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'
-  --model {cosmoflow,resnet50,unet3d}, -m {cosmoflow,resnet50,unet3d}
+  --model {flux1,dlrmv2,retinanet}, -m {flux1,dlrmv2,retinanet}
                         Model to emulate. A specific model defines the sample size, sample container format, and data
                         rates for each supported accelerator.
   --client-host-memory-in-gb CLIENT_HOST_MEMORY_IN_GB, -cm CLIENT_HOST_MEMORY_IN_GB
@@ -253,7 +253,7 @@ optional arguments:
                         Number of simulated accelerators. In multi-host configurations the accelerators will be
                         initiated in a round-robin fashion to ensure equal distribution of simulated accelerator
                         processes
-  --accelerator-type {h100,a100,b200,mi355}, -g {h100,a100,b200,mi355}
+  --accelerator-type {b200,mi355}, -g {b200,mi355}
                         Accelerator to simulate for the benchmark. A specific accelerator defines the data access
                         sizes and rates for each supported workload
   --num-client-hosts NUM_CLIENT_HOSTS, -nc NUM_CLIENT_HOSTS
@@ -295,10 +295,10 @@ View Only:
 
 Example:
 
-For running benchmark on `unet3d` workload with data located in `unet3d_data` directory using 2 h100 accelerators spread across 2 client hosts(with IPs 10.117.61.121,10.117.61.165) and results on `unet3d_results` directory, 
+For running benchmark on `retinanet` workload with data located in `unet3d_data` directory using 2 b200 accelerators spread across 2 client hosts(with IPs 10.117.61.121,10.117.61.165) and results on `unet3d_results` directory, 
 
 ```bash
-mlpstorage training run --hosts 10.117.61.121,10.117.61.165 --num-client-hosts 2 --client-host-memory-in-gb 64 --num-accelerators 2 --accelerator-type h100 --model unet3d  --data-dir unet3d_data --results-dir unet3d_results    --param dataset.num_files_train=400 
+mlpstorage training run --hosts 10.117.61.121,10.117.61.165 --num-client-hosts 2 --client-host-memory-in-gb 64 --num-accelerators 2 --accelerator-type b200 --model retinanet  --data-dir unet3d_data --results-dir unet3d_results    --param dataset.num_files_train=400 
 ```
 
 4. Benchmark submission report is generated by aggregating the individual run results. The reporting command provides the associated functions to generate a report for a given results directory
@@ -370,34 +370,34 @@ Note: The `reportgen` script must be run in the launcher client host.
 
 ## Training Models
 Currently, the storage benchmark suite supports benchmarking of 3 deep learning workloads
-- Image segmentation using U-Net3D model 
-- Image classification using Resnet-50 model
-- Cosmology parameter prediction using CosmoFlow model
+- Image generation using a FLUX.1 model 
+- Image recognition using a RetinaNet model
+- Recommendations using a DLRMv2 model
 
 ### FLUX.1
 
 Calculate minimum dataset size required for the benchmark run based on your client configuration
 
 ```bash
-mlpstorage training datasize --model unet3d --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 4 --accelerator-type h100
+mlpstorage training datasize --model retinanet --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 4 --accelerator-type b200
 ```
 
 Generate data for the benchmark run based on the minimum files
 
 ```bash
-mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model unet3d --data-dir unet3d_data --results-dir unet3d_results  --param dataset.num_files_train=42000
+mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model retinanet --data-dir retinanet_data --results-dir retinanet_results  --param dataset.num_files_train=42000
 ```
   
 Run the benchmark.
 
 ```bash
-mlpstorage training run --hosts 127.0.0.1 --num-client-hosts 1 --client-host-memory-in-gb 64 --num-accelerators 4 --accelerator-type h100 --model unet3d  --data-dir unet3d_data --results-dir unet3d_results --param dataset.num_files_train=42000
+mlpstorage training run --hosts 127.0.0.1 --num-client-hosts 1 --client-host-memory-in-gb 64 --num-accelerators 4 --accelerator-type b200 --model retinanet  --data-dir retinanet_data --results-dir retinanet_results --param dataset.num_files_train=42000
 ```
 
 All results will be stored in the directory configured using `--results-dir`(or `-r`) argument. To generate the final report, run the following in the launcher client host. 
 
 ```bash 
-mlpstorage reports reportgen --results-dir unet3d_results
+mlpstorage reports reportgen --results-dir retinanet_results
 ```
 
 ### RetinaNet
@@ -405,25 +405,25 @@ mlpstorage reports reportgen --results-dir unet3d_results
 Calculate minimum dataset size required for the benchmark run based on your client configuration
 
 ```bash
- mlpstorage training datasize --model resnet50 --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 16 --accelerator-type h100
+ mlpstorage training datasize --model dlrmv2 --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 16 --accelerator-type b200
 ```
 
 Generate data for the benchmark run
 
 ```bash
-mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model resnet50 --data-dir resnet50_data --results-dir resnet50_results  --param dataset.num_files_train=2557
+mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model dlrmv2 --data-dir dlrmv2_data --results-dir dlrmv2_results  --param dataset.num_files_train=2557
 ```
   
 Run the benchmark.
 
 ```bash
-mlpstorage training run --hosts 127.0.0.1 --num-client-hosts 1  --client-host-memory-in-gb 64  --num-accelerators 16 --accelerator-type h100  --model resnet50  --data-dir resnet50_data --results-dir resnet50_results --param dataset.num_files_train=2557
+mlpstorage training run --hosts 127.0.0.1 --num-client-hosts 1  --client-host-memory-in-gb 64  --num-accelerators 16 --accelerator-type b200  --model dlrmv2  --data-dir dlrmv2_data --results-dir dlrmv2_results --param dataset.num_files_train=2557
 ```
 
 All results will be stored in the directory configured using `--results-dir`(or `-r`) argument. To generate the final report, run the following in the launcher client host. 
 
 ```bash 
-mlpstorage reports reportgen --results-dir resnet50_results
+mlpstorage reports reportgen --results-dir dlrmv2_results
 ```
 
 ### DLRMv2
@@ -431,25 +431,25 @@ mlpstorage reports reportgen --results-dir resnet50_results
 Calculate minimum dataset size required for the benchmark run based on your client configuration
 
 ```bash
-mlpstorage training datasize --model cosmoflow --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 16 --accelerator-type h100 
+mlpstorage training datasize --model flux1 --client-host-memory-in-gb 64 --num-client-hosts 1 --max-accelerators 16 --accelerator-type b200 
 ```
 
 Generate data for the benchmark run
 
 ```bash
-mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model cosmoflow --data-dir cosmoflow_data --results-dir=cosmoflow_results  --param dataset.num_files_train=121477
+mlpstorage training datagen --hosts 127.0.0.1 --num-processes 8 --model flux1 --data-dir flux1_data --results-dir=flux1_results  --param dataset.num_files_train=121477
 ```
   
 Run the benchmark.
 
 ```bash
-mlpstorage training run  --hosts 127.0.0.1 --num-client-hosts 1  --client-host-memory-in-gb 64 --num-accelerators 16  --accelerator-type h100  --model cosmoflow --data-dir cosmoflow_data --results-dir cosmoflow_results --param dataset.num_files_train=121477 
+mlpstorage training run  --hosts 127.0.0.1 --num-client-hosts 1  --client-host-memory-in-gb 64 --num-accelerators 16  --accelerator-type b200  --model flux1 --data-dir flux1_data --results-dir flux1_results --param dataset.num_files_train=121477 
 ```
 
 All results will be stored in the directory configured using `--results-dir`(or `-r`) argument. To generate the final report, run the following in the launcher client host. 
 
 ```bash 
-mlpstorage reports reportgen --results-dir cosmoflow_results
+mlpstorage reports reportgen --results-dir flux1_results
 ```
 
 ## Parameters 
@@ -468,7 +468,7 @@ Below table displays the list of configurable parameters for the benchmark in th
 | reader.computation_threads    | Number of threads to preprocess the data(for TensorFlow)      |1|
 | reader.prefetch_size    | Number of batches to prefetch      |2|
 | reader.transfer_size       | Number of bytes in the read buffer(only for Tensorflow)  		        | |
-| reader.odirect                  | Whether to use direct I/O for reader (currectly applicable to UNet3D)   | False | 
+| reader.odirect                  | Whether to use direct I/O for reader   | False | 
 | **Checkpoint params**		|								|   |
 | checkpoint.checkpoint_folder	| The folder to save the checkpoints  				| --|
 | **Storage params**		|								|   |
@@ -500,8 +500,6 @@ MLPerf™ Storage is a benchmark suite to characterize the performance of storag
 
 This benchmark attempts to balance two goals. First, we aim for **comparability** between benchmark submissions to enable decision making by the AI/ML Community. Second, we aim for **flexibility** to enable experimentation and to show off unique storage system features that will benefit the AI/ML Community. To that end we have defined two classes of submissions: CLOSED and OPEN. 
 
-Published results for the 3D-Unet, ResNet-50, and Cosmoflow Training workloads are comparable across v1.0 and v2.0 of the MLPerf Storage benchmark.  A [full listing of comparability is available](https://github.com/mlcommons/policies/blob/master/MLPerf_Compatibility_Table.adoc).
-
 The MLPerf name and logo are trademarks of the MLCommons® Association ("MLCommons"). In order to refer to a result using the MLPerf name, the result must conform to the letter and spirit of the rules specified in this document. MLCommons reserves the right to solely determine if a use of its name or logos is acceptable.
 
 ## Benchmark Overview
@@ -514,15 +512,15 @@ MLPerf Storage emulates (or "simulates", the terms are used interchangably in th
 
 Instead, our benchmark tool replaces the training on the accelerator for a single batch of data with a ``sleep()`` call. The ``sleep()`` interval depends on the batch size and accelerator type and has been determined through measurement on a system running the real training workload. The rest of the data ingestion pipeline (data loading, caching, checkpointing) is unchanged and runs in the same way as when the actual training is performed.
 
-There are two main advantages to accelerator emulation. First, MLPerf Storage allows testing different storage systems with different types of accelerators. To change the type of accelerator that the benchmark emulates (e.g., to switch to a system with NVIDIA H100 GPUs instead of A100 GPUs), it is enough to adjust the batch size and ``sleep()`` parameter. The second advantage is that MLPerf Storage can put a high load on the storage system simply by increasing the number of emulated accelerators. This allows for testing the behavior of the storage system in large-scale scenarios without purchasing/renting the AI compute infrastructure.
+There are two main advantages to accelerator emulation. First, MLPerf Storage allows testing different storage systems with different types of accelerators. To change the type of accelerator that the benchmark emulates (e.g., to switch to a system with NVIDIA B200 GPUs), it is enough to adjust the batch size and ``sleep()`` parameter. The second advantage is that MLPerf Storage can put a high load on the storage system simply by increasing the number of emulated accelerators. This allows for testing the behavior of the storage system in large-scale scenarios without purchasing/renting the AI compute infrastructure.
 
 The benchmark suite provides workload [configurations](https://github.com/mlcommons/storage/tree/main/storage-conf/workload) that simulate the I/O patterns of selected workloads listed in Table 1. The I/O patterns for each MLPerf Storage benchmark correspond to the I/O patterns of the MLPerf Training and MLPerf HPC benchmarks (i.e., the I/O generated by our tool for 3D U-Net closely follows the I/O generated by actually running the 3D U-Net training workload). The benchmark suite can also generate synthetic datasets which show the same I/O load as the actual datasets listed in Table 1. 
 
 | Area | Problem | Model | Data Loader | Dataset seed | Minimum AU% |
 | ---- | ------- | ----- | ----------- | ------------ | ----------- |
-| Vision | Image segmentation (medical) | 3D U-Net | PyTorch | KiTS 19 (140MB/sample) | 90% |
-| Vision | Image classification | ResNet-50 | TensorFlow | ImageNet (150KB/sample) | 90% |
-| Scientific | Cosmology | parameter prediction | TensorFlow | CosmoFlow N-body simulation (2MB/sample) | 70% |
+| Vision | Image generation | FLUX.1 | PyTorch | ??? | 90% |
+| Vision | Image Recognition | RetinaNet | PyTorch | ??? | 90% |
+| Recommender | Recommender | ??? | PyTorch | ??? | 90% |
 
 Table 1: Benchmark description
 
@@ -571,7 +569,7 @@ The following definitions are used throughout this document:
 
 The metrics reported by the benchmark are different for different types of workloads.  They are broken out below.
 
-The benchmark performance metric for Training workloads (3D-Unet, ResNet-50, and Cosmflow) is **samples per second, subject to a minimum accelerator utilization (AU) defined for that workload**. Higher samples per second is better. 
+The benchmark performance metric for Training workloads is **samples per second, subject to a minimum accelerator utilization (AU) defined for that workload**. Higher samples per second is better. 
 
 To pass a benchmark run, the AU should be equal to or greater than the minimum value, and is computed as follows:
 ```
@@ -587,7 +585,7 @@ The total compute time can be derived from the batch size, total dataset size, n
 total_compute_time = (records_per_file * total_files) / simulated_accelerators / batch_size * computation_time * epochs.
 ```
 
-*NOTE: The sleep time has been determined by running the actual MLPerf training workloads including the compute step on real hardware and is dependent on the accelerator type. In this version of the benchmark we include sleep times for **NVIDIA A100, H100, and B200 GPUs, as well as AMD MI355 accelerators**. We plan on expanding the measurements to different accelerator types in future releases.*
+*NOTE: The sleep time has been determined by running the actual MLPerf training workloads including the compute step on real hardware and is dependent on the accelerator type. In this version of the benchmark we include sleep times for **NVIDIA B200 GPUs, as well as AMD MI355 accelerators**. We plan on expanding the measurements to different accelerator types in future releases.*
 
 ## Dataset Generation
 
@@ -667,10 +665,9 @@ A small number of parameters can be configured in CLOSED submissions; listed in 
 |                              |                                                                                                                                     |          |
 | *Reader parameters*          |                                                                                                                                     |          |
 | reader.read_threads          | Number of threads to load the data                                                                                                  | --       |
-| reader.computation_threads   | Number of threads to preprocess the data (only for resnet)                                                                          | --       |
-| reader.transfer_size         | An int64 scalar representing the number of bytes in the read buffer. (only supported for Tensorflow models -- Resnet and Cosmoflow) |          |
+| reader.computation_threads   | Number of threads to preprocess the data                                                                          | --       |
 | reader.prefetch_size         | An int64 scalar representing the amount of prefetching done, with values of 0, 1, or 2.                                             |          |
-| reader.odirect               | Enable ODIRECT mode for Unet3D Training                                                                                             | False    |
+| reader.odirect               | Enable ODIRECT mode                                                                                             | False    |
 |                              |                                                                                                                                     |          |
 | *Checkpoint parameters*      |                                                                                                                                     |          |
 | checkpoint.checkpoint_folder | The folder to save the checkpoints                                                                                                  | --       |
@@ -698,20 +695,20 @@ The essence of OPEN division results is that for a given benchmark area, they ar
 
 Changes to DLIO itself are allowed in OPEN division submissions.  Any changes to DLIO code or command line options must be disclosed. 
 
-While changes to DLIO are allowed, changing the workload itself is not.  Ie: how the workload is processed can be changed, but those changes cannot fundamentally change the purpose and result of the training.  For example, changing the workload imposed upon storage by a ResNet-50 training task into 3D-Unet training task is not allowed.
+While changes to DLIO are allowed, changing the workload itself is not.  Ie: how the workload is processed can be changed, but those changes cannot fundamentally change the purpose and result of the training.  For example, changing the workload imposed upon storage by a training task into a checkpointing task is not allowed.
 
 In addition to what can be changed in the CLOSED submission, the following parameters can be changed in the benchmark.sh script:
 
 | Parameter                    | Description                                | Default                                                             |
 |------------------------------|--------------------------------------------|---------------------------------------------------------------------|
-| framework                    | The machine learning framework.            | 3D U-Net: PyTorch<br>ResNet-50: Tensorflow<br>Cosmoflow: Tensorflow |
+| framework                    | The machine learning framework.            | PyTorch |
 |                              |                                            |                                                                     |
 | *Dataset parameters*         |                                            |                                                                     |
-| dataset.format               | Format of the dataset.                     | 3D U-Net: .npz<br>ResNet-50: .tfrecord<br>Cosmoflow: .tfrecord      |
-| dataset.num_samples_per_file |                                            | 3D U-Net: 1<br>ResNet-50: 1251<br>Cosmoflow: 1                      |
+| dataset.format               | Format of the dataset.                     | FLUX.1: ???<br>RetinaNet: ???<br>DLRMv2: ???      |
+| dataset.num_samples_per_file |                                            | FLUX.1: ???<br>RetinaNet: ???<br>DLRMv2: ???                      |
 |                              |                                            |                                                                     |
 | *Reader parameters*          |                                            |                                                                     |
-| reader.data_loader           | Supported options: Tensorflow or PyTorch.  | 3D U-Net: PyTorch<br>ResNet-50: Tensorflow<br>Cosmoflow: Tensorflow |
+| reader.data_loader           | PyTorch  | PyTorch |
 
 
 #### OPEN: num_samples_per_file


### PR DESCRIPTION
Separate the READMEs into one-per-workload-type (eg: a general/overview README, then one for training, checkpointing, VDB, and KVCache).

These are not completely correct yet, but they're close and getting them into the tree enables much easier/better review.