### PR TITLE
Add Apache-2.0 license to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "mlpstorage"
 version = "2.0.0b1"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
+license = {text = "Apache-2.0"}
 authors = [
     {name = "MLCommons Storage Working Group"}
 ]


### PR DESCRIPTION
Fixes #340

The LICENSE.md file specifies Apache 2.0 but pyproject.toml was missing the license field.
This caused `pip show mlpstorage` to report an empty license.                                                                                                                         

**Change:**  Added `license = {text = "Apache-2.0"}` to the `[project]` section.                                                                                                       

**Verified:**
1. Before: `License:` (empty)
2. After: `License: Apache-2.0`
3. One metadata line added, no code changes.
