### PR TITLE
Fixes #365 Apply CLI override_parameters into metadata.json parameters

### DIFF
--- a/mlpstorage_py/benchmarks/base.py
+++ b/mlpstorage_py/benchmarks/base.py
@@ -294,6 +294,24 @@ class Benchmark(BenchmarkInterface, abc.ABC):
 
             return stdout, stderr, return_code
 
+    @staticmethod
+    def _apply_dotted_overrides(params, overrides):
+        """Apply override_parameters (dotted keys) into a nested params dict.
+
+        Fixes #365: makes metadata['parameters'] reflect the effective
+        run configuration (YAML defaults + CLI overrides), which is what
+        the submission_checker reads.
+        """
+        import copy
+        out = copy.deepcopy(params)
+        for dotted, value in (overrides or {}).items():
+            parts = dotted.split('.')
+            cur = out
+            for p in parts[:-1]:
+                cur = cur.setdefault(p, {})
+            cur[parts[-1]] = value
+        return out
+
     @property
     def metadata(self) -> Dict[str, Any]:
         """Generate metadata dict capturing the benchmark run configuration.
@@ -322,9 +340,16 @@ class Benchmark(BenchmarkInterface, abc.ABC):
             'result_dir': self.run_result_output,
         }
 
-        # Parameters - prefer combined_params if available (includes YAML + overrides)
+        # Parameters - YAML defaults with CLI overrides applied (fixes #365).
+        # combined_params from process_dlio_params() does not fold CLI
+        # overrides into nested keys (e.g. checkpoint.num_checkpoints_*),
+        # so the submission_checker (which reads from `parameters`)
+        # under-counts two-phase submissions. Apply override_parameters
+        # here so `parameters` reflects the effective run config;
+        # `override_parameters` is still emitted unchanged for audit.
         if hasattr(self, 'combined_params'):
-            metadata['parameters'] = self.combined_params
+            metadata['parameters'] = self._apply_dotted_overrides(
+                self.combined_params, getattr(self, 'params_dict', {}))
         else:
             metadata['parameters'] = {}
 


### PR DESCRIPTION
Fixes #365  (Checkpointing Benchmark: Invalid Submission Due to Incorrect Operation Count)

Two-phase checkpoint runs (separate write-only and read-only mlpstorage invocations) are flagged INVALID because the submission_checker counts each phase as 10W+10R and aggregates to 20W+20R.

 ## Root cause:

```
    mlpstorage_py/benchmarks/dlio.py:339-340
      self.params_dict['checkpoint.num_checkpoints_read']  =
  args.num_checkpoints_read
      self.params_dict['checkpoint.num_checkpoints_write'] =
  args.num_checkpoints_write
      # CLI args correctly captured here

    mlpstorage_py/benchmarks/base.py
      metadata['parameters']          = self.combined_params   # YAML defaults only
      metadata['override_parameters'] = self.params_dict        # CLI args (correct)
      # Two separate fields - parameters does NOT include the CLI overrides

    mlpstorage_py/rules/submission_checkers/checkpointing.py:34-36
      checkpoint_params = run.parameters.get('checkpoint', {})
      num_writes += checkpoint_params.get('num_checkpoints_write', 0)
      # Reads from `parameters` only - sees YAML defaults (10/10) regardless of
      # what the CLI flags actually set
```

  So even though --num-checkpoints-write=10 --num-checkpoints-read=0 drove the actual run correctly, metadata.json's `parameters` block recorded 10/10 and the checker tallied 20W+20R.

  ## Fix
At metadata serialization time, apply override_parameters (dotted keys)  into the nested parameters dict, so `parameters` reflects the effective run configuration. `override_parameters` is still emitted unchanged for audit.

 ## Verification

  Pre-patch on the test script from #365:

    $ mlpstorage checkpointing run ... --num-checkpoints-write=10 --num-checkpoints-read=0
    $ # cache clear between phases
    $ mlpstorage checkpointing run ... --num-checkpoints-write=0 --num-checkpoints-read=10
    $ mlpstorage reports reportgen --results-dir <dir> --file --closed

    INVALID: Expected 10 total read operations, but found 20
    INVALID: Expected 10 total write operations, but found 20

  Post-patch:
```
    Summary: 2 runs analyzed
      CLOSED:  2 runs
      INVALID: 0 runs
    [CLOSED] Submissions (1) - No actionable issues
```