### PR TITLE
docs: fix QUICK_START.md Local Filesystem examples to match current CLI

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -35,16 +35,18 @@ Uses the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) to simu
 # Generate data
 mlpstorage training datagen \
   --model resnet50 \
-  --params storage.storage_type=local \
-  --params storage.storage_root=/tmp/mlperf-test/resnet50
+  --file \
+  --num-processes 4 \
+  --data-dir /tmp/mlperf-test/resnet50
 
 # Run
 mlpstorage training run \
   --model resnet50 \
   --accelerator-type h100 \
-  --num-processes 4 \
-  --params storage.storage_type=local \
-  --params storage.storage_root=/tmp/mlperf-test/resnet50
+  --num-accelerators 4 \
+  --client-host-memory-in-gb 64 \
+  --file \
+  --data-dir /tmp/mlperf-test/resnet50
 ```
 
 ### S3 Object Storage


### PR DESCRIPTION
Fixes #335

The Training → Local Filesystem examples in docs/QUICK_START.md use old CLI flags (--params storage.storage_type=local, --params storage.storage_root=..., --num-processes on run) that the current mlpstorage no longer accepts. Running the examples as written produces argparse errors for missing required arguments.

**Change:** Updated the datagen and run examples in the Local Filesystem block to use the current CLI :  --file, --num-processes (datagen) / --num-accelerators (run),  --client-host-memory-in-gb, --data-dir.

**Verified:**
1. Before (datagen): error: the following arguments are required: --num-processes/-np
2. Before (run): error: the following arguments are required: --client-host-memory-in-gb/-cm, --num-accelerators/-na
3. After: both commands parse and execute successfully end-to-end.

Docs-only change, no code modified.