### PR TITLE
Fix #376: argparse conflicting option string: --file

### DIFF
--- a/mlpstorage_py/cli/common_args.py
+++ b/mlpstorage_py/cli/common_args.py
@@ -192,21 +192,12 @@ def add_universal_arguments(parser):
         help="Path to YAML file with argument overrides"
     )
 
-    # Create a mutually exclusive group for file/object options
-    access_proto = standard_args.add_mutually_exclusive_group(required=True)
-    access_proto.add_argument(
-        "--file",
-        action="store_true",
-        help="Use POSIX files as the data access method"
-    )
-    access_proto.add_argument(
-        "--object",
-        nargs="?",
-        type=str,
-        const="s3",
-        choices=["s3"],
-        help="Use the given Object API as the data access method, defaults to S3"
-    )
+    # NOTE: --file / --object are intentionally NOT added here. They are
+    # declared exclusively in ``add_storage_type_arguments`` and attached
+    # only to benchmark subparsers (training, checkpointing, vectordb,
+    # kvcache). Adding them in both places would raise
+    # ``argparse.ArgumentError: argument --file: conflicting option string``
+    # the moment any subparser builder calls both functions — see issue #376.
 
     # Create a mutually exclusive group for closed/open options.
     # Both flags set their own independent boolean so downstream code can

--- a/mlpstorage_py/tests/test_issue_376_file_arg_conflict.py
+++ b/mlpstorage_py/tests/test_issue_376_file_arg_conflict.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Regression tests for issue #376:
+
+    Unexpected error: argument --file: conflicting option string: --file
+
+Root cause: ``add_universal_arguments`` and ``add_storage_type_arguments``
+both declared ``--file`` / ``--object``. Every benchmark subparser
+(training, checkpointing, vectordb, kvcache) calls both, so the duplicate
+declaration crashed argparse at parser-construction time — which fired on
+the very first ``mlpstorage --help`` invocation, before any user args
+were even parsed.
+
+After the fix:
+
+* ``--file`` / ``--object`` are declared **only** in
+  ``add_storage_type_arguments``.
+* All four benchmark subparser builders can be constructed without
+  raising ``argparse.ArgumentError``.
+* Utility subparsers (reportgen, history, lockfile) that only call
+  ``add_universal_arguments`` no longer expose ``--file``/``--object``,
+  which is the intended behavior.
+
+These tests pin those invariants so the regression cannot reappear.
+"""
+
+import argparse
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Direct reproduction of the original failure mode
+# ---------------------------------------------------------------------------
+
+def test_universal_then_storage_type_does_not_conflict():
+    """Calling both adders on one parser must not raise ArgumentError."""
+    from mlpstorage_py.cli.common_args import (
+        add_universal_arguments,
+        add_storage_type_arguments,
+    )
+
+    parser = argparse.ArgumentParser()
+    add_universal_arguments(parser)
+    # Pre-fix this line raised:
+    #   argparse.ArgumentError: argument --file: conflicting option string: --file
+    add_storage_type_arguments(parser)
+
+    ns = parser.parse_args(["--file"])
+    assert ns.file is True
+    assert ns.object is None
+
+
+def test_file_declared_in_exactly_one_adder():
+    """``--file`` must live in add_storage_type_arguments only."""
+    from mlpstorage_py.cli.common_args import (
+        add_universal_arguments,
+        add_storage_type_arguments,
+    )
+
+    universal_parser = argparse.ArgumentParser()
+    add_universal_arguments(universal_parser)
+    universal_opts = {
+        opt for action in universal_parser._actions for opt in action.option_strings
+    }
+    assert "--file" not in universal_opts, (
+        "--file leaked back into add_universal_arguments; this re-introduces "
+        "issue #376 because every benchmark subparser then registers --file twice."
+    )
+    assert "--object" not in universal_opts
+
+    storage_parser = argparse.ArgumentParser()
+    add_storage_type_arguments(storage_parser)
+    storage_opts = {
+        opt for action in storage_parser._actions for opt in action.option_strings
+    }
+    assert "--file" in storage_opts
+    assert "--object" in storage_opts
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: every real benchmark subparser must build cleanly
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "module_path, builder_attr",
+    [
+        ("mlpstorage_py.cli.training_args",      "add_training_arguments"),
+        ("mlpstorage_py.cli.checkpointing_args", "add_checkpointing_arguments"),
+        ("mlpstorage_py.cli.vectordb_args",      "add_vectordb_arguments"),
+        ("mlpstorage_py.cli.kvcache_args",       "add_kvcache_arguments"),
+    ],
+)
+def test_benchmark_subparser_builds_without_argparse_conflict(module_path, builder_attr):
+    """Each benchmark subparser builder must not raise during construction.
+
+    Pre-fix, all four crashed during the builder call because both
+    ``add_universal_arguments`` and ``add_storage_type_arguments`` registered
+    ``--file`` on the same subparser.
+    """
+    import importlib
+    module = importlib.import_module(module_path)
+    builder = getattr(module, builder_attr, None)
+    if builder is None:
+        pytest.skip(f"{module_path} has no builder named {builder_attr}")
+
+    # The real CLI wires these builders by passing a subcommand parser
+    # (the return value of ``sub_programs.add_parser(...)``), not the
+    # ``_SubParsersAction`` itself — mirror that here.
+    root = argparse.ArgumentParser()
+    sub_programs = root.add_subparsers(dest="program")
+    cmd_parser = sub_programs.add_parser(builder_attr.replace("add_", "").replace("_arguments", ""))
+
+    # If this raises argparse.ArgumentError, the regression is back.
+    builder(cmd_parser)
+
+
+# ---------------------------------------------------------------------------
+# --debug must work — it was reported as broken in #376, but only because
+# the argparse crash fired before --debug could be evaluated.
+# ---------------------------------------------------------------------------
+
+def test_debug_flag_parses_after_fix():
+    """``--debug`` is in add_universal_arguments; it must parse normally."""
+    from mlpstorage_py.cli.common_args import (
+        add_universal_arguments,
+        add_storage_type_arguments,
+    )
+
+    parser = argparse.ArgumentParser()
+    add_universal_arguments(parser)
+    add_storage_type_arguments(parser)
+
+    ns = parser.parse_args(["--file", "--debug"])
+    assert ns.debug is True

--- a/mlpstorage_py/tests/test_open_closed_flag_recognition.py
+++ b/mlpstorage_py/tests/test_open_closed_flag_recognition.py
@@ -40,9 +40,16 @@ class TestOpenClosedCLIFlags:
 
     def _build_parser(self):
         import argparse
-        from mlpstorage_py.cli.common_args import add_universal_arguments
+        from mlpstorage_py.cli.common_args import (
+            add_universal_arguments,
+            add_storage_type_arguments,
+        )
         parser = argparse.ArgumentParser()
         add_universal_arguments(parser)
+        # --file/--object now live exclusively in add_storage_type_arguments
+        # (see issue #376). Real benchmark subparsers call both, so the
+        # test mirrors that to keep ``--file`` available in parse_args calls.
+        add_storage_type_arguments(parser)
         return parser
 
     def test_neither_flag_sets_both_false(self):


### PR DESCRIPTION
# Fix #376: argparse "conflicting option string: --file" by removing duplicate declaration

Fixes #376.

## Root cause

`--file` / `--object` are declared in two places in `mlpstorage_py/cli/common_args.py`:

- `add_universal_arguments()` — line ~198
- `add_storage_type_arguments()` — line ~323

Every benchmark subparser builder (`add_training_arguments`, `add_checkpointing_arguments`, `add_vectordb_arguments`, `add_kvcache_arguments`) calls **both** functions on the same parser, so argparse raises

```
argparse.ArgumentError: argument --file: conflicting option string: --file
```

at parser-construction time — which fires on the very first `mlpstorage --help` invocation, before any user arg is parsed. This is also why `--debug` appeared not to work in the report: the parser never finishes being built, so no flag gets evaluated.

## How the regression was introduced

Two commits, in sequence:

1. **PR #359 (`39e657d`, May 8 2026)** — Correctly *extracted* `--file`/`--object` out of `add_universal_arguments` into a new `add_storage_type_arguments()`. After this commit `--file` lived in one place.

2. **PR #352 (`258483b`, May 13 2026)** — Fix for #349 `--open` recognition. The substantive change was rewriting the `--open`/`--closed` mutex group inside `add_universal_arguments`, but the diff *also re-introduced* the `--file`/`--object` mutex block (with `required=True`) — most likely a merge-conflict resolution against a pre-#359 base. From that commit onward, `--file` exists in both functions and every benchmark subparser builder crashes.

Verifiable from `git show 258483b -- mlpstorage_py/cli/common_args.py`: the diff adds back an `access_proto.add_argument("--file", ...)` block that PR #359 had explicitly removed eight days earlier.

## Fix

Remove the duplicate `--file`/`--object` block from `add_universal_arguments`. Replace with a comment that pins the invariant so a future merge can't silently re-introduce it. Restores PR #359's intent: declare those flags once, in `add_storage_type_arguments`, attached only to benchmark subparsers (training, checkpointing, vectordb, kvcache).

Utility subparsers (`reports`, `history`, `lockfile`) that only call `add_universal_arguments` no longer carry `--file`/`--object`, which is the correct behavior — they don't need storage-type selection.

## Tests

**New file:** `mlpstorage_py/tests/test_issue_376_file_arg_conflict.py` — seven cases pinning the invariant:

- Direct reproduction: both adders on one parser no longer raise
- `--file`/`--object` declared in exactly one adder (`add_storage_type_arguments`)
- All four benchmark builders (`add_training_arguments`, `add_checkpointing_arguments`, `add_vectordb_arguments`, `add_kvcache_arguments`) construct cleanly when invoked the same way `cli_parser.py` invokes them
- `--debug` parses correctly post-fix

**Updated:** `mlpstorage_py/tests/test_open_closed_flag_recognition.py` — `_build_parser` now also calls `add_storage_type_arguments`, mirroring how real benchmark subparsers are built, so the open/closed CLI tests keep working.

## Validation

| Check | Pre-fix | Post-fix |
|---|---|---|
| `mlpstorage --help` | `ArgumentError: --file conflict` | clean `SystemExit(0)` |
| `mlpstorage training --help` | crash | clean `SystemExit(0)` |
| `mlpstorage checkpointing --help` | crash | clean `SystemExit(0)` |
| `mlpstorage vectordb --help` | crash | clean `SystemExit(0)` |
| `mlpstorage kvcache --help` | crash | clean `SystemExit(0)` |
| `mlpstorage --debug --help` | crash | clean `SystemExit(0)` |
| `tests/unit/test_cli.py::TestAddUniversalArguments` (8 tests) | **7 failed, 1 passed** | **8 passed** |
| `mlpstorage_py/tests/test_open_closed_flag_recognition.py::TestOpenClosedCLIFlags` (4 tests) | crash | 4 passed |
| `mlpstorage_py/tests/test_issue_376_file_arg_conflict.py` (7 tests, new) | — | 7 passed |

The 7 pre-existing unit-test failures in `TestAddUniversalArguments` were caused by the same regression (the `required=True` re-introduction made every `parse_args` call without `--file` exit with code 2) — they likely went unnoticed because CI wasn't running them on PR #352.

## Diff stats

```
 mlpstorage_py/cli/common_args.py                          | 21 +++++--------------
 mlpstorage_py/tests/test_open_closed_flag_recognition.py  |  9 +++++++-
 mlpstorage_py/tests/test_issue_376_file_arg_conflict.py   | 131 +++++++++++++++ (new)
 3 files changed, 145 insertions(+), 16 deletions(-)
```
