### PR TITLE
Fix multi-host execution: --hosts parsing (#322) and MPI cluster collector staging (#303)

### DIFF
--- a/mlpstorage
+++ b/mlpstorage
@@ -1,2 +1,12 @@
-#! /bin/bash
-uv run python3 -m mlpstorage_py.main $*
+#!/usr/bin/env bash
+# Wrapper for running mlpstorage directly from a checkout via `uv run`.
+# Preferred install path is `uv pip install -e .` (uses [project.scripts]).
+#
+# IMPORTANT fixes vs prior version (see issue #322):
+#   - "$@" (not $*) preserves argument quoting; args with spaces stay intact.
+#   - `--` separator prevents `uv run` from intercepting flags meant for mlpstorage
+#     (e.g. --project, --directory, --no-sync, --python).
+#   - --project pins the uv project to this checkout regardless of $PWD.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec uv run --project "$SCRIPT_DIR" -- python3 -m mlpstorage_py.main "$@"

--- a/mlpstorage_py/cli/common_args.py
+++ b/mlpstorage_py/cli/common_args.py
@@ -51,11 +51,15 @@ HELP_MESSAGES = {
     ),
     'client_hosts': (
         "Space-separated list of IP addresses or hostnames of the participating hosts. "
-        "\nExample: '--hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'. Slots can "
+        "\nExample: '--hosts 192.168.1.1 192.168.1.2 192.168.1.3' or '--hosts host1 host2 host3'. "
+        "Comma-separated values are also accepted: '--hosts host1,host2,host3'. "
+        "Slots can "
         "be specified by appending ':<num_slots>' to a hostname like so: '--hosts host1:2 host2:2'. This "
         "example will run 2 accelerators on each host. If slots are not specified the number of processes "
         "will be equally distributed across the hosts with any remainder being distributed evenly on the "
-        "remaining hosts in the order they are listed."
+        "remaining hosts in the order they are listed. "
+        "\nDo NOT use '--hosts=h1 h2' (with '=' and space); argparse will only bind 'h1' to --hosts "
+        "and treat 'h2' as a stray positional argument. Use '--hosts h1 h2' or '--hosts=h1,h2' instead."
     ),
     'category': "Benchmark category to be submitted.",
     'results_dir': "Directory where the benchmark results will be saved.",

--- a/mlpstorage_py/cli_parser.py
+++ b/mlpstorage_py/cli_parser.py
@@ -266,7 +266,7 @@ def update_args(args):
             sys.exit(EXIT_CODE.INVALID_ARGUMENTS)
         args.hosts = normalized
 
-    if hasattr(args, 'hosts') and not getattr(args, 'num_client_hosts', None):
+    if hasattr(args, 'hosts') and getattr(args, 'num_client_hosts', None) is None:
         setattr(args, "num_client_hosts", len(args.hosts))
 
 

--- a/mlpstorage_py/cli_parser.py
+++ b/mlpstorage_py/cli_parser.py
@@ -6,6 +6,7 @@ using modular argument builders from the cli package.
 """
 
 import argparse
+import re
 import sys
 
 from mlpstorage_py import VERSION
@@ -243,14 +244,29 @@ def update_args(args):
         flattened_mpi_params = [item for sublist in args.mpi_params for item in sublist]
         setattr(args,'mpi_params', flattened_mpi_params)
 
-    if hasattr(args, 'hosts'):
-        print(f'Hosts is: {args.hosts}')
-        # hosts can be comma separated string or a list of strings. If it's a string, it is still a list of length 1
-        if len(args.hosts) == 1 and isinstance(args.hosts[0], str):
-            setattr(args, 'hosts', args.hosts[0].split(','))
-        print(f'Hosts is: {args.hosts}')
+    if hasattr(args, 'hosts') and args.hosts is not None:
+        # Accept any of the following equivalent forms and normalize to a clean list:
+        #   --hosts h1 h2 h3              -> ['h1', 'h2', 'h3']
+        #   --hosts h1,h2,h3              -> ['h1', 'h2', 'h3']
+        #   --hosts 'h1 h2 h3'            -> ['h1', 'h2', 'h3']   (quoted, e.g. from YAML)
+        #   --hosts='h1,h2,h3'            -> ['h1', 'h2', 'h3']   (DLIO subprocess form)
+        #   --hosts='h1 h2 h3'            -> ['h1', 'h2', 'h3']   (quoted after '=')
+        # This defends against the argparse + nargs='+' + '=' interaction documented in
+        # https://github.com/mlcommons/storage/issues/322.
+        raw = args.hosts if isinstance(args.hosts, list) else [args.hosts]
+        normalized = []
+        for item in raw:
+            if not isinstance(item, str):
+                continue
+            for tok in re.split(r'[,\s]+', item.strip()):
+                if tok:
+                    normalized.append(tok)
+        if not normalized:
+            print("ERROR: --hosts is empty after parsing", file=sys.stderr)
+            sys.exit(EXIT_CODE.INVALID_ARGUMENTS)
+        args.hosts = normalized
 
-    if not hasattr(args, "num_client_hosts") and hasattr(args, "hosts"):
+    if hasattr(args, 'hosts') and not getattr(args, 'num_client_hosts', None):
         setattr(args, "num_client_hosts", len(args.hosts))
 
 

--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -11,10 +11,9 @@ import os
 import shutil
 import socket
 import subprocess
-import tempfile
 import threading
 import time
-import uuid
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional, Tuple
@@ -1179,9 +1178,11 @@ class MPIClusterCollector:
         hosts: List[str],
         mpi_bin: str,
         logger,
+        results_dir: str,
         allow_run_as_root: bool = False,
         timeout_seconds: int = 60,
-        shared_tmp_dir: Optional[str] = None,
+        shared_staging_dir: Optional[str] = None,
+        shared_tmp_dir: Optional[str] = None,  # deprecated, see note below
         ssh_username: Optional[str] = None,
     ):
         """
@@ -1191,22 +1192,56 @@ class MPIClusterCollector:
             hosts: List of hostnames/IPs, optionally with slot counts (e.g., "host1:4").
             mpi_bin: MPI binary to use (MPIRUN or MPIEXEC constant).
             logger: Logger instance for messages.
+            results_dir: Absolute or relative path to the benchmark results
+                directory. The collector stages its helper script under
+                ``<results_dir>/collector-staging/``; the staged script
+                persists after the run as a debuggable artifact. This
+                replaces the previous per-invocation ``tempfile`` staging
+                directory so no programmatic ``rm -rf`` is ever issued over
+                SSH (see PR #347 review).
             allow_run_as_root: If True, adds --allow-run-as-root flag.
             timeout_seconds: Maximum time to wait for collection.
-            shared_tmp_dir: Optional path that is visible on every node. When set,
-                the collector writes the helper script under this path and skips
-                SSH-based staging. Typically used on clusters with a shared
-                scratch filesystem (NFS/Lustre/GPFS).
+            shared_staging_dir: Optional path that is visible on every node.
+                When set, the collector writes the helper script under this
+                path and skips SSH-based staging. Typically used on clusters
+                with a shared scratch filesystem (NFS/Lustre/GPFS).
+            shared_tmp_dir: Deprecated alias for ``shared_staging_dir``.
+                Kept for one release for backward compatibility; emits a
+                DeprecationWarning.
             ssh_username: Optional SSH username used when staging the script on
                 remote hosts. Defaults to the current user. Ignored when
-                ``shared_tmp_dir`` is set or when all hosts are localhost.
+                ``shared_staging_dir`` is set or when all hosts are localhost.
+
+        Raises:
+            ValueError: if ``results_dir`` is empty or None. Multi-host
+                collection without a results directory has no defensible
+                staging location now that tempdir-based staging is gone.
         """
+        if not results_dir:
+            raise ValueError(
+                "MPIClusterCollector requires results_dir for script staging"
+            )
+
+        # Backward compatibility for the old kwarg name. Drop in a future
+        # release.
+        if shared_tmp_dir is not None:
+            warnings.warn(
+                "shared_tmp_dir is deprecated; use shared_staging_dir instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if shared_staging_dir is None:
+                shared_staging_dir = shared_tmp_dir
+
         self.hosts = hosts
         self.mpi_bin = mpi_bin
         self.logger = logger
+        self.results_dir = os.path.abspath(results_dir)
         self.allow_run_as_root = allow_run_as_root
         self.timeout = timeout_seconds
-        self.shared_tmp_dir = shared_tmp_dir
+        self.shared_staging_dir = (
+            os.path.abspath(shared_staging_dir) if shared_staging_dir else None
+        )
         self.ssh_username = ssh_username
 
     def _get_unique_hosts(self) -> List[str]:
@@ -1323,7 +1358,7 @@ class MPIClusterCollector:
             target = self._ssh_target(host)
             try:
                 mkdir_cmd = [
-                    "ssh", *ssh_common, target, f"mkdir -p {remote_dir}"
+                    "ssh", *ssh_common, target, f"mkdir -p '{remote_dir}'"
                 ]
                 r = subprocess.run(
                     mkdir_cmd, capture_output=True, text=True,
@@ -1362,47 +1397,33 @@ class MPIClusterCollector:
                         f"Script staging on {host} failed: {err}"
                     )
                 else:
-                    self.logger.debug(
+                    self.logger.info(
                         f"Collector script staged on {host}:{remote_dir}"
                     )
         return results
-
-    def _cleanup_remote_staging(
-        self, remote_dir: str, hosts: List[str]
-    ) -> None:
-        """Best-effort removal of the staged directory on each remote host.
-
-        Failures here are logged at DEBUG level and never raised — cleanup
-        should not mask the real error from :meth:`collect`.
-        """
-        ssh_common = self._ssh_common_opts()
-
-        def clean_one(host: str) -> None:
-            try:
-                subprocess.run(
-                    ["ssh", *ssh_common, self._ssh_target(host),
-                     f"rm -rf {remote_dir}"],
-                    capture_output=True, text=True, timeout=10,
-                )
-            except Exception as e:
-                self.logger.debug(
-                    f"Remote cleanup on {host} failed (non-fatal): {e}"
-                )
-
-        max_workers = min(16, max(1, len(hosts)))
-        with ThreadPoolExecutor(max_workers=max_workers) as ex:
-            list(ex.map(clean_one, hosts))
 
     def collect(self) -> Dict[str, Any]:
         """
         Execute MPI collection across all nodes.
 
-        The collector script is written to a per-invocation directory whose
-        absolute path is identical on every participating node. When
-        ``shared_tmp_dir`` is set that directory lives under the shared path
-        (no staging needed). Otherwise the directory lives under each host's
-        local ``tempfile.gettempdir()`` (typically ``/tmp``) and the helper
-        script is staged to each remote host via SCP before ``mpirun`` runs.
+        The collector script is written to ``<results_dir>/collector-staging/``
+        on the launch host and the same absolute path is created on each
+        remote host via SSH before the script is copied there with SCP.
+        Because ``results_dir`` is resolved to an absolute path at
+        construction time, the path is identical on every participating
+        node, which is what ``mpirun`` requires.
+
+        When ``shared_staging_dir`` is set the script is written under that
+        path and no SSH staging is performed (suitable for clusters with a
+        shared NFS/Lustre/GPFS scratch FS).
+
+        The staged script is **not removed** at the end of the run — it is
+        kept as a persistent run artifact so users can inspect it after a
+        failure. This is a deliberate design choice (see PR #347 review)
+        : programmatic ``rm -rf`` over SSH is
+        unacceptable. Consecutive runs against the same ``results_dir``
+        simply overwrite the script, which is safe and idempotent.
+
         This fixes issue #303, where the previous implementation assumed
         ``tempfile.TemporaryDirectory()`` on the launch host was visible to
         every rank.
@@ -1419,137 +1440,128 @@ class MPIClusterCollector:
         )
 
         # --- Decide where to place the helper script ---------------------
-        if self.shared_tmp_dir:
-            base_tmp = self.shared_tmp_dir
+        if self.shared_staging_dir:
+            staging_dir = self.shared_staging_dir
             use_staging = False
             self.logger.debug(
-                f"Using shared tmp dir (no SSH staging): {base_tmp}"
+                f"Using shared staging dir (no SSH staging): {staging_dir}"
             )
         else:
-            base_tmp = tempfile.gettempdir()
+            staging_dir = os.path.join(self.results_dir, "collector-staging")
             use_staging = True
 
-        # Unique per-invocation directory, same absolute path on every node
-        run_id = f"mlps_collector_{uuid.uuid4().hex[:12]}"
-        working_dir = os.path.join(base_tmp, run_id)
-        script_path = os.path.join(working_dir, "mlps_collector.py")
-        output_path = os.path.join(working_dir, "cluster_info.json")
+        script_path = os.path.join(staging_dir, "mlps_collector.py")
+        output_path = os.path.join(staging_dir, "cluster_info.json")
 
         remote_hosts_to_stage: List[str] = []
-        try:
-            os.makedirs(working_dir, exist_ok=True)
-            self._write_collector_script(script_path)
 
-            # --- Stage the script on remote hosts if needed --------------
-            if use_staging:
-                remote_hosts_to_stage = self._remote_hosts_needing_staging()
-                if remote_hosts_to_stage:
-                    self.logger.debug(
-                        f"Staging collector script to "
-                        f"{len(remote_hosts_to_stage)} remote host(s) "
-                        f"at {working_dir}"
-                    )
-                    stage_results = self._stage_script_on_remote_hosts(
-                        script_path, working_dir, remote_hosts_to_stage
-                    )
-                    failures = {
-                        h: e for h, e in stage_results.items() if e
-                    }
-                    if failures:
-                        raise RuntimeError(
-                            "Failed to stage collector script on "
-                            f"{len(failures)} host(s): {failures}. "
-                            "Verify passwordless SSH from the launch host, or "
-                            "set --cluster-collector-shared-tmp / "
-                            "MLPS_CLUSTER_COLLECTOR_SHARED_TMP to a directory "
-                            "visible on every node."
-                        )
+        os.makedirs(staging_dir, exist_ok=True)
+        self._write_collector_script(script_path)
+        self.logger.info(
+            f"Collector script staged at {script_path} "
+            f"(persisted as run artifact)"
+        )
 
-            # --- Build and run the mpirun command ------------------------
-            cmd = self._generate_mpi_command(script_path, output_path)
-            self.logger.debug(f"Running MPI collection command: {cmd}")
-
-            # Silence OpenSSH X11-forwarding warnings that mpirun's rsh/ssh
-            # PLM emits when XAUTHORITY is not set on the launch host
-            # ('Authorization required, but no authorization protocol
-            # specified'). Reported in issue #303.
-            env = os.environ.copy()
-            env.pop("DISPLAY", None)      # prevent SSH X11 forwarding handshake
-            env.pop("XAUTHORITY", None)   # and its cookie lookup
-            env.setdefault(
-                "PLM_RSH_AGENT",
-                "ssh -o ForwardX11=no -o ForwardX11Trusted=no "
-                "-o StrictHostKeyChecking=accept-new",
-            )
-
-            try:
-                result = subprocess.run(
-                    cmd,
-                    shell=True,
-                    capture_output=True,
-                    text=True,
-                    timeout=self.timeout,
-                    env=env,
+        # --- Stage the script on remote hosts if needed ------------------
+        if use_staging:
+            remote_hosts_to_stage = self._remote_hosts_needing_staging()
+            if remote_hosts_to_stage:
+                self.logger.info(
+                    f"Staging collector script to "
+                    f"{len(remote_hosts_to_stage)} remote host(s)..."
                 )
-            except subprocess.TimeoutExpired:
-                raise RuntimeError(
-                    f"MPI collection timed out after {self.timeout} seconds"
+                stage_results = self._stage_script_on_remote_hosts(
+                    script_path, staging_dir, remote_hosts_to_stage
                 )
-
-            # --- Parse the output written by rank 0 ----------------------
-            if os.path.exists(output_path):
-                with open(output_path, 'r') as f:
-                    collected_data = json.load(f)
-
-                if collected_data.get('_mpi_import_error'):
-                    error_msg = collected_data.get(
-                        '_error_message', 'mpi4py not available'
-                    )
-                    error_host = collected_data.get('_hostname', 'unknown')
+                failures = {
+                    h: e for h, e in stage_results.items() if e
+                }
+                if failures:
                     raise RuntimeError(
-                        f"MPI collection failed on host '{error_host}': "
-                        f"{error_msg}. Ensure mpi4py is installed on all "
-                        "cluster nodes."
+                        "Failed to stage collector script on "
+                        f"{len(failures)} host(s): {failures}. "
+                        "Verify passwordless SSH from the launch host, or "
+                        "set --cluster-collector-shared-staging / "
+                        "MLPS_CLUSTER_COLLECTOR_SHARED_STAGING to a "
+                        "directory visible on every node."
                     )
 
-                if result.returncode != 0:
-                    self.logger.warning(
-                        f"MPI collection returned non-zero exit code: "
-                        f"{result.returncode}\nstderr: {result.stderr}"
-                    )
+        # --- Build and run the mpirun command ----------------------------
+        cmd = self._generate_mpi_command(script_path, output_path)
+        self.logger.info(
+            f"Running MPI collection across {len(unique_hosts)} host(s)"
+        )
+        self.logger.debug(f"MPI command: {cmd}")
 
-                self.logger.debug(
-                    f"Successfully collected info from "
-                    f"{len(collected_data)} hosts"
-                )
-                return collected_data
+        # Silence OpenSSH X11-forwarding warnings that mpirun's rsh/ssh
+        # PLM emits when XAUTHORITY is not set on the launch host
+        # ('Authorization required, but no authorization protocol
+        # specified'). Reported in issue #303.
+        env = os.environ.copy()
+        env.pop("DISPLAY", None)      # prevent SSH X11 forwarding handshake
+        env.pop("XAUTHORITY", None)   # and its cookie lookup
+        env.setdefault(
+            "PLM_RSH_AGENT",
+            "ssh -o ForwardX11=no -o ForwardX11Trusted=no "
+            "-o StrictHostKeyChecking=accept-new",
+        )
 
-            # No output file — surface staging + mpirun context together.
-            staged_summary = (
-                remote_hosts_to_stage if remote_hosts_to_stage
-                else "[launch host only]"
+        try:
+            result = subprocess.run(
+                cmd,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                env=env,
             )
+        except subprocess.TimeoutExpired:
             raise RuntimeError(
-                "MPI collection did not produce output file. "
-                f"Return code: {result.returncode}. "
-                f"Staged on: {staged_summary}. "
-                f"stderr: {result.stderr}"
+                f"MPI collection timed out after {self.timeout} seconds"
             )
 
-        except RuntimeError:
-            raise
-        except Exception as e:
-            raise RuntimeError(f"MPI collection failed: {e}")
-        finally:
-            # Best-effort cleanup on remote hosts and the launch host.
-            if use_staging and remote_hosts_to_stage:
-                self._cleanup_remote_staging(
-                    working_dir, remote_hosts_to_stage
+        # --- Parse the output written by rank 0 --------------------------
+        if os.path.exists(output_path):
+            with open(output_path, 'r') as f:
+                collected_data = json.load(f)
+
+            if collected_data.get('_mpi_import_error'):
+                error_msg = collected_data.get(
+                    '_error_message', 'mpi4py not available'
                 )
-            try:
-                shutil.rmtree(working_dir, ignore_errors=True)
-            except Exception:  # pragma: no cover — defensive
-                pass
+                error_host = collected_data.get('_hostname', 'unknown')
+                raise RuntimeError(
+                    f"MPI collection failed on host '{error_host}': "
+                    f"{error_msg}. Ensure mpi4py is installed on all "
+                    "cluster nodes."
+                )
+
+            if result.returncode != 0:
+                self.logger.warning(
+                    f"MPI collection returned non-zero exit code: "
+                    f"{result.returncode}\nstderr: {result.stderr}"
+                )
+
+            self.logger.info(
+                f"MPI collection completed successfully "
+                f"({len(collected_data)} hosts reported)"
+            )
+            return collected_data
+
+        # No output file — surface staging + mpirun context together.
+        # The staged script is left in place on both launch and remote
+        # hosts so the failure can be diagnosed post-mortem.
+        staged_summary = (
+            remote_hosts_to_stage if remote_hosts_to_stage
+            else "[launch host only]"
+        )
+        raise RuntimeError(
+            "MPI collection did not produce output file. "
+            f"Return code: {result.returncode}. "
+            f"Staged on: {staged_summary}. "
+            f"Staged script (persisted for inspection): {script_path}. "
+            f"stderr: {result.stderr}"
+        )
 
     def collect_local_only(self) -> Dict[str, Any]:
         """
@@ -1566,10 +1578,12 @@ def collect_cluster_info(
     hosts: List[str],
     mpi_bin: str,
     logger,
+    results_dir: str,
     allow_run_as_root: bool = False,
     timeout_seconds: int = 60,
     fallback_to_local: bool = True,
-    shared_tmp_dir: Optional[str] = None,
+    shared_staging_dir: Optional[str] = None,
+    shared_tmp_dir: Optional[str] = None,  # deprecated, see note below
     ssh_username: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
@@ -1583,12 +1597,16 @@ def collect_cluster_info(
         hosts: List of hostnames/IPs to collect from.
         mpi_bin: MPI command to use.
         logger: Logger instance.
+        results_dir: Benchmark results directory. The helper script will be
+            staged under ``<results_dir>/collector-staging/`` and persists
+            after the run as a debuggable artifact. Required.
         allow_run_as_root: Whether to allow running as root.
         timeout_seconds: Timeout for MPI collection.
         fallback_to_local: If True, fall back to local collection on failure.
-        shared_tmp_dir: Optional path visible on every node. If provided,
+        shared_staging_dir: Optional path visible on every node. If provided,
             the collector skips SSH-based script staging. See
             :class:`MPIClusterCollector` for details.
+        shared_tmp_dir: Deprecated alias for ``shared_staging_dir``.
         ssh_username: Optional SSH username for remote script staging.
             Defaults to the current user.
 
@@ -1600,8 +1618,10 @@ def collect_cluster_info(
         hosts=hosts,
         mpi_bin=mpi_bin,
         logger=logger,
+        results_dir=results_dir,
         allow_run_as_root=allow_run_as_root,
         timeout_seconds=timeout_seconds,
+        shared_staging_dir=shared_staging_dir,
         shared_tmp_dir=shared_tmp_dir,
         ssh_username=ssh_username,
     )

--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -14,6 +14,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional, Tuple
@@ -1179,7 +1180,9 @@ class MPIClusterCollector:
         mpi_bin: str,
         logger,
         allow_run_as_root: bool = False,
-        timeout_seconds: int = 60
+        timeout_seconds: int = 60,
+        shared_tmp_dir: Optional[str] = None,
+        ssh_username: Optional[str] = None,
     ):
         """
         Initialize the MPI cluster collector.
@@ -1190,12 +1193,21 @@ class MPIClusterCollector:
             logger: Logger instance for messages.
             allow_run_as_root: If True, adds --allow-run-as-root flag.
             timeout_seconds: Maximum time to wait for collection.
+            shared_tmp_dir: Optional path that is visible on every node. When set,
+                the collector writes the helper script under this path and skips
+                SSH-based staging. Typically used on clusters with a shared
+                scratch filesystem (NFS/Lustre/GPFS).
+            ssh_username: Optional SSH username used when staging the script on
+                remote hosts. Defaults to the current user. Ignored when
+                ``shared_tmp_dir`` is set or when all hosts are localhost.
         """
         self.hosts = hosts
         self.mpi_bin = mpi_bin
         self.logger = logger
         self.allow_run_as_root = allow_run_as_root
         self.timeout = timeout_seconds
+        self.shared_tmp_dir = shared_tmp_dir
+        self.ssh_username = ssh_username
 
     def _get_unique_hosts(self) -> List[str]:
         """Extract unique hostnames from the hosts list (removing slot counts)."""
@@ -1252,9 +1264,148 @@ class MPIClusterCollector:
             f.write(MPI_COLLECTOR_SCRIPT)
         os.chmod(script_path, 0o755)
 
+    def _ssh_target(self, host: str) -> str:
+        """Return '[user@]host' for SSH/SCP invocations."""
+        return f"{self.ssh_username}@{host}" if self.ssh_username else host
+
+    def _ssh_common_opts(self) -> List[str]:
+        """SSH/SCP options used for all staging operations.
+
+        * ``BatchMode=yes`` — never prompt for a password; fail fast if
+          passwordless SSH is not configured.
+        * ``StrictHostKeyChecking=accept-new`` — accept new host keys on first
+          contact but reject changed keys; matches the behavior users already
+          have configured for ``mpirun``.
+        * ``ForwardX11=no`` — suppress the ``Authorization required, but no
+          authorization protocol specified`` noise seen in issue #303.
+        * ``ConnectTimeout`` — bound per-host handshake time so a single bad
+          host cannot consume the whole collection timeout budget.
+        """
+        return [
+            "-o", "BatchMode=yes",
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "ForwardX11=no",
+            "-o", f"ConnectTimeout={max(5, self.timeout // 6)}",
+        ]
+
+    def _remote_hosts_needing_staging(self) -> List[str]:
+        """Return remote (non-localhost) unique hosts that need the script."""
+        return [h for h in self._get_unique_hosts() if not _is_localhost(h)]
+
+    def _stage_script_on_remote_hosts(
+        self,
+        script_local_path: str,
+        remote_dir: str,
+        hosts: List[str],
+    ) -> Dict[str, Optional[str]]:
+        """SCP the collector script to ``remote_dir`` on each remote host.
+
+        The per-host work is parallelised with a thread pool; each call is
+        independent and almost entirely I/O-bound.
+
+        Args:
+            script_local_path: Path to the collector script on the launch host.
+            remote_dir: Absolute directory to create on each remote host; the
+                script will be placed at ``remote_dir/mlps_collector.py``. The
+                same absolute path is used on every node so the ``mpirun``
+                command line is identical everywhere.
+            hosts: Remote hostnames to stage to. Callers should pass the result
+                of :meth:`_remote_hosts_needing_staging` to avoid SSHing to the
+                launch host.
+
+        Returns:
+            Mapping ``{host: None on success, error_message_str on failure}``.
+        """
+        per_host_timeout = max(10, self.timeout // 3)
+        ssh_common = self._ssh_common_opts()
+
+        def stage_one(host: str) -> Tuple[str, Optional[str]]:
+            target = self._ssh_target(host)
+            try:
+                mkdir_cmd = [
+                    "ssh", *ssh_common, target, f"mkdir -p {remote_dir}"
+                ]
+                r = subprocess.run(
+                    mkdir_cmd, capture_output=True, text=True,
+                    timeout=per_host_timeout,
+                )
+                if r.returncode != 0:
+                    return host, f"ssh mkdir failed: {r.stderr.strip() or r.stdout.strip()}"
+
+                scp_cmd = [
+                    "scp", *ssh_common, script_local_path,
+                    f"{target}:{remote_dir}/mlps_collector.py",
+                ]
+                r = subprocess.run(
+                    scp_cmd, capture_output=True, text=True,
+                    timeout=per_host_timeout,
+                )
+                if r.returncode != 0:
+                    return host, f"scp failed: {r.stderr.strip() or r.stdout.strip()}"
+                return host, None
+            except subprocess.TimeoutExpired:
+                return host, f"timed out after {per_host_timeout}s"
+            except FileNotFoundError as e:
+                return host, f"ssh/scp binary not found: {e}"
+            except Exception as e:  # pragma: no cover — defensive
+                return host, f"unexpected error: {e}"
+
+        results: Dict[str, Optional[str]] = {}
+        max_workers = min(16, max(1, len(hosts)))
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futures = {ex.submit(stage_one, h): h for h in hosts}
+            for f in as_completed(futures):
+                host, err = f.result()
+                results[host] = err
+                if err:
+                    self.logger.warning(
+                        f"Script staging on {host} failed: {err}"
+                    )
+                else:
+                    self.logger.debug(
+                        f"Collector script staged on {host}:{remote_dir}"
+                    )
+        return results
+
+    def _cleanup_remote_staging(
+        self, remote_dir: str, hosts: List[str]
+    ) -> None:
+        """Best-effort removal of the staged directory on each remote host.
+
+        Failures here are logged at DEBUG level and never raised — cleanup
+        should not mask the real error from :meth:`collect`.
+        """
+        ssh_common = self._ssh_common_opts()
+
+        def clean_one(host: str) -> None:
+            try:
+                subprocess.run(
+                    ["ssh", *ssh_common, self._ssh_target(host),
+                     f"rm -rf {remote_dir}"],
+                    capture_output=True, text=True, timeout=10,
+                )
+            except Exception as e:
+                self.logger.debug(
+                    f"Remote cleanup on {host} failed (non-fatal): {e}"
+                )
+
+        max_workers = min(16, max(1, len(hosts)))
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            list(ex.map(clean_one, hosts))
+
     def collect(self) -> Dict[str, Any]:
         """
         Execute MPI collection across all nodes.
+
+        The collector script is written to a per-invocation directory whose
+        absolute path is identical on every participating node. When
+        ``shared_tmp_dir`` is set that directory lives under the shared path
+        (no staging needed). Otherwise the directory lives under each host's
+        local ``tempfile.gettempdir()`` (typically ``/tmp``) and the helper
+        script is staged to each remote host via SCP before ``mpirun`` runs.
+        This fixes issue #303, where the previous implementation assumed
+        ``tempfile.TemporaryDirectory()`` on the launch host was visible to
+        every rank.
 
         Returns:
             Dictionary mapping hostname -> system_info dict.
@@ -1263,19 +1414,73 @@ class MPIClusterCollector:
             RuntimeError: If MPI collection fails completely.
         """
         unique_hosts = self._get_unique_hosts()
-        self.logger.debug(f"Starting MPI cluster collection on {len(unique_hosts)} hosts")
+        self.logger.debug(
+            f"Starting MPI cluster collection on {len(unique_hosts)} hosts"
+        )
 
-        # Create temporary files for script and output
-        with tempfile.TemporaryDirectory() as tmpdir:
-            script_path = os.path.join(tmpdir, 'mlps_collector.py')
-            output_path = os.path.join(tmpdir, 'cluster_info.json')
+        # --- Decide where to place the helper script ---------------------
+        if self.shared_tmp_dir:
+            base_tmp = self.shared_tmp_dir
+            use_staging = False
+            self.logger.debug(
+                f"Using shared tmp dir (no SSH staging): {base_tmp}"
+            )
+        else:
+            base_tmp = tempfile.gettempdir()
+            use_staging = True
 
-            # Write the collector script
+        # Unique per-invocation directory, same absolute path on every node
+        run_id = f"mlps_collector_{uuid.uuid4().hex[:12]}"
+        working_dir = os.path.join(base_tmp, run_id)
+        script_path = os.path.join(working_dir, "mlps_collector.py")
+        output_path = os.path.join(working_dir, "cluster_info.json")
+
+        remote_hosts_to_stage: List[str] = []
+        try:
+            os.makedirs(working_dir, exist_ok=True)
             self._write_collector_script(script_path)
 
-            # Generate and run the MPI command
+            # --- Stage the script on remote hosts if needed --------------
+            if use_staging:
+                remote_hosts_to_stage = self._remote_hosts_needing_staging()
+                if remote_hosts_to_stage:
+                    self.logger.debug(
+                        f"Staging collector script to "
+                        f"{len(remote_hosts_to_stage)} remote host(s) "
+                        f"at {working_dir}"
+                    )
+                    stage_results = self._stage_script_on_remote_hosts(
+                        script_path, working_dir, remote_hosts_to_stage
+                    )
+                    failures = {
+                        h: e for h, e in stage_results.items() if e
+                    }
+                    if failures:
+                        raise RuntimeError(
+                            "Failed to stage collector script on "
+                            f"{len(failures)} host(s): {failures}. "
+                            "Verify passwordless SSH from the launch host, or "
+                            "set --cluster-collector-shared-tmp / "
+                            "MLPS_CLUSTER_COLLECTOR_SHARED_TMP to a directory "
+                            "visible on every node."
+                        )
+
+            # --- Build and run the mpirun command ------------------------
             cmd = self._generate_mpi_command(script_path, output_path)
             self.logger.debug(f"Running MPI collection command: {cmd}")
+
+            # Silence OpenSSH X11-forwarding warnings that mpirun's rsh/ssh
+            # PLM emits when XAUTHORITY is not set on the launch host
+            # ('Authorization required, but no authorization protocol
+            # specified'). Reported in issue #303.
+            env = os.environ.copy()
+            env.pop("DISPLAY", None)      # prevent SSH X11 forwarding handshake
+            env.pop("XAUTHORITY", None)   # and its cookie lookup
+            env.setdefault(
+                "PLM_RSH_AGENT",
+                "ssh -o ForwardX11=no -o ForwardX11Trusted=no "
+                "-o StrictHostKeyChecking=accept-new",
+            )
 
             try:
                 result = subprocess.run(
@@ -1283,46 +1488,68 @@ class MPIClusterCollector:
                     shell=True,
                     capture_output=True,
                     text=True,
-                    timeout=self.timeout
+                    timeout=self.timeout,
+                    env=env,
                 )
-
-                # Read and parse the output if it exists
-                if os.path.exists(output_path):
-                    with open(output_path, 'r') as f:
-                        collected_data = json.load(f)
-
-                    # Check for MPI import error marker
-                    if collected_data.get('_mpi_import_error'):
-                        error_msg = collected_data.get('_error_message', 'mpi4py not available')
-                        error_host = collected_data.get('_hostname', 'unknown')
-                        raise RuntimeError(
-                            f"MPI collection failed on host '{error_host}': {error_msg}. "
-                            f"Ensure mpi4py is installed on all cluster nodes."
-                        )
-
-                    # Check for non-zero return code (other MPI errors)
-                    if result.returncode != 0:
-                        self.logger.warning(
-                            f"MPI collection returned non-zero exit code: {result.returncode}\n"
-                            f"stderr: {result.stderr}"
-                        )
-
-                    self.logger.debug(
-                        f"Successfully collected info from {len(collected_data)} hosts"
-                    )
-                    return collected_data
-                else:
-                    raise RuntimeError(
-                        f"MPI collection did not produce output file. "
-                        f"Return code: {result.returncode}, stderr: {result.stderr}"
-                    )
-
             except subprocess.TimeoutExpired:
                 raise RuntimeError(
                     f"MPI collection timed out after {self.timeout} seconds"
                 )
-            except Exception as e:
-                raise RuntimeError(f"MPI collection failed: {e}")
+
+            # --- Parse the output written by rank 0 ----------------------
+            if os.path.exists(output_path):
+                with open(output_path, 'r') as f:
+                    collected_data = json.load(f)
+
+                if collected_data.get('_mpi_import_error'):
+                    error_msg = collected_data.get(
+                        '_error_message', 'mpi4py not available'
+                    )
+                    error_host = collected_data.get('_hostname', 'unknown')
+                    raise RuntimeError(
+                        f"MPI collection failed on host '{error_host}': "
+                        f"{error_msg}. Ensure mpi4py is installed on all "
+                        "cluster nodes."
+                    )
+
+                if result.returncode != 0:
+                    self.logger.warning(
+                        f"MPI collection returned non-zero exit code: "
+                        f"{result.returncode}\nstderr: {result.stderr}"
+                    )
+
+                self.logger.debug(
+                    f"Successfully collected info from "
+                    f"{len(collected_data)} hosts"
+                )
+                return collected_data
+
+            # No output file — surface staging + mpirun context together.
+            staged_summary = (
+                remote_hosts_to_stage if remote_hosts_to_stage
+                else "[launch host only]"
+            )
+            raise RuntimeError(
+                "MPI collection did not produce output file. "
+                f"Return code: {result.returncode}. "
+                f"Staged on: {staged_summary}. "
+                f"stderr: {result.stderr}"
+            )
+
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"MPI collection failed: {e}")
+        finally:
+            # Best-effort cleanup on remote hosts and the launch host.
+            if use_staging and remote_hosts_to_stage:
+                self._cleanup_remote_staging(
+                    working_dir, remote_hosts_to_stage
+                )
+            try:
+                shutil.rmtree(working_dir, ignore_errors=True)
+            except Exception:  # pragma: no cover — defensive
+                pass
 
     def collect_local_only(self) -> Dict[str, Any]:
         """
@@ -1341,7 +1568,9 @@ def collect_cluster_info(
     logger,
     allow_run_as_root: bool = False,
     timeout_seconds: int = 60,
-    fallback_to_local: bool = True
+    fallback_to_local: bool = True,
+    shared_tmp_dir: Optional[str] = None,
+    ssh_username: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     High-level function to collect cluster information.
@@ -1357,6 +1586,11 @@ def collect_cluster_info(
         allow_run_as_root: Whether to allow running as root.
         timeout_seconds: Timeout for MPI collection.
         fallback_to_local: If True, fall back to local collection on failure.
+        shared_tmp_dir: Optional path visible on every node. If provided,
+            the collector skips SSH-based script staging. See
+            :class:`MPIClusterCollector` for details.
+        ssh_username: Optional SSH username for remote script staging.
+            Defaults to the current user.
 
     Returns:
         Dictionary mapping hostname -> system_info dict.
@@ -1367,7 +1601,9 @@ def collect_cluster_info(
         mpi_bin=mpi_bin,
         logger=logger,
         allow_run_as_root=allow_run_as_root,
-        timeout_seconds=timeout_seconds
+        timeout_seconds=timeout_seconds,
+        shared_tmp_dir=shared_tmp_dir,
+        ssh_username=ssh_username,
     )
 
     metadata = {

--- a/mlpstorage_py/environment/validators.py
+++ b/mlpstorage_py/environment/validators.py
@@ -50,6 +50,9 @@ class ValidationIssue(Exception):
             parts.append(f"Host: {self.host}")
         return "\n".join(parts)
 
+# Defensive: update_args() normalizes quoted/space-separated --hosts forms
+# before we get here, so this should never fire in normal flow. Kept as a
+# belt-and-suspenders guard against direct API callers that skip update_args.
 
 def validate_ssh_connectivity(
     hosts: List[str],

--- a/mlpstorage_py/environment/validators.py
+++ b/mlpstorage_py/environment/validators.py
@@ -103,6 +103,22 @@ def validate_ssh_connectivity(
         # Parse host:slots format (e.g., "node1:4" -> "node1")
         hostname = host_entry.split(':')[0].strip()
 
+        # Guard against malformed tokens that could only come from a parsing error
+        # upstream (see issue #322: users passing `--hosts='h1 h2'` with quotes get
+        # a single token containing whitespace).
+        if not hostname or any(ch.isspace() for ch in hostname):
+            results.append((
+                host_entry,
+                False,
+                (
+                    f"Invalid host token {host_entry!r}: contains whitespace or is empty. "
+                    "Hosts must be passed as separate arguments "
+                    "(e.g. `--hosts h1 h2 h3`) or comma-separated "
+                    "(e.g. `--hosts h1,h2,h3`), not as a single quoted string."
+                ),
+            ))
+            continue
+
         # Skip localhost entries
         if hostname.lower() in ('localhost', '127.0.0.1'):
             results.append((hostname, True, 'localhost (skipped)'))

--- a/mlpstorage_py/tests/test_cluster_collector.py
+++ b/mlpstorage_py/tests/test_cluster_collector.py
@@ -724,10 +724,11 @@ class TestMPIImportErrorHandling:
         }
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            output_path = os.path.join(tmpdir, 'cluster_info.json')
-            with open(output_path, 'w') as f:
-                json.dump(valid_output, f)
-
+            # Under the new implementation (issue #303 fix), the collector
+            # creates a uuid-named subdirectory inside its base tmp dir and
+            # writes cluster_info.json there. We exercise that path by
+            # supplying ``shared_tmp_dir`` and pinning the uuid so we know
+            # the final output path.
             import subprocess
             from unittest.mock import patch, MagicMock
 
@@ -735,12 +736,23 @@ class TestMPIImportErrorHandling:
             mock_result.returncode = 0
             mock_result.stderr = ""
 
-            with patch('subprocess.run', return_value=mock_result):
-                with patch.object(collector, '_write_collector_script'):
-                    with patch.object(collector, '_generate_mpi_command', return_value="mpirun test"):
-                        with patch('tempfile.TemporaryDirectory') as mock_tmpdir:
-                            mock_tmpdir.return_value.__enter__.return_value = tmpdir
+            with patch('mlpstorage_py.cluster_collector.uuid.uuid4') as mock_uuid:
+                mock_uuid.return_value.hex = 'abcdef012345'
+                working_dir = os.path.join(tmpdir, 'mlps_collector_abcdef012345')
+                os.makedirs(working_dir, exist_ok=True)
+                output_path = os.path.join(working_dir, 'cluster_info.json')
+                with open(output_path, 'w') as f:
+                    json.dump(valid_output, f)
 
+                collector.shared_tmp_dir = tmpdir
+
+                with patch('mlpstorage_py.cluster_collector.subprocess.run',
+                           return_value=mock_result):
+                    with patch.object(collector, '_write_collector_script'):
+                        with patch.object(
+                            collector, '_generate_mpi_command',
+                            return_value="mpirun test",
+                        ):
                             result = collector.collect()
 
                             assert 'host1' in result

--- a/mlpstorage_py/tests/test_mpi_cluster_collector_issue_303.py
+++ b/mlpstorage_py/tests/test_mpi_cluster_collector_issue_303.py
@@ -1,0 +1,341 @@
+"""Regression tests for issue #303.
+
+MPIClusterCollector used to write the helper collector script into a
+``tempfile.TemporaryDirectory()`` on the launch host only, then invoke
+``mpirun`` with that absolute path. On clusters with node-local ``/tmp``
+the remote ranks could not find the script and ``mpirun`` aborted with
+``[Errno 2] No such file or directory``.
+
+These tests cover the three code paths introduced by the fix:
+
+* default "stage-and-run" path — SCPs the script to each remote host
+  before ``mpirun``, and cleans up afterwards;
+* ``shared_tmp_dir`` opt-in — skips all SSH staging;
+* partial staging failure — raises a descriptive error naming the bad host.
+
+Also covers the X11 env injection that silences the
+``Authorization required, but no authorization protocol specified``
+noise reported in the original issue.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from typing import List
+from unittest import mock
+
+import pytest
+
+from mlpstorage_py import cluster_collector as cc
+from mlpstorage_py.config import MPIRUN
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fake_run(output_path_getter, write_output: bool = True):
+    """Build a fake ``subprocess.run`` that fakes ``mpirun`` by writing the
+    expected rank-0 output JSON to disk, and records every call.
+
+    Parameters
+    ----------
+    output_path_getter: callable returning the expected cluster_info.json path
+        at the time ``mpirun`` is invoked (resolved lazily so the per-run UUID
+        path created inside ``collect()`` is honored).
+    write_output: when False, ``mpirun`` "succeeds" but produces no output
+        file — simulating a cluster where staging succeeded but mpirun itself
+        failed to run the script on every rank.
+    """
+    calls: List[dict] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list):
+            argv = cmd
+            kind = argv[0]
+        else:
+            argv = cmd.split()
+            kind = "mpirun" if "mpirun" in cmd or "mpiexec" in cmd else argv[0]
+
+        calls.append({
+            "argv": argv,
+            "kind": kind,
+            "env": kwargs.get("env"),
+            "shell": kwargs.get("shell", False),
+        })
+
+        # Successful mpirun: write the aggregated JSON rank 0 would produce.
+        if kind in ("mpirun", "mpiexec") and write_output:
+            output_path = output_path_getter()
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+            with open(output_path, "w") as f:
+                json.dump(
+                    {
+                        "host-a": {"hostname": "host-a", "total_memory_kb": 1024},
+                        "host-b": {"hostname": "host-b", "total_memory_kb": 2048},
+                    },
+                    f,
+                )
+
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    return fake_run, calls
+
+
+def _collector(tmp_path, hosts, **kwargs):
+    logger = logging.getLogger("test.cluster_collector")
+    logger.setLevel(logging.DEBUG)
+    return cc.MPIClusterCollector(
+        hosts=hosts,
+        mpi_bin=MPIRUN,
+        logger=logger,
+        timeout_seconds=30,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestMPIStaging:
+    """Default path: the collector must SCP the script to remote hosts."""
+
+    def test_stages_script_on_each_remote_host(self, tmp_path, monkeypatch):
+        collector = _collector(tmp_path, hosts=["host-a:1", "host-b:1"])
+
+        # The tempdir is created inside collect() under tempfile.gettempdir().
+        # Redirect it to tmp_path so the test is hermetic.
+        monkeypatch.setattr(cc.tempfile, "gettempdir", lambda: str(tmp_path))
+
+        # Make _is_localhost return True only for 'host-a' so host-b is staged.
+        monkeypatch.setattr(cc, "_is_localhost",
+                            lambda h: h in ("host-a", "localhost", "127.0.0.1"))
+
+        output_holder = {}
+
+        def capture_output_path(collector_self=collector, holder=output_holder):
+            return holder["output_path"]
+
+        fake_run, calls = _make_fake_run(capture_output_path)
+
+        # Wrap subprocess.run so we can snapshot the output path the collector
+        # picks on this invocation (needed by the fake mpirun above).
+        original_makedirs = os.makedirs
+
+        def spy_makedirs(path, *a, **kw):
+            # The first makedirs in collect() is on working_dir.
+            if "output_path" not in output_holder and str(tmp_path) in path:
+                output_holder["output_path"] = os.path.join(
+                    path, "cluster_info.json"
+                )
+            return original_makedirs(path, *a, **kw)
+
+        monkeypatch.setattr(cc.os, "makedirs", spy_makedirs)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+
+        result = collector.collect()
+
+        # mpirun was invoked
+        mpi_calls = [c for c in calls if c["kind"] in ("mpirun", "mpiexec")]
+        assert len(mpi_calls) == 1, f"expected 1 mpirun call, got {calls}"
+
+        # The script was staged to host-b (only remote host) via ssh+scp
+        ssh_calls = [c for c in calls if c["kind"] == "ssh"]
+        scp_calls = [c for c in calls if c["kind"] == "scp"]
+        assert any("host-b" in " ".join(c["argv"]) for c in ssh_calls), \
+            "expected at least one ssh call targeting host-b"
+        assert any("host-b" in " ".join(c["argv"]) for c in scp_calls), \
+            "expected at least one scp call targeting host-b"
+
+        # Cleanup was performed (rm -rf via ssh)
+        rm_calls = [
+            c for c in ssh_calls if any("rm -rf" in a for a in c["argv"])
+        ]
+        assert rm_calls, "expected remote rm -rf cleanup after mpirun"
+
+        # Result shape unchanged from before the fix
+        assert "host-a" in result and "host-b" in result
+
+    def test_single_localhost_skips_staging(self, tmp_path, monkeypatch):
+        """A localhost-only invocation must not SSH anywhere."""
+        collector = _collector(tmp_path, hosts=["127.0.0.1:1"])
+        monkeypatch.setattr(cc.tempfile, "gettempdir", lambda: str(tmp_path))
+
+        output_holder = {}
+        original_makedirs = os.makedirs
+
+        def spy_makedirs(path, *a, **kw):
+            if "output_path" not in output_holder and str(tmp_path) in path:
+                output_holder["output_path"] = os.path.join(
+                    path, "cluster_info.json"
+                )
+            return original_makedirs(path, *a, **kw)
+
+        fake_run, calls = _make_fake_run(
+            lambda: output_holder["output_path"]
+        )
+
+        monkeypatch.setattr(cc.os, "makedirs", spy_makedirs)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+
+        collector.collect()
+
+        assert not any(c["kind"] in ("ssh", "scp") for c in calls), \
+            "localhost-only run must not invoke ssh or scp"
+
+
+class TestSharedTmpDir:
+    """Opt-in fast path: when shared_tmp_dir is set, no SSH staging at all."""
+
+    def test_shared_tmp_dir_skips_staging(self, tmp_path, monkeypatch):
+        shared = tmp_path / "shared_scratch"
+        shared.mkdir()
+
+        collector = _collector(
+            tmp_path,
+            hosts=["host-a:1", "host-b:1"],
+            shared_tmp_dir=str(shared),
+        )
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+
+        output_holder = {}
+        original_makedirs = os.makedirs
+
+        def spy_makedirs(path, *a, **kw):
+            if "output_path" not in output_holder and str(shared) in path:
+                output_holder["output_path"] = os.path.join(
+                    path, "cluster_info.json"
+                )
+            return original_makedirs(path, *a, **kw)
+
+        fake_run, calls = _make_fake_run(
+            lambda: output_holder["output_path"]
+        )
+        monkeypatch.setattr(cc.os, "makedirs", spy_makedirs)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+
+        collector.collect()
+
+        # Zero ssh/scp calls when a shared tmpdir is provided
+        assert not any(c["kind"] in ("ssh", "scp") for c in calls), \
+            f"shared_tmp_dir path must not SSH; got {calls}"
+
+        # The working dir must live under the shared path
+        mpi_call = next(
+            c for c in calls if c["kind"] in ("mpirun", "mpiexec")
+        )
+        joined = " ".join(mpi_call["argv"])
+        assert str(shared) in joined, \
+            f"mpirun command must use shared_tmp_dir path; got: {joined}"
+
+
+class TestStagingFailure:
+    """Staging failure must raise a clear error naming the bad host."""
+
+    def test_stage_failure_raises_with_host_info(self, tmp_path, monkeypatch):
+        collector = _collector(tmp_path, hosts=["host-a:1", "bad-host:1"])
+        monkeypatch.setattr(cc.tempfile, "gettempdir", lambda: str(tmp_path))
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+
+        def fake_run(cmd, *args, **kwargs):
+            # Every ssh/scp to bad-host fails
+            argv = cmd if isinstance(cmd, list) else cmd.split()
+            if argv[0] in ("ssh", "scp") and any(
+                "bad-host" in a for a in argv
+            ):
+                return subprocess.CompletedProcess(
+                    argv, 255, stdout="",
+                    stderr="ssh: connect to host bad-host port 22: "
+                           "Connection refused",
+                )
+            # mpirun should never be reached in this test
+            if argv[0] in ("mpirun", "mpiexec"):
+                pytest.fail(
+                    "mpirun must not run when staging failed on any host"
+                )
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            collector.collect()
+
+        msg = str(excinfo.value)
+        assert "bad-host" in msg, f"error must name the failing host; got: {msg}"
+        assert "stage" in msg.lower() or "staging" in msg.lower() \
+            or "passwordless ssh" in msg.lower(), \
+            f"error must mention staging/SSH; got: {msg}"
+
+
+class TestX11Silence:
+    """The mpirun subprocess must receive an env that disables X11 forwarding."""
+
+    def test_plm_rsh_agent_disables_x11(self, tmp_path, monkeypatch):
+        collector = _collector(tmp_path, hosts=["127.0.0.1:1"])
+        monkeypatch.setattr(cc.tempfile, "gettempdir", lambda: str(tmp_path))
+
+        output_holder = {}
+        original_makedirs = os.makedirs
+
+        def spy_makedirs(path, *a, **kw):
+            if "output_path" not in output_holder and str(tmp_path) in path:
+                output_holder["output_path"] = os.path.join(
+                    path, "cluster_info.json"
+                )
+            return original_makedirs(path, *a, **kw)
+
+        fake_run, calls = _make_fake_run(
+            lambda: output_holder["output_path"]
+        )
+        monkeypatch.setattr(cc.os, "makedirs", spy_makedirs)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+
+        # Ensure the test environment does NOT pre-set PLM_RSH_AGENT, so
+        # we are verifying that the collector itself injects it.
+        monkeypatch.delenv("PLM_RSH_AGENT", raising=False)
+
+        collector.collect()
+
+        mpi_call = next(
+            c for c in calls if c["kind"] in ("mpirun", "mpiexec")
+        )
+        env = mpi_call["env"]
+        assert env is not None, "mpirun must be invoked with a custom env"
+        assert "PLM_RSH_AGENT" in env, \
+            "PLM_RSH_AGENT must be set to silence X11 warnings"
+        assert "ForwardX11=no" in env["PLM_RSH_AGENT"], \
+            f"PLM_RSH_AGENT must disable X11 forwarding; got {env['PLM_RSH_AGENT']!r}"
+
+    def test_existing_plm_rsh_agent_is_preserved(self, tmp_path, monkeypatch):
+        """If the user has their own PLM_RSH_AGENT, don't clobber it."""
+        collector = _collector(tmp_path, hosts=["127.0.0.1:1"])
+        monkeypatch.setattr(cc.tempfile, "gettempdir", lambda: str(tmp_path))
+        monkeypatch.setenv("PLM_RSH_AGENT", "ssh -i /custom/key")
+
+        output_holder = {}
+        original_makedirs = os.makedirs
+
+        def spy_makedirs(path, *a, **kw):
+            if "output_path" not in output_holder and str(tmp_path) in path:
+                output_holder["output_path"] = os.path.join(
+                    path, "cluster_info.json"
+                )
+            return original_makedirs(path, *a, **kw)
+
+        fake_run, calls = _make_fake_run(
+            lambda: output_holder["output_path"]
+        )
+        monkeypatch.setattr(cc.os, "makedirs", spy_makedirs)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+
+        collector.collect()
+
+        mpi_call = next(
+            c for c in calls if c["kind"] in ("mpirun", "mpiexec")
+        )
+        assert mpi_call["env"]["PLM_RSH_AGENT"] == "ssh -i /custom/key", \
+            "user-provided PLM_RSH_AGENT must be preserved"

--- a/mlpstorage_py/tests/test_mpi_cluster_collector_issue_303.py
+++ b/mlpstorage_py/tests/test_mpi_cluster_collector_issue_303.py
@@ -1,57 +1,69 @@
 """Regression tests for issue #303.
-
+ 
 MPIClusterCollector used to write the helper collector script into a
 ``tempfile.TemporaryDirectory()`` on the launch host only, then invoke
 ``mpirun`` with that absolute path. On clusters with node-local ``/tmp``
 the remote ranks could not find the script and ``mpirun`` aborted with
 ``[Errno 2] No such file or directory``.
-
-These tests cover the three code paths introduced by the fix:
-
+ 
+Review-driven redesign (PR #347):
+ 
+* **wolfgang-desalvador**: programmatic ``rm -rf`` over SSH is unacceptable.
+  The collector now stages under ``<results_dir>/collector-staging/`` and
+  never removes anything remotely. The staged script persists as a run
+  artifact for post-mortem.
+* **russfellows**: staging progress emitted at INFO; remaining ``mkdir -p``
+  path is single-quoted; ``num_client_hosts`` re-derive uses ``is None``.
+ 
+These tests cover the resulting code paths:
+ 
 * default "stage-and-run" path — SCPs the script to each remote host
-  before ``mpirun``, and cleans up afterwards;
-* ``shared_tmp_dir`` opt-in — skips all SSH staging;
-* partial staging failure — raises a descriptive error naming the bad host.
-
+  before ``mpirun``; the script persists afterwards (no cleanup);
+* ``shared_staging_dir`` opt-in — skips all SSH staging;
+* partial staging failure — raises a descriptive error naming the bad host;
+* no ``rm``/``rm -rf``/``rmdir``/``rmtree`` is ever invoked over SSH;
+* staged-script path is emitted at INFO for debuggability;
+* ``mkdir -p`` command single-quotes the staging path.
+ 
 Also covers the X11 env injection that silences the
 ``Authorization required, but no authorization protocol specified``
 noise reported in the original issue.
 """
-
+ 
 from __future__ import annotations
-
+ 
 import json
 import logging
 import os
 import subprocess
 from typing import List
 from unittest import mock
-
+ 
 import pytest
-
+ 
 from mlpstorage_py import cluster_collector as cc
 from mlpstorage_py.config import MPIRUN
-
-
+ 
+ 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
+ 
 def _make_fake_run(output_path_getter, write_output: bool = True):
     """Build a fake ``subprocess.run`` that fakes ``mpirun`` by writing the
     expected rank-0 output JSON to disk, and records every call.
-
+ 
     Parameters
     ----------
     output_path_getter: callable returning the expected cluster_info.json path
-        at the time ``mpirun`` is invoked (resolved lazily so the per-run UUID
-        path created inside ``collect()`` is honored).
+        at the time ``mpirun`` is invoked (resolved lazily so the per-run
+        staging path created inside ``collect()`` is honored).
     write_output: when False, ``mpirun`` "succeeds" but produces no output
         file — simulating a cluster where staging succeeded but mpirun itself
         failed to run the script on every rank.
     """
     calls: List[dict] = []
-
+ 
     def fake_run(cmd, *args, **kwargs):
         if isinstance(cmd, list):
             argv = cmd
@@ -59,14 +71,14 @@ def _make_fake_run(output_path_getter, write_output: bool = True):
         else:
             argv = cmd.split()
             kind = "mpirun" if "mpirun" in cmd or "mpiexec" in cmd else argv[0]
-
+ 
         calls.append({
             "argv": argv,
             "kind": kind,
             "env": kwargs.get("env"),
             "shell": kwargs.get("shell", False),
         })
-
+ 
         # Successful mpirun: write the aggregated JSON rank 0 would produce.
         if kind in ("mpirun", "mpiexec") and write_output:
             output_path = output_path_getter()
@@ -79,70 +91,74 @@ def _make_fake_run(output_path_getter, write_output: bool = True):
                     },
                     f,
                 )
-
+ 
         return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
-
+ 
     return fake_run, calls
-
-
-def _collector(tmp_path, hosts, **kwargs):
+ 
+ 
+def _collector(tmp_path, hosts, results_dir=None, **kwargs):
+    """
+    Construct a collector for testing.
+ 
+    ``results_dir`` defaults to ``tmp_path`` so every test gets a hermetic
+    results directory per the new staging design. Callers that want to test
+    a specific results_dir layout (absolute vs relative, shared, etc.) can
+    pass one explicitly.
+    """
     logger = logging.getLogger("test.cluster_collector")
     logger.setLevel(logging.DEBUG)
+    if results_dir is None:
+        results_dir = str(tmp_path)
     return cc.MPIClusterCollector(
         hosts=hosts,
         mpi_bin=MPIRUN,
         logger=logger,
         timeout_seconds=30,
+        results_dir=results_dir,
         **kwargs,
     )
-
-
+ 
+ 
+def _expected_staging_dir(results_dir) -> str:
+    """Canonical staging path per the Option-1 design wolfgang-desalvador asked for."""
+    return os.path.join(os.path.abspath(str(results_dir)), "collector-staging")
+ 
+ 
+def _expected_script_path(results_dir) -> str:
+    return os.path.join(_expected_staging_dir(results_dir), "mlps_collector.py")
+ 
+ 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
-
+ 
 class TestMPIStaging:
-    """Default path: the collector must SCP the script to remote hosts."""
-
+    """Default path: the collector must SCP the script to remote hosts.
+ 
+    Under the new design the staging root is ``<results_dir>/collector-staging/``
+    — not a tempfile.gettempdir() subtree — and nothing is ever removed.
+    """
+ 
     def test_stages_script_on_each_remote_host(self, tmp_path, monkeypatch):
         collector = _collector(tmp_path, hosts=["host-a:1", "host-b:1"])
-
-        # The tempdir is created inside collect() under tempfile.gettempdir().
-        # Redirect it to tmp_path so the test is hermetic.
-        monkeypatch.setattr(cc.tempfile, "gettempdir", lambda: str(tmp_path))
-
+ 
         # Make _is_localhost return True only for 'host-a' so host-b is staged.
         monkeypatch.setattr(cc, "_is_localhost",
                             lambda h: h in ("host-a", "localhost", "127.0.0.1"))
-
-        output_holder = {}
-
-        def capture_output_path(collector_self=collector, holder=output_holder):
-            return holder["output_path"]
-
-        fake_run, calls = _make_fake_run(capture_output_path)
-
-        # Wrap subprocess.run so we can snapshot the output path the collector
-        # picks on this invocation (needed by the fake mpirun above).
-        original_makedirs = os.makedirs
-
-        def spy_makedirs(path, *a, **kw):
-            # The first makedirs in collect() is on working_dir.
-            if "output_path" not in output_holder and str(tmp_path) in path:
-                output_holder["output_path"] = os.path.join(
-                    path, "cluster_info.json"
-                )
-            return original_makedirs(path, *a, **kw)
-
-        monkeypatch.setattr(cc.os, "makedirs", spy_makedirs)
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
+        )
+        fake_run, calls = _make_fake_run(lambda: output_path)
         monkeypatch.setattr(cc.subprocess, "run", fake_run)
-
+ 
         result = collector.collect()
-
+ 
         # mpirun was invoked
         mpi_calls = [c for c in calls if c["kind"] in ("mpirun", "mpiexec")]
         assert len(mpi_calls) == 1, f"expected 1 mpirun call, got {calls}"
-
+ 
         # The script was staged to host-b (only remote host) via ssh+scp
         ssh_calls = [c for c in calls if c["kind"] == "ssh"]
         scp_calls = [c for c in calls if c["kind"] == "scp"]
@@ -150,97 +166,271 @@ class TestMPIStaging:
             "expected at least one ssh call targeting host-b"
         assert any("host-b" in " ".join(c["argv"]) for c in scp_calls), \
             "expected at least one scp call targeting host-b"
-
-        # Cleanup was performed (rm -rf via ssh)
-        rm_calls = [
-            c for c in ssh_calls if any("rm -rf" in a for a in c["argv"])
-        ]
-        assert rm_calls, "expected remote rm -rf cleanup after mpirun"
-
+ 
         # Result shape unchanged from before the fix
         assert "host-a" in result and "host-b" in result
-
+ 
+    def test_staged_script_path_is_under_results_dir(self, tmp_path, monkeypatch):
+        """Staging root lives under results_dir, not under tempfile.gettempdir()."""
+        collector = _collector(tmp_path, hosts=["host-a:1", "host-b:1"])
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
+        )
+        fake_run, calls = _make_fake_run(lambda: output_path)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+ 
+        collector.collect()
+ 
+        # Every ssh and scp call must reference a path rooted under results_dir.
+        expected_root = _expected_staging_dir(tmp_path)
+ 
+        for c in calls:
+            if c["kind"] not in ("ssh", "scp"):
+                continue
+            joined = " ".join(c["argv"])
+            assert expected_root in joined, \
+                f"{c['kind']} call must reference results_dir staging path; " \
+                f"got: {joined}"
+ 
+    def test_staging_path_is_absolute_even_with_relative_results_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """mpirun needs the same absolute path on every node; relative inputs
+        must be resolved at construction time."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "rel-results").mkdir()
+ 
+        collector = _collector(
+            tmp_path,
+            hosts=["host-a:1"],
+            results_dir="rel-results",
+        )
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path / "rel-results"), "cluster_info.json"
+        )
+        fake_run, calls = _make_fake_run(lambda: output_path)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+ 
+        collector.collect()
+ 
+        mpi_call = next(c for c in calls if c["kind"] in ("mpirun", "mpiexec"))
+        joined = " ".join(mpi_call["argv"])
+        # Absolute path to the resolved results_dir must appear in the mpirun argv.
+        assert str((tmp_path / "rel-results").resolve()) in joined, \
+            f"mpirun must use an absolute staging path; got: {joined}"
+ 
     def test_single_localhost_skips_staging(self, tmp_path, monkeypatch):
         """A localhost-only invocation must not SSH anywhere."""
         collector = _collector(tmp_path, hosts=["127.0.0.1:1"])
-        monkeypatch.setattr(cc.tempfile, "gettempdir", lambda: str(tmp_path))
-
-        output_holder = {}
-        original_makedirs = os.makedirs
-
-        def spy_makedirs(path, *a, **kw):
-            if "output_path" not in output_holder and str(tmp_path) in path:
-                output_holder["output_path"] = os.path.join(
-                    path, "cluster_info.json"
-                )
-            return original_makedirs(path, *a, **kw)
-
-        fake_run, calls = _make_fake_run(
-            lambda: output_holder["output_path"]
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
         )
-
-        monkeypatch.setattr(cc.os, "makedirs", spy_makedirs)
+        fake_run, calls = _make_fake_run(lambda: output_path)
         monkeypatch.setattr(cc.subprocess, "run", fake_run)
-
+ 
         collector.collect()
-
+ 
         assert not any(c["kind"] in ("ssh", "scp") for c in calls), \
             "localhost-only run must not invoke ssh or scp"
-
-
-class TestSharedTmpDir:
-    """Opt-in fast path: when shared_tmp_dir is set, no SSH staging at all."""
-
-    def test_shared_tmp_dir_skips_staging(self, tmp_path, monkeypatch):
+ 
+ 
+class TestNoRemoteCleanup:
+    """wolfgang-desalvador: no programmatic destructive command over SSH.
+ 
+    The staged script must persist after the run (on both launch and remote
+    hosts) and no ``rm``/``rm -rf``/``rmdir``/``rmtree`` command may ever be
+    issued to any host — success or failure.
+    """
+ 
+    _FORBIDDEN_TOKENS = ("rm -rf", " rm ", "rmdir", "rmtree")
+ 
+    def _assert_no_destructive_calls(self, calls):
+        for c in calls:
+            joined = " " + " ".join(c["argv"]) + " "
+            for tok in self._FORBIDDEN_TOKENS:
+                assert tok not in joined, (
+                    f"forbidden destructive command {tok.strip()!r} "
+                    f"appeared in {c['kind']} call: {joined!r}"
+                )
+ 
+    def test_no_rm_on_successful_run(self, tmp_path, monkeypatch):
+        collector = _collector(tmp_path, hosts=["host-a:1", "host-b:1"])
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
+        )
+        fake_run, calls = _make_fake_run(lambda: output_path)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+ 
+        collector.collect()
+        self._assert_no_destructive_calls(calls)
+ 
+    def test_no_rm_on_mpi_failure(self, tmp_path, monkeypatch):
+        """Even when mpirun fails, no cleanup rm is emitted."""
+        collector = _collector(tmp_path, hosts=["host-a:1", "host-b:1"])
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+ 
+        recorded: List[dict] = []
+ 
+        def failing_mpirun(cmd, *args, **kwargs):
+            argv = cmd if isinstance(cmd, list) else cmd.split()
+            joined = " ".join(argv)
+            kind = "mpirun" if "mpirun" in joined or "mpiexec" in joined else argv[0]
+            recorded.append({
+                "argv": argv,
+                "kind": kind,
+                "env": kwargs.get("env"),
+                "shell": kwargs.get("shell", False),
+            })
+            if kind in ("mpirun", "mpiexec"):
+                return subprocess.CompletedProcess(
+                    argv, 1, stdout="", stderr="mpirun: simulated failure"
+                )
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+ 
+        monkeypatch.setattr(cc.subprocess, "run", failing_mpirun)
+ 
+        # collect() may raise or return a partial result; either is acceptable
+        # as long as no destructive call leaks out.
+        try:
+            collector.collect()
+        except Exception:
+            pass
+ 
+        self._assert_no_destructive_calls(recorded)
+ 
+    def test_staged_script_persists_after_run(self, tmp_path, monkeypatch):
+        """After a successful collect(), the staged script is still on disk."""
+        collector = _collector(tmp_path, hosts=["host-a:1"])
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
+        )
+        fake_run, _calls = _make_fake_run(lambda: output_path)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+ 
+        collector.collect()
+ 
+        script_path = _expected_script_path(tmp_path)
+        assert os.path.isfile(script_path), (
+            f"staged collector script must persist as a run artifact; "
+            f"expected at {script_path}"
+        )
+ 
+    def test_rerun_is_idempotent(self, tmp_path, monkeypatch):
+        """Two consecutive collects against the same results_dir must not
+        fail on pre-existing staging dir or stale script file."""
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
+        )
+        fake_run, _calls = _make_fake_run(lambda: output_path)
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+ 
+        _collector(tmp_path, hosts=["host-a:1"]).collect()
+        # Second collector reuses the same staging dir; must not raise.
+        _collector(tmp_path, hosts=["host-a:1"]).collect()
+ 
+        assert os.path.isfile(_expected_script_path(tmp_path))
+ 
+ 
+class TestMkdirQuoting:
+    """russfellows: the remaining ``mkdir -p`` path must be single-quoted
+    when it appears inside an ssh shell command string."""
+ 
+    def test_remote_mkdir_path_is_single_quoted(self, tmp_path, monkeypatch):
+        collector = _collector(tmp_path, hosts=["host-a:1", "host-b:1"])
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
+        )
+        fake_run, calls = _make_fake_run(lambda: output_path)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+ 
+        collector.collect()
+ 
+        ssh_mkdir_calls = [
+            c for c in calls
+            if c["kind"] == "ssh"
+            and any("mkdir" in a for a in c["argv"])
+        ]
+        assert ssh_mkdir_calls, \
+            "expected at least one ssh mkdir call for the remote staging dir"
+ 
+        expected = _expected_staging_dir(tmp_path)
+        quoted = f"'{expected}'"
+        assert any(
+            any(quoted in a for a in c["argv"]) for c in ssh_mkdir_calls
+        ), (
+            f"staging path must be single-quoted in ssh mkdir args; "
+            f"expected substring {quoted!r} in one of {ssh_mkdir_calls!r}"
+        )
+ 
+ 
+class TestSharedStagingDir:
+    """Opt-in fast path: when shared_staging_dir is set, no SSH staging at all.
+ 
+    (Formerly ``shared_tmp_dir``; renamed to reflect that staging is no longer
+    a tempdir concept.)
+    """
+ 
+    def test_shared_staging_dir_skips_staging(self, tmp_path, monkeypatch):
         shared = tmp_path / "shared_scratch"
         shared.mkdir()
-
+ 
         collector = _collector(
             tmp_path,
             hosts=["host-a:1", "host-b:1"],
-            shared_tmp_dir=str(shared),
+            shared_staging_dir=str(shared),
         )
         monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
-
+ 
         output_holder = {}
         original_makedirs = os.makedirs
-
+ 
         def spy_makedirs(path, *a, **kw):
             if "output_path" not in output_holder and str(shared) in path:
                 output_holder["output_path"] = os.path.join(
                     path, "cluster_info.json"
                 )
             return original_makedirs(path, *a, **kw)
-
+ 
         fake_run, calls = _make_fake_run(
             lambda: output_holder["output_path"]
         )
         monkeypatch.setattr(cc.os, "makedirs", spy_makedirs)
         monkeypatch.setattr(cc.subprocess, "run", fake_run)
-
+ 
         collector.collect()
-
-        # Zero ssh/scp calls when a shared tmpdir is provided
+ 
+        # Zero ssh/scp calls when a shared staging dir is provided
         assert not any(c["kind"] in ("ssh", "scp") for c in calls), \
-            f"shared_tmp_dir path must not SSH; got {calls}"
-
+            f"shared_staging_dir path must not SSH; got {calls}"
+ 
         # The working dir must live under the shared path
         mpi_call = next(
             c for c in calls if c["kind"] in ("mpirun", "mpiexec")
         )
         joined = " ".join(mpi_call["argv"])
         assert str(shared) in joined, \
-            f"mpirun command must use shared_tmp_dir path; got: {joined}"
-
-
+            f"mpirun command must use shared_staging_dir path; got: {joined}"
+ 
+ 
 class TestStagingFailure:
     """Staging failure must raise a clear error naming the bad host."""
-
+ 
     def test_stage_failure_raises_with_host_info(self, tmp_path, monkeypatch):
         collector = _collector(tmp_path, hosts=["host-a:1", "bad-host:1"])
-        monkeypatch.setattr(cc.tempfile, "gettempdir", lambda: str(tmp_path))
         monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
-
+ 
         def fake_run(cmd, *args, **kwargs):
             # Every ssh/scp to bad-host fails
             argv = cmd if isinstance(cmd, list) else cmd.split()
@@ -258,48 +448,106 @@ class TestStagingFailure:
                     "mpirun must not run when staging failed on any host"
                 )
             return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
-
+ 
         monkeypatch.setattr(cc.subprocess, "run", fake_run)
-
+ 
         with pytest.raises(RuntimeError) as excinfo:
             collector.collect()
-
+ 
         msg = str(excinfo.value)
         assert "bad-host" in msg, f"error must name the failing host; got: {msg}"
         assert "stage" in msg.lower() or "staging" in msg.lower() \
             or "passwordless ssh" in msg.lower(), \
             f"error must mention staging/SSH; got: {msg}"
-
-
+ 
+ 
+class TestLoggingVisibility:
+    """russfellows: staging progress and staged-script path must be visible
+    at the default INFO log level, not DEBUG."""
+ 
+    def test_staging_progress_logged_at_info(self, tmp_path, monkeypatch, caplog):
+        collector = _collector(tmp_path, hosts=["host-a:1", "host-b:1"])
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
+        )
+        fake_run, _calls = _make_fake_run(lambda: output_path)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+ 
+        with caplog.at_level(logging.INFO, logger="test.cluster_collector"):
+            collector.collect()
+ 
+        info_msgs = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.INFO
+        ]
+ 
+        assert any("stag" in m.lower() for m in info_msgs), (
+            f"expected a 'staging' INFO line at default level; got: {info_msgs}"
+        )
+        assert any("mpi" in m.lower() for m in info_msgs), (
+            f"expected an MPI-related INFO line at default level; got: {info_msgs}"
+        )
+ 
+    def test_staged_script_path_logged_at_info(self, tmp_path, monkeypatch, caplog):
+        """Absolute staged-script path must appear in INFO output so users
+        can find it post-run for debugging."""
+        collector = _collector(tmp_path, hosts=["host-a:1"])
+        monkeypatch.setattr(cc, "_is_localhost", lambda h: h == "host-a")
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
+        )
+        fake_run, _calls = _make_fake_run(lambda: output_path)
+        monkeypatch.setattr(cc.subprocess, "run", fake_run)
+ 
+        with caplog.at_level(logging.INFO, logger="test.cluster_collector"):
+            collector.collect()
+ 
+        script_path = _expected_script_path(tmp_path)
+        info_msgs = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.INFO
+        ]
+        assert any(script_path in m for m in info_msgs), (
+            f"expected staged-script absolute path {script_path!r} in INFO "
+            f"logs; got: {info_msgs}"
+        )
+ 
+ 
+class TestConstructionPreconditions:
+    """results_dir is required under the new design; without it there is no
+    defensible staging location (tempdir-based staging is gone)."""
+ 
+    def test_missing_results_dir_raises(self):
+        logger = logging.getLogger("test.cluster_collector")
+        with pytest.raises((ValueError, TypeError)):
+            cc.MPIClusterCollector(
+                hosts=["host-a:1"],
+                mpi_bin=MPIRUN,
+                logger=logger,
+                timeout_seconds=30,
+                results_dir=None,
+            )
+ 
+ 
 class TestX11Silence:
     """The mpirun subprocess must receive an env that disables X11 forwarding."""
-
+ 
     def test_plm_rsh_agent_disables_x11(self, tmp_path, monkeypatch):
         collector = _collector(tmp_path, hosts=["127.0.0.1:1"])
-        monkeypatch.setattr(cc.tempfile, "gettempdir", lambda: str(tmp_path))
-
-        output_holder = {}
-        original_makedirs = os.makedirs
-
-        def spy_makedirs(path, *a, **kw):
-            if "output_path" not in output_holder and str(tmp_path) in path:
-                output_holder["output_path"] = os.path.join(
-                    path, "cluster_info.json"
-                )
-            return original_makedirs(path, *a, **kw)
-
-        fake_run, calls = _make_fake_run(
-            lambda: output_holder["output_path"]
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
         )
-        monkeypatch.setattr(cc.os, "makedirs", spy_makedirs)
+        fake_run, calls = _make_fake_run(lambda: output_path)
         monkeypatch.setattr(cc.subprocess, "run", fake_run)
-
+ 
         # Ensure the test environment does NOT pre-set PLM_RSH_AGENT, so
         # we are verifying that the collector itself injects it.
         monkeypatch.delenv("PLM_RSH_AGENT", raising=False)
-
+ 
         collector.collect()
-
+ 
         mpi_call = next(
             c for c in calls if c["kind"] in ("mpirun", "mpiexec")
         )
@@ -309,31 +557,20 @@ class TestX11Silence:
             "PLM_RSH_AGENT must be set to silence X11 warnings"
         assert "ForwardX11=no" in env["PLM_RSH_AGENT"], \
             f"PLM_RSH_AGENT must disable X11 forwarding; got {env['PLM_RSH_AGENT']!r}"
-
+ 
     def test_existing_plm_rsh_agent_is_preserved(self, tmp_path, monkeypatch):
         """If the user has their own PLM_RSH_AGENT, don't clobber it."""
         collector = _collector(tmp_path, hosts=["127.0.0.1:1"])
-        monkeypatch.setattr(cc.tempfile, "gettempdir", lambda: str(tmp_path))
         monkeypatch.setenv("PLM_RSH_AGENT", "ssh -i /custom/key")
-
-        output_holder = {}
-        original_makedirs = os.makedirs
-
-        def spy_makedirs(path, *a, **kw):
-            if "output_path" not in output_holder and str(tmp_path) in path:
-                output_holder["output_path"] = os.path.join(
-                    path, "cluster_info.json"
-                )
-            return original_makedirs(path, *a, **kw)
-
-        fake_run, calls = _make_fake_run(
-            lambda: output_holder["output_path"]
+ 
+        output_path = os.path.join(
+            _expected_staging_dir(tmp_path), "cluster_info.json"
         )
-        monkeypatch.setattr(cc.os, "makedirs", spy_makedirs)
+        fake_run, calls = _make_fake_run(lambda: output_path)
         monkeypatch.setattr(cc.subprocess, "run", fake_run)
-
+ 
         collector.collect()
-
+ 
         mpi_call = next(
             c for c in calls if c["kind"] in ("mpirun", "mpiexec")
         )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -483,6 +483,116 @@ class TestUpdateArgs:
         update_args(args)
         assert args.hosts == ['host1', 'host2', 'host3']
 
+    # -------------------------------------------------------------------
+    # Regression tests for https://github.com/mlcommons/storage/issues/322
+    #
+    # These exercise every form of `--hosts` the CLI can plausibly receive,
+    # including the forms that used to silently produce a single "host"
+    # containing whitespace and then crash `ssh`.
+    # -------------------------------------------------------------------
+
+    def test_hosts_space_separated_list_unchanged(self):
+        """`--hosts h1 h2 h3` -> argparse nargs='+' gives a clean list; pass through."""
+        args = argparse.Namespace(
+            hosts=['host1', 'host2', 'host3'],
+            params=None,
+            mpi_params=None,
+        )
+        update_args(args)
+        assert args.hosts == ['host1', 'host2', 'host3']
+
+    def test_hosts_single_quoted_space_separated_string(self):
+        """`--hosts 'h1 h2 h3'` -> one token with spaces must be split (issue #322 Sample 3)."""
+        args = argparse.Namespace(
+            hosts=['srt017-e0 srt018-e0'],
+            params=None,
+            mpi_params=None,
+        )
+        update_args(args)
+        assert args.hosts == ['srt017-e0', 'srt018-e0']
+
+    def test_hosts_equals_quoted_space_separated(self):
+        """`--hosts='h1 h2 h3'` -> same single-token-with-spaces case (issue #322 Sample 3)."""
+        args = argparse.Namespace(
+            hosts=['host-a host-b host-c'],
+            params=None,
+            mpi_params=None,
+        )
+        update_args(args)
+        assert args.hosts == ['host-a', 'host-b', 'host-c']
+
+    def test_hosts_mixed_comma_and_space(self):
+        """Accept mixed comma/space separators in a single token."""
+        args = argparse.Namespace(
+            hosts=['host1, host2,host3  host4'],
+            params=None,
+            mpi_params=None,
+        )
+        update_args(args)
+        assert args.hosts == ['host1', 'host2', 'host3', 'host4']
+
+    def test_hosts_mixed_list_and_internal_split(self):
+        """A list where some entries need splitting and others don't."""
+        args = argparse.Namespace(
+            hosts=['h1', 'h2 h3', 'h4,h5'],
+            params=None,
+            mpi_params=None,
+        )
+        update_args(args)
+        assert args.hosts == ['h1', 'h2', 'h3', 'h4', 'h5']
+
+    def test_hosts_preserves_slots_suffix(self):
+        """`host:N` slot notation must survive the split."""
+        args = argparse.Namespace(
+            hosts=['host1:2 host2:4'],
+            params=None,
+            mpi_params=None,
+        )
+        update_args(args)
+        assert args.hosts == ['host1:2', 'host2:4']
+
+    def test_hosts_strips_stray_whitespace_and_empty_tokens(self):
+        """Multiple spaces and leading/trailing whitespace don't produce empty entries."""
+        args = argparse.Namespace(
+            hosts=['   host1   host2 ,,, host3  '],
+            params=None,
+            mpi_params=None,
+        )
+        update_args(args)
+        assert args.hosts == ['host1', 'host2', 'host3']
+
+    def test_hosts_empty_after_parsing_exits(self):
+        """An input that normalizes to zero tokens is a user error; exit cleanly."""
+        args = argparse.Namespace(
+            hosts=['   ,,,  '],
+            params=None,
+            mpi_params=None,
+        )
+        with pytest.raises(SystemExit):
+            update_args(args)
+
+    def test_num_client_hosts_derived_when_none(self):
+        """When argparse leaves num_client_hosts=None (user didn't pass it), derive from hosts."""
+        args = argparse.Namespace(
+            hosts=['h1', 'h2', 'h3'],
+            num_client_hosts=None,
+            params=None,
+            mpi_params=None,
+        )
+        update_args(args)
+        assert args.num_client_hosts == 3
+
+    def test_num_client_hosts_respected_when_set(self):
+        """An explicit --num-client-hosts must not be overwritten."""
+        args = argparse.Namespace(
+            hosts=['h1', 'h2'],
+            num_client_hosts=5,
+            params=None,
+            mpi_params=None,
+        )
+        update_args(args)
+        assert args.num_client_hosts == 5
+
     def test_sets_num_client_hosts_from_hosts(self):
         """Should set num_client_hosts from hosts length."""
         args = argparse.Namespace(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -613,7 +613,12 @@ class TestUpdateArgs:
         )
         update_args(args)
         assert args.runtime is not None
-
+    
+    def test_num_client_hosts_zero_is_preserved(self):
+        """Regression: --num-client-hosts 0 must not be re-derived from len(hosts)."""
+        args = Namespace(hosts=['h1', 'h2', 'h3'], num_client_hosts=0)
+        update_args(args)
+        assert args.num_client_hosts == 0
 
 class TestApplyYamlConfigOverrides:
     """Tests for apply_yaml_config_overrides function."""

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -431,6 +431,31 @@ class TestValidateSshConnectivity:
                 assert 'skipped' in results[0][2].lower()
                 mock_run.assert_not_called()
 
+    def test_rejects_whitespace_token_without_running_ssh(self):
+        """Regression for #322: a host token with whitespace must fail fast, not call ssh."""
+        with patch('shutil.which', return_value='/usr/bin/ssh'):
+            with patch('subprocess.run') as mock_run:
+                results = validate_ssh_connectivity(['srt017-e0 srt018-e0'])
+
+                assert len(results) == 1
+                host, ok, message = results[0]
+                assert host == 'srt017-e0 srt018-e0'
+                assert ok is False
+                # Message should point the user at the argparse pitfall,
+                # not leave them guessing about SSH.
+                assert 'whitespace' in message.lower() or 'invalid host token' in message.lower()
+                mock_run.assert_not_called()
+
+    def test_rejects_empty_token_without_running_ssh(self):
+        """An empty or whitespace-only host token should be rejected, not passed to ssh."""
+        with patch('shutil.which', return_value='/usr/bin/ssh'):
+            with patch('subprocess.run') as mock_run:
+                results = validate_ssh_connectivity(['   '])
+
+                assert len(results) == 1
+                assert results[0][1] is False
+                mock_run.assert_not_called()
+
     def test_parses_host_slots_format(self):
         """Should parse host:slots format correctly."""
         with patch('shutil.which', return_value='/usr/bin/ssh'):


### PR DESCRIPTION
Fixes #322
Fixes #303

## Details

These two bugs are separately reported. The parsing bug (#322) prevents users from getting past argparse with any quoted form of `--hosts`. Once that's fixed, the very next blocker on a real multi-host run is #303 — the MPI cluster collector writes its helper script into a launch-host-only `tempfile.TemporaryDirectory()` and then asks `mpirun` to execute it on every node, which fails with `[Errno 2] No such file or directory` on clusters with node-local `/tmp` (i.e. most of them).

Fixing #322 alone would leave the user staring at cryptic `mpirun` errors and "Authorization required" noise from the collector. Fixing #303 alone is unreachable until the parsing works. Keeping them together lets us to actually complete a multi-host `mlpstorage training datasize` or `datagen` run end-to-end.

Both fixes are separable and could be reverted independently if needed.

## Summary of changes

### Part A — `--hosts` parsing (#322)

The original `update_args` only split on commas, so:

| User input | Before | After |
|---|---|---|
| `--hosts h1 h2 h3` | `['h1', 'h2', 'h3']` ✅ | `['h1', 'h2', 'h3']` ✅ |
| `--hosts h1,h2,h3` | `['h1', 'h2', 'h3']` ✅ | `['h1', 'h2', 'h3']` ✅ |
| `--hosts 'h1 h2 h3'` | `['h1 h2 h3']` ❌ (fails SSH) | `['h1', 'h2', 'h3']` ✅ |
| `--hosts='h1 h2 h3'` | `['h1 h2 h3']` ❌ (fails SSH) | `['h1', 'h2', 'h3']` ✅ |
| `--hosts='h1,h2,h3'` | `['h1', 'h2', 'h3']` ✅ | `['h1', 'h2', 'h3']` ✅ |
| `--hosts=h1 h2 h3` (no quotes) | argparse error | argparse error (unfixable; documented) |

Also fixes a silent latent bug: `num_client_hosts` was never auto-derived from `len(hosts)` because argparse sets the attribute to `None` (not absent), so `hasattr(...)` always returned True. Switched to `getattr(..., None)`.

Also removes two leaked `print(f'Hosts is: {args.hosts}')` debug statements that were appearing in every multi-host run.

**Wrapper hardening:** the `mlpstorage` bash wrapper used unquoted `$*`, which silently (1) re-word-splits any argument containing whitespace and (2) glob-expands patterns in `--params` against `$CWD`. Switched to `"$@"`, added the `--` separator so `uv run` cannot intercept flags meant for mlpstorage, and pinned `--project` to the wrapper's own directory. This closes a previously unreported data-integrity issue where `--params 'dataset.data_folder=/data/*'` would get expanded by the shell before reaching mlpstorage.

**SSH pre-validation:** `validate_ssh_connectivity` now rejects host tokens containing whitespace with a message that points at the argparse pitfall directly, rather than letting users hit a cryptic `ssh: Could not resolve hostname 'h1 h2'`.

### Part B — MPI cluster collector staging (#303)

`MPIClusterCollector` creates its helper script (`mlps_collector.py`) under `tempfile.TemporaryDirectory()` on the launch host only, then invokes `mpirun` with that absolute path. On clusters with node-local `/tmp` (HPC, Kubernetes, bare-metal without a shared scratch FS), the remote ranks cannot find the script and `mpirun` aborts with `[Errno 2] No such file or directory`. The collector's fallback logic treats this as "collection failed" and reports local-only data — so multi-node runs silently characterise one node and claim it represents the whole cluster.

This change:

- Creates a UUID-named working directory whose absolute path is identical on every node.
- By default, SCPs the helper script to each remote host in parallel before running `mpirun`; cleans up via `ssh rm -rf` in a `finally` block.
- Adds an opt-in `shared_tmp_dir` kwarg for clusters that *do* have a shared scratch FS (skips staging entirely).
- Injects `PLM_RSH_AGENT="ssh -o ForwardX11=no -o StrictHostKeyChecking=accept-new"` and strips `DISPLAY` / `XAUTHORITY` from the subprocess env, silencing the misleading `Authorization required, but no authorization protocol specified` stderr noise.
- Improves error messages when staging or `mpirun` fails, naming the specific failing host.
- Plumbs `ssh_username` through to mirror `SSHClusterCollector`.
- Uses `.setdefault("PLM_RSH_AGENT", ...)` rather than overwriting, so users with a custom `PLM_RSH_AGENT` (e.g. a specific SSH key) are respected.

## Files changed

```
mlpstorage                                                 |  14 ++-
mlpstorage_py/cli/common_args.py                           |   8 +-
mlpstorage_py/cli_parser.py                                |  32 ++-
mlpstorage_py/cluster_collector.py                         | 317 ++++++++++---
mlpstorage_py/environment/validators.py                    |  16 +
tests/unit/test_cli.py                                     | 110 +++++
tests/unit/test_environment.py                             |  25 ++
mlpstorage_py/tests/test_cluster_collector.py              |  15 +-
mlpstorage_py/tests/test_mpi_cluster_collector_issue_303.py| 248 +++++++++++
```

## Verification

### Unit tests

**Part A (#322):** 10 new cases in `TestUpdateArgs` exercising every input form from the issue (including the three failing samples), slot preservation (`h1:2 h2:4`), mixed separators, and the empty-after-parse exit path. 2 new cases in `TestValidateSshConnectivity` confirming whitespace tokens are rejected without invoking `ssh`.

**Part B (#303):** 6 new cases in `test_mpi_cluster_collector_issue_303.py`: remote-host staging, localhost-only skipping staging, `shared_tmp_dir` fast path, staging-failure error message, `PLM_RSH_AGENT` injection, preservation of user-provided `PLM_RSH_AGENT`. One existing test updated for the new UUID-named tempdir layout.

Full suite: **68/68 passing locally.**

### Multi-host smoke test (issue reproducer)

On a two-host cluster (`localhost` + `10.10.40.211`), running all four `--hosts` forms from the issue:

```bash
# Form A — canonical (was already working)
mlpstorage training datasize --model unet3d \
    --hosts localhost 10.10.40.211 \
    --client-host-memory-in-gb 247 --max-accelerators 2 \
    --num-client-hosts 2 --accelerator-type a100 --file \
    --results-dir /tmp/smoke-A

# Form B — comma-separated (was already working)
mlpstorage training datasize --model unet3d --hosts localhost,10.10.40.211 ...

# Form C — quoted string (issue #322 Sample 3, PREVIOUSLY FAILED)
mlpstorage training datasize --model unet3d --hosts 'localhost 10.10.40.211' ...

# Form D — equals + quoted (issue #322 Sample 2, PREVIOUSLY FAILED)
mlpstorage training datasize --model unet3d --hosts='localhost 10.10.40.211' ...
```

All four produced identical output:

```
2026-04-22 22:09:39 | INFO: Environment validation passed
2026-04-22 22:09:49 | RESULT: Number of training files: 18090
2026-04-22 22:09:49 | RESULT: Total disk space required for training: 2469.87GiB
2026-04-22 22:09:49 | RESULT: Run the following command to generate data:
  mlpstorage training datagen --hosts=localhost,10.10.40.211 --model=unet3d ...
```

And the `metadata.json` records the final parsed host list from Form C as `["localhost", "10.10.40.211"]` — proving the quoted-string form normalized to two distinct hosts.

### Before / after evidence for #303

**Before** (from the smoke test prior to applying Part B, on the same two hosts):

```
WARNING: MPI collection failed: ... stderr: Authorization required, but no
  authorization protocol specified
python3: can't open file '/tmp/tmpjkay13x0/mlps_collector.py':
  [Errno 2] No such file or directory
mpirun detected that one or more processes exited with non-zero status
INFO: Falling back to local-only collection
```

**After** (with Part B applied, same invocation):

```
INFO: Staging mlps_collector.py to 1 remote host(s)...
INFO: Successfully staged to 10.10.40.211
INFO: Running MPI collection across 2 host(s)
INFO: MPI collection completed successfully (2 hosts reported)
INFO: Cleaning up staged files on remote hosts
```


## Tests

- [x] Tests added for both fixes (18 new cases total)
- [x] Existing tests updated where the UUID tempdir layout required it (1 test)
- [x] Full local suite passes: 68/68
- [x] End-to-end smoke test on two hosts, all four `--hosts` forms produce identical output
- [x] Before/after changes captured for both #322 and #303

