### PR TITLE
Fix #375: chunked vector loading uses globally-unique primary keys

### DIFF
--- a/vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py
+++ b/vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py
@@ -1,0 +1,152 @@
+"""
+Regression tests for issue #375:
+
+    vdb benchmark shows a very low recall@10 because the flat_gt
+    collection size is too small.
+
+Root cause: ``load_vdb.insert_data`` computed primary keys as
+``range(batch_start, batch_end)`` based on the *chunk-local* index,
+so every chunk re-used IDs ``0..chunk_size-1``. With ``num_vectors=1M``
+and ``chunk_size=10k`` the source collection ended up with only 10k
+unique PKs (and 99 duplicates per PK), which in turn made the
+``flat_gt`` collection only 10k rows — about 1% of the source — and
+drove recall@10 down to ~0.009.
+
+The fix adds a ``start_id`` offset to ``insert_data`` and threads a
+running ``global_id_offset`` through the chunked path in ``main``.
+These tests verify the IDs are globally unique across chunks, and that
+the legacy default (``start_id=0``) still works for the single-chunk
+path.
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+# Make the package importable regardless of where pytest is invoked from.
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+# We import the function under test from the real module. We do NOT import
+# the module-level argparse / Milvus connect code — those run only inside
+# ``main()``. The import itself is cheap.
+from vdbbench.load_vdb import insert_data  # noqa: E402
+
+
+def _captured_ids(mock_collection):
+    """Concatenate every IDs list passed to ``collection.insert``."""
+    captured = []
+    for call in mock_collection.insert.call_args_list:
+        # ``insert`` is called as ``collection.insert([ids, batch_vectors])``.
+        args, _kwargs = call
+        payload = args[0]
+        ids = payload[0]
+        captured.extend(list(ids))
+    return captured
+
+
+class TestInsertDataIdOffset:
+    """Verify primary-key uniqueness across chunked inserts."""
+
+    def test_default_start_id_preserves_legacy_behavior(self):
+        """When ``start_id`` is omitted, IDs start at 0 — same as before #375."""
+        collection = MagicMock()
+        vectors = np.zeros((100, 8), dtype=np.float32)
+
+        total, _elapsed = insert_data(collection, vectors, batch_size=25)
+
+        assert total == 100
+        ids = _captured_ids(collection)
+        assert ids == list(range(0, 100))
+
+    def test_start_id_offsets_all_batches(self):
+        """A non-zero ``start_id`` shifts every batch's IDs by that offset."""
+        collection = MagicMock()
+        vectors = np.zeros((50, 4), dtype=np.float32)
+
+        insert_data(collection, vectors, batch_size=10, start_id=1000)
+
+        ids = _captured_ids(collection)
+        assert ids == list(range(1000, 1050))
+
+    def test_three_chunks_produce_globally_unique_ids(self):
+        """
+        Exact reproduction of issue #375: simulate the chunked path in
+        ``main()`` with three chunks. Before the fix, every chunk re-used
+        IDs 0..chunk_size-1 and the union had only ``chunk_size`` unique
+        values; after the fix the union has ``3 * chunk_size`` unique values.
+        """
+        collection = MagicMock()
+        chunk_size = 1000
+        batch_size = 100
+        num_chunks = 3
+
+        global_offset = 0
+        for _ in range(num_chunks):
+            chunk = np.zeros((chunk_size, 4), dtype=np.float32)
+            insert_data(collection, chunk, batch_size=batch_size, start_id=global_offset)
+            global_offset += chunk_size
+
+        ids = _captured_ids(collection)
+        assert len(ids) == num_chunks * chunk_size
+        # The critical assertion the original code would fail:
+        assert len(set(ids)) == num_chunks * chunk_size, (
+            "Duplicate primary keys across chunks — issue #375 regression."
+        )
+        assert min(ids) == 0
+        assert max(ids) == num_chunks * chunk_size - 1
+
+    def test_uneven_final_chunk(self):
+        """The final chunk is usually smaller than ``chunk_size``."""
+        collection = MagicMock()
+        # 2500 vectors total, chunks of 1000 → 1000, 1000, 500
+        chunks = [1000, 1000, 500]
+        global_offset = 0
+        for n in chunks:
+            chunk = np.zeros((n, 4), dtype=np.float32)
+            insert_data(collection, chunk, batch_size=300, start_id=global_offset)
+            global_offset += n
+
+        ids = _captured_ids(collection)
+        assert ids == list(range(0, 2500))
+        assert len(set(ids)) == 2500
+
+    def test_batch_size_larger_than_chunk(self):
+        """``batch_size`` >= len(vectors) should still produce one batch with the offset applied."""
+        collection = MagicMock()
+        vectors = np.zeros((42, 4), dtype=np.float32)
+
+        insert_data(collection, vectors, batch_size=1000, start_id=500)
+
+        assert collection.insert.call_count == 1
+        ids = _captured_ids(collection)
+        assert ids == list(range(500, 542))
+
+
+class TestFlatGtCoverageGuard:
+    """
+    Sanity-check the *intent* of the coverage guard added to
+    ``enhanced_bench.create_flat_collection``: a flat_gt collection
+    that covers far fewer entities than the source should be flagged.
+
+    We assert the threshold here rather than invoking Milvus, so this
+    test runs in CI with no external dependencies.
+    """
+
+    @pytest.mark.parametrize(
+        "flat_count,source_count,should_pass",
+        [
+            (1_000_000, 1_000_000, True),    # exact match
+            (995_000, 1_000_000, True),      # 99.5%, within tolerance
+            (10_000, 1_000_000, False),      # the issue #375 failure mode
+            (100_000, 1_000_000, False),     # only 10%, still wrong
+            (0, 1_000_000, False),           # empty
+        ],
+    )
+    def test_coverage_threshold(self, flat_count, source_count, should_pass):
+        coverage = flat_count / source_count if source_count else 0.0
+        passes = coverage >= 0.99
+        assert passes is should_pass

--- a/vdb_benchmark/vdbbench/enhanced_bench.py
+++ b/vdb_benchmark/vdbbench/enhanced_bench.py
@@ -903,7 +903,13 @@ def create_flat_collection(
                     pct = min(100.0, 100.0 * copied / total_vectors)
                     print(f"  Copied {copied}/{total_vectors} vectors ({pct:.1f}%)")
 
-        print(f"  Copied {copied}/{total_vectors} vectors (100.0%)")
+        # Compute actual completion percentage rather than hardcoding 100%.
+        # When the source collection has duplicate primary keys, the
+        # query_iterator deduplicates and `copied` ends up well below
+        # `total_vectors` — printing "100.0%" here used to hide that
+        # (see issue #375).
+        final_pct = 100.0 * copied / total_vectors if total_vectors else 0.0
+        print(f"  Copied {copied}/{total_vectors} vectors ({final_pct:.1f}%)")
         flat_coll.flush()
 
         # Wait for entity count to stabilize after flush
@@ -928,6 +934,24 @@ def create_flat_collection(
         flat_coll.load()
         print(f"FLAT collection '{flat_collection_name}' ready with "
               f"{flat_coll.num_entities} vectors.")
+
+        # Guard: the ground-truth FLAT collection must cover the source
+        # collection's vectors. If it doesn't, recall@k will be artificially
+        # low because most ANN-returned PKs simply won't exist in the GT
+        # set. This was the failure mode reported in issue #375 (caused by
+        # duplicate PKs in the source). Fail loudly rather than silently
+        # producing meaningless recall numbers.
+        coverage = (flat_coll.num_entities / total_vectors) if total_vectors else 0.0
+        if coverage < 0.99:
+            print(f"ERROR: FLAT ground-truth collection covers only "
+                  f"{flat_coll.num_entities}/{total_vectors} "
+                  f"({coverage * 100:.2f}%) of the source collection. "
+                  f"This will produce artificially low recall@k. "
+                  f"Common cause: duplicate primary keys in the source "
+                  f"collection (see issue #375). "
+                  f"Re-run the load step and verify unique PKs.")
+            return False
+
         return True
 
     except Exception as e:

--- a/vdb_benchmark/vdbbench/load_vdb.py
+++ b/vdb_benchmark/vdbbench/load_vdb.py
@@ -197,8 +197,23 @@ def generate_vectors(num_vectors, dim, distribution='uniform'):
     return vectors
 
 
-def insert_data(collection, vectors, batch_size=10000):
-    """Insert vectors into the collection in batches"""
+def insert_data(collection, vectors, batch_size=10000, start_id=0):
+    """Insert vectors into the collection in batches.
+
+    Args:
+        collection: The Milvus collection to insert into.
+        vectors: A numpy array (or list) of vectors to insert.
+        batch_size: Number of vectors to send per insert() call.
+        start_id: Global ID offset for the primary key. When the caller is
+            generating data in chunks and calling ``insert_data`` once per
+            chunk, ``start_id`` MUST be set to the number of vectors already
+            inserted across previous chunks. Without this offset, every chunk
+            would re-use primary keys 0..len(vectors)-1, producing duplicate
+            PKs (see issue #375).
+
+    Returns:
+        Tuple of (total_inserted, elapsed_seconds).
+    """
     total_vectors = len(vectors)
     num_batches = (total_vectors + batch_size - 1) // batch_size
 
@@ -210,8 +225,9 @@ def insert_data(collection, vectors, batch_size=10000):
         batch_end = min((i + 1) * batch_size, total_vectors)
         batch_size_actual = batch_end - batch_start
 
-        # Prepare batch data
-        ids = list(range(batch_start, batch_end))
+        # Prepare batch data — IDs must be globally unique across chunks,
+        # hence the start_id offset (see docstring + issue #375).
+        ids = list(range(start_id + batch_start, start_id + batch_end))
         batch_vectors = vectors[batch_start:batch_end]
 
         # Insert batch
@@ -225,7 +241,8 @@ def insert_data(collection, vectors, batch_size=10000):
             rate = total_inserted / elapsed if elapsed > 0 else 0
 
             logger.info(f"Inserted batch {i+1}/{num_batches}: {progress:.2f}% complete, "
-                        f"rate: {rate:.2f} vectors/sec")
+                        f"rate: {rate:.2f} vectors/sec, "
+                        f"id_range=[{ids[0]}, {ids[-1]}]")
 
         except Exception as e:
             logger.error(f"Error inserting batch {i+1}: {str(e)}")
@@ -332,7 +349,11 @@ def main():
         vectors = []
         remaining = args.num_vectors
         chunks_processed = 0
-        
+        # Running global offset for primary keys. This is the FIX for
+        # issue #375: without it each chunk re-inserts IDs 0..chunk_size-1,
+        # producing duplicate PKs and a too-small flat_gt collection.
+        global_id_offset = 0
+
         while remaining > 0:
             chunk_size = min(args.chunk_size, remaining)
             logger.info(f"Generating chunk {chunks_processed+1}: {chunk_size:,} vectors")
@@ -344,11 +365,17 @@ def main():
                         f"Progress: {(args.num_vectors - remaining):,}/{args.num_vectors:,} vectors "
                         f"({(args.num_vectors - remaining) / args.num_vectors * 100:.1f}%)")
 
-            # Insert data
-            logger.info(f"Inserting {args.num_vectors} vectors into collection '{args.collection_name}'")
-            total_inserted, insert_time = insert_data(collection, chunk_vectors, args.batch_size)
+            # Insert data — pass the running global_id_offset so PKs are
+            # unique across chunks.
+            logger.info(f"Inserting chunk {chunks_processed+1} ({chunk_size:,} vectors) into "
+                        f"collection '{args.collection_name}' starting at id={global_id_offset}")
+            total_inserted, insert_time = insert_data(
+                collection, chunk_vectors, args.batch_size,
+                start_id=global_id_offset,
+            )
             logger.info(f"Inserted {total_inserted} vectors in {insert_time:.2f} seconds")
 
+            global_id_offset += chunk_size
             remaining -= chunk_size
             chunks_processed += 1
     else:
@@ -356,7 +383,7 @@ def main():
         vectors = generate_vectors(args.num_vectors, args.dimension, args.distribution)
         # Insert data
         logger.info(f"Inserting {args.num_vectors} vectors into collection '{args.collection_name}'")
-        total_inserted, insert_time = insert_data(collection, vectors, args.batch_size)
+        total_inserted, insert_time = insert_data(collection, vectors, args.batch_size, start_id=0)
         logger.info(f"Inserted {total_inserted} vectors in {insert_time:.2f} seconds")
 
     gen_time = time.time() - start_gen_time


### PR DESCRIPTION
# Fix #375: chunked vector loading uses globally-unique primary keys

Closes #375.

## Problem

In a 1M-vector dry-run on a single Gen5 NVMe, `vdb_benchmark` reported **mean recall@10 = 0.0090**. The `mlps_1m_1shards_1536dim_uniform_flat_gt` ground-truth collection held only **10,000** vectors — 1% of the source collection — so almost every PK returned by the ANN search was missing from the GT set, and `set_intersection / k` collapsed.

## Root cause

`load_vdb.insert_data()` built each batch's primary keys as

```python
ids = list(range(batch_start, batch_end))
```

where `batch_start` / `batch_end` were the **chunk-local** indices. When `num_vectors > chunk_size`, the caller in `main()` invokes `insert_data` once per generated chunk and passes only that chunk's vectors. With `chunk_size = 10_000`, every chunk therefore inserted IDs `0..9_999`, i.e. all 100 chunks collided on the same 10 000 primary keys.

* The main collection's `num_entities` still reports 1 000 000 because Milvus counts physical rows, not distinct PKs — masking the bug during loading.
* `enhanced_bench.create_flat_collection()` copies the source via `query_iterator()`, which deduplicates by PK, so the FLAT collection only ever sees the 10 000 unique IDs.
* A second, smaller bug in `enhanced_bench.py` hardcoded the final copy-progress line to `(100.0%)`, hiding the discrepancy in the logs (`Copied 10000/1000000 vectors (100.0%)` in the original report).

## Fix

| File | Change |
|---|---|
| `vdb_benchmark/vdbbench/load_vdb.py` | `insert_data()` takes a new `start_id` (default `0`, preserves legacy single-chunk behavior). IDs are now `range(start_id + batch_start, start_id + batch_end)`. |
| `vdb_benchmark/vdbbench/load_vdb.py` | `main()` threads a running `global_id_offset` through the chunked-generation loop and passes it as `start_id` on every `insert_data` call. The `else` (single-chunk) branch passes `start_id=0` explicitly for clarity. |
| `vdb_benchmark/vdbbench/enhanced_bench.py` | Replace hardcoded `(100.0%)` with the real percentage in `create_flat_collection()`. |
| `vdb_benchmark/vdbbench/enhanced_bench.py` | New coverage guard: if the FLAT collection holds <99% of `source_coll.num_entities`, abort with a clear pointer to issue #375 instead of silently producing meaningless recall numbers. |
| `vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py` | New regression suite (10 tests) covering the `start_id` offset, the three-chunk scenario from the bug report, uneven final chunks, batch sizes larger than the chunk, and the coverage-threshold parametrization. |

## Testing

```
smrc@dskbd029:~/Storage_Repo_Tests/storage_vdb375$ uv sync --extra vectordb --extra test
Resolved 98 packages in 1ms
Checked 98 packages in 1ms
smrc@dskbd029:~/Storage_Repo_Tests/storage_vdb375$ uv run pytest vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py \
              vdb_benchmark/tests/tests/test_load_vdb.py -v
================================================================ test session starts =================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /home/smrc/Storage_Repo_Tests/storage_vdb375/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/smrc/Storage_Repo_Tests/storage_vdb375
configfile: pyproject.toml
plugins: hydra-core-1.3.2, mock-3.15.1, cov-7.1.0
collected 25 items                                                                                                                                   

vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestInsertDataIdOffset::test_default_start_id_preserves_legacy_behavior 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestInsertDataIdOffset::test_default_start_id_preserves_legacy_behavior (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestInsertDataIdOffset::test_start_id_offsets_all_batches 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestInsertDataIdOffset::test_start_id_offsets_all_batches (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestInsertDataIdOffset::test_three_chunks_produce_globally_unique_ids 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestInsertDataIdOffset::test_three_chunks_produce_globally_unique_ids (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestInsertDataIdOffset::test_uneven_final_chunk 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestInsertDataIdOffset::test_uneven_final_chunk (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestInsertDataIdOffset::test_batch_size_larger_than_chunk 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestInsertDataIdOffset::test_batch_size_larger_than_chunk (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestFlatGtCoverageGuard::test_coverage_threshold[1000000-1000000-True] 
        SETUP    F reset_milvus_connections
        SETUP    F flat_count[1000000]
        SETUP    F source_count[1000000]
        SETUP    F should_pass[True]
        vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestFlatGtCoverageGuard::test_coverage_threshold[1000000-1000000-True] (fixtures used: flat_count, reset_milvus_connections, should_pass, source_count)PASSED
        TEARDOWN F should_pass[True]
        TEARDOWN F source_count[1000000]
        TEARDOWN F flat_count[1000000]
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestFlatGtCoverageGuard::test_coverage_threshold[995000-1000000-True] 
        SETUP    F reset_milvus_connections
        SETUP    F flat_count[995000]
        SETUP    F source_count[1000000]
        SETUP    F should_pass[True]
        vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestFlatGtCoverageGuard::test_coverage_threshold[995000-1000000-True] (fixtures used: flat_count, reset_milvus_connections, should_pass, source_count)PASSED
        TEARDOWN F should_pass[True]
        TEARDOWN F source_count[1000000]
        TEARDOWN F flat_count[995000]
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestFlatGtCoverageGuard::test_coverage_threshold[10000-1000000-False] 
        SETUP    F reset_milvus_connections
        SETUP    F flat_count[10000]
        SETUP    F source_count[1000000]
        SETUP    F should_pass[False]
        vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestFlatGtCoverageGuard::test_coverage_threshold[10000-1000000-False] (fixtures used: flat_count, reset_milvus_connections, should_pass, source_count)PASSED
        TEARDOWN F should_pass[False]
        TEARDOWN F source_count[1000000]
        TEARDOWN F flat_count[10000]
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestFlatGtCoverageGuard::test_coverage_threshold[100000-1000000-False] 
        SETUP    F reset_milvus_connections
        SETUP    F flat_count[100000]
        SETUP    F source_count[1000000]
        SETUP    F should_pass[False]
        vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestFlatGtCoverageGuard::test_coverage_threshold[100000-1000000-False] (fixtures used: flat_count, reset_milvus_connections, should_pass, source_count)PASSED
        TEARDOWN F should_pass[False]
        TEARDOWN F source_count[1000000]
        TEARDOWN F flat_count[100000]
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestFlatGtCoverageGuard::test_coverage_threshold[0-1000000-False] 
        SETUP    F reset_milvus_connections
        SETUP    F flat_count[0]
        SETUP    F source_count[1000000]
        SETUP    F should_pass[False]
        vdb_benchmark/tests/tests/test_issue_375_chunked_insert_ids.py::TestFlatGtCoverageGuard::test_coverage_threshold[0-1000000-False] (fixtures used: flat_count, reset_milvus_connections, should_pass, source_count)PASSED
        TEARDOWN F should_pass[False]
        TEARDOWN F source_count[1000000]
        TEARDOWN F flat_count[0]
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_uniform_vector_generation 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_uniform_vector_generation (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_normal_vector_generation 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_normal_vector_generation (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_normalized_vector_generation 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_normalized_vector_generation (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_chunked_vector_generation 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_chunked_vector_generation (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_vector_generation_with_ids 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_vector_generation_with_ids (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_vector_generation_progress_tracking 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorGeneration::test_vector_generation_progress_tracking (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_batch_insertion 
        SETUP    F reset_milvus_connections
        SETUP    F mock_collection
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_batch_insertion (fixtures used: mock_collection, reset_milvus_connections)PASSED
        TEARDOWN F mock_collection
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_insertion_with_error_handling 
        SETUP    F reset_milvus_connections
        SETUP    F mock_collection
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_insertion_with_error_handling (fixtures used: mock_collection, reset_milvus_connections)PASSED
        TEARDOWN F mock_collection
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_parallel_insertion 
        SETUP    F reset_milvus_connections
        SETUP    F mock_collection
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_parallel_insertion (fixtures used: mock_collection, reset_milvus_connections)PASSED
        TEARDOWN F mock_collection
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_insertion_with_metadata 
        SETUP    F reset_milvus_connections
        SETUP    F mock_collection
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_insertion_with_metadata (fixtures used: mock_collection, reset_milvus_connections)PASSED
        TEARDOWN F mock_collection
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_insertion_rate_monitoring 
        SETUP    F reset_milvus_connections
        SETUP    F mock_collection
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_insertion_rate_monitoring (fixtures used: mock_collection, reset_milvus_connections)PASSED
        TEARDOWN F mock_collection
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_load_checkpoint_resume 
SETUP    S test_data_dir
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_load_vdb.py::TestVectorLoading::test_load_checkpoint_resume (fixtures used: reset_milvus_connections, test_data_dir)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestLoadOptimization::test_dynamic_batch_sizing 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_load_vdb.py::TestLoadOptimization::test_dynamic_batch_sizing (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestLoadOptimization::test_memory_aware_loading 
        SETUP    F reset_milvus_connections
        vdb_benchmark/tests/tests/test_load_vdb.py::TestLoadOptimization::test_memory_aware_loading (fixtures used: reset_milvus_connections)PASSED
        TEARDOWN F reset_milvus_connections
vdb_benchmark/tests/tests/test_load_vdb.py::TestLoadOptimization::test_flush_optimization 
        SETUP    F reset_milvus_connections
        SETUP    F mock_collection
        vdb_benchmark/tests/tests/test_load_vdb.py::TestLoadOptimization::test_flush_optimization (fixtures used: mock_collection, reset_milvus_connections)PASSED
        TEARDOWN F mock_collection
        TEARDOWN F reset_milvus_connections
TEARDOWN S test_data_dir

================================================================= 25 passed in 0.13s =================================================================
smrc@dskbd029:~/Storage_Repo_Tests/storage_vdb375$ htop
smrc@dskbd029:~/Storage_Repo_Tests/storage_vdb375$ uv run python vdb_benchmark/vdbbench/load_vdb.py \
    --host 127.0.0.1 --collection test375_smoke \
    --num-vectors 50000 --chunk-size 10000 --dimension 1536 \
    --batch-size 5000 --distribution uniform
2026-05-26 00:56:51,123 - INFO - Connected to Milvus server at 127.0.0.1:19530
2026-05-26 00:56:51,123 - WARNING - FLOAT16 data type not available in this version of pymilvus. Using FLOAT_VECTOR instead.
2026-05-26 00:56:51,142 - INFO - Created collection 'test375_smoke' with 1536 dimensions and 1 shards
2026-05-26 00:56:51,142 - INFO - Creating index with parameters: {'index_type': 'DISKANN', 'metric_type': 'COSINE', 'params': {'MaxDegree': 16, 'SearchListSize': 200}}
2026-05-26 00:56:51,653 - INFO - Index creation command completed in 0.51 seconds
2026-05-26 00:56:51,653 - INFO - Generating 50000 vectors with 1536 dimensions using uniform distribution
2026-05-26 00:56:51,653 - INFO - Large vector count detected. Generating in chunks of 10,000 vectors
2026-05-26 00:56:51,653 - INFO - Generating chunk 1: 10,000 vectors
2026-05-26 00:56:51,877 - INFO - Generated chunk 0 (10,000 vectors) in 0.22 seconds. Progress: 0/50,000 vectors (0.0%)
2026-05-26 00:56:51,877 - INFO - Inserting chunk 1 (10,000 vectors) into collection 'test375_smoke' starting at id=0
2026-05-26 00:56:53,038 - INFO - Inserted batch 1/2: 50.00% complete, rate: 4308.30 vectors/sec, id_range=[0, 4999]
2026-05-26 00:56:54,045 - INFO - Inserted batch 2/2: 100.00% complete, rate: 4614.54 vectors/sec, id_range=[5000, 9999]
2026-05-26 00:56:54,045 - INFO - Inserted 10000 vectors in 2.17 seconds
2026-05-26 00:56:54,045 - INFO - Generating chunk 2: 10,000 vectors
2026-05-26 00:56:54,251 - INFO - Generated chunk 1 (10,000 vectors) in 0.21 seconds. Progress: 10,000/50,000 vectors (20.0%)
2026-05-26 00:56:54,251 - INFO - Inserting chunk 2 (10,000 vectors) into collection 'test375_smoke' starting at id=10000
2026-05-26 00:56:55,305 - INFO - Inserted batch 1/2: 50.00% complete, rate: 4744.59 vectors/sec, id_range=[10000, 14999]
2026-05-26 00:56:56,378 - INFO - Inserted batch 2/2: 100.00% complete, rate: 4702.16 vectors/sec, id_range=[15000, 19999]
2026-05-26 00:56:56,378 - INFO - Inserted 10000 vectors in 2.13 seconds
2026-05-26 00:56:56,378 - INFO - Generating chunk 3: 10,000 vectors
2026-05-26 00:56:56,583 - INFO - Generated chunk 2 (10,000 vectors) in 0.20 seconds. Progress: 20,000/50,000 vectors (40.0%)
2026-05-26 00:56:56,583 - INFO - Inserting chunk 3 (10,000 vectors) into collection 'test375_smoke' starting at id=20000
2026-05-26 00:56:57,526 - INFO - Inserted batch 1/2: 50.00% complete, rate: 5304.51 vectors/sec, id_range=[20000, 24999]
2026-05-26 00:56:58,458 - INFO - Inserted batch 2/2: 100.00% complete, rate: 5334.07 vectors/sec, id_range=[25000, 29999]
2026-05-26 00:56:58,458 - INFO - Inserted 10000 vectors in 1.87 seconds
2026-05-26 00:56:58,458 - INFO - Generating chunk 4: 10,000 vectors
2026-05-26 00:56:58,658 - INFO - Generated chunk 3 (10,000 vectors) in 0.20 seconds. Progress: 30,000/50,000 vectors (60.0%)
2026-05-26 00:56:58,659 - INFO - Inserting chunk 4 (10,000 vectors) into collection 'test375_smoke' starting at id=30000
2026-05-26 00:56:59,579 - INFO - Inserted batch 1/2: 50.00% complete, rate: 5432.54 vectors/sec, id_range=[30000, 34999]
2026-05-26 00:57:00,597 - INFO - Inserted batch 2/2: 100.00% complete, rate: 5159.16 vectors/sec, id_range=[35000, 39999]
2026-05-26 00:57:00,597 - INFO - Inserted 10000 vectors in 1.94 seconds
2026-05-26 00:57:00,597 - INFO - Generating chunk 5: 10,000 vectors
2026-05-26 00:57:00,802 - INFO - Generated chunk 4 (10,000 vectors) in 0.20 seconds. Progress: 40,000/50,000 vectors (80.0%)
2026-05-26 00:57:00,802 - INFO - Inserting chunk 5 (10,000 vectors) into collection 'test375_smoke' starting at id=40000
2026-05-26 00:57:01,893 - INFO - Inserted batch 1/2: 50.00% complete, rate: 4585.04 vectors/sec, id_range=[40000, 44999]
2026-05-26 00:57:02,787 - INFO - Inserted batch 2/2: 100.00% complete, rate: 5036.72 vectors/sec, id_range=[45000, 49999]
2026-05-26 00:57:02,787 - INFO - Inserted 10000 vectors in 1.99 seconds
2026-05-26 00:57:02,787 - INFO - Generated all 50,000 vectors in 11.13 seconds
2026-05-26 00:57:03,311 - INFO - Flush completed in 0.52 seconds
2026-05-26 00:57:03,311 - INFO - Starting to monitor index building progress (checking every 5 seconds)
2026-05-26 00:57:03,314 - INFO - Starting to monitor progress for collection: test375_smoke
2026-05-26 00:57:03,315 - INFO - Initial state: 0 of 50,000 rows indexed
2026-05-26 00:57:03,315 - INFO - Initial pending rows: 50,000
2026-05-26 00:57:08,317 - INFO - Progress: 0.00% complete... (0/50,000 rows) | Pending rows: 50,000
2026-05-26 00:57:13,323 - INFO - Progress: 0.00% complete... (0/50,000 rows) | Pending rows: 50,000
2026-05-26 00:57:18,329 - INFO - Progress: 0.00% complete... (0/50,000 rows) | Pending rows: 50,000
2026-05-26 00:57:23,333 - INFO - No pending rows detected. Assuming indexing phase is complete.
2026-05-26 00:57:23,334 - INFO - No pending rows for 0.0 seconds (waiting for 10 seconds to confirm)
2026-05-26 00:57:28,338 - INFO - No pending rows for 5.0 seconds (waiting for 10 seconds to confirm)
2026-05-26 00:57:33,341 - INFO - No pending rows for 10.0 seconds (waiting for 10 seconds to confirm)
2026-05-26 00:57:33,341 - INFO - No pending rows detected for 0 minutes. Process is considered complete.
2026-05-26 00:57:33,341 - INFO - Process fully complete! Total time: 0:00:30
2026-05-26 00:57:33,341 - INFO - Benchmark completed successfully!
smrc@dskbd029:~/Storage_Repo_Tests/storage_vdb375$ uv run python - <<'PY'
from pymilvus import connections, Collection
connections.connect("default", host="127.0.0.1", port="19530")
c = Collection("test375_smoke"); c.flush(); c.load()

# (a) Total physical rows
print("num_entities:", c.num_entities)            # expect 50000

# (b) PK range is contiguous and reaches the top — the real test.
# Pre-fix this maxed out at chunk_size-1 (9999).
tail = c.query(expr="id >= 49990", output_fields=["id"], limit=20)
ids = sorted(r["id"] for r in tail)
print("max id seen:", max(ids))                   # expect 49999, NOT 9999
print("tail ids:", ids)

# (c) Spot-check no duplicate at a chunk boundary
boundary = c.query(expr="id in [9999, 10000, 19999, 20000]",
                   output_fields=["id"], limit=10)
print("boundary ids found:", sorted(r['id'] for r in boundary))  # expect all four
PY
num_entities: 50000
max id seen: 49999
tail ids: [49990, 49991, 49992, 49993, 49994, 49995, 49996, 49997, 49998, 49999]
boundary ids found: [9999, 10000, 19999, 20000]
smrc@dskbd029:~/Storage_Repo_Tests/storage_vdb375$ uv run python vdb_benchmark/vdbbench/enhanced_bench.py \
    --host 127.0.0.1 --collection test375_smoke \
    --auto-create-flat --runtime 10 --queries 1000 \
    --recall-k 10 --search-limit 10 --batch-size 10 --processes 2

============================================================
ENHANCED VDB BENCH — runtime/query-count mode
============================================================
Results will be saved to: vdbbench_results/20260526_010852

============================================================
Database Verification and Collection Loading
============================================================
Connecting to Milvus server at 127.0.0.1:19530...
Collection test375_smoke already loaded.

Collection: test375_smoke  vectors=50000  dim=1536  index=DISKANN  metric=COSINE
Detected source vector field: 'vector'

============================================================
RECALL SETUP (outside benchmark timing)
============================================================
Ground truth is pre-computed using a FLAT (brute-force) index.
Using metric type: COSINE

Generating 1000 query vectors (dim=1536, seed=42)...
Generated 1000 query vectors.

Setting up FLAT collection: test375_smoke_flat_gt
Creating FLAT collection 'test375_smoke_flat_gt' from source 'test375_smoke'...
Source schema: pk_field='id' (INT64), vec_field='vector', vectors=50000
Copying 50000 vectors to FLAT collection (batch_size=5000)...
  Copied 50000/50000 vectors (100.0%)
Building FLAT index...
FLAT collection 'test375_smoke_flat_gt' ready with 50000 vectors.
Pre-computing ground truth for 1000 queries using FLAT index (top_k=10)...
Ground truth pre-computation complete: 1000 queries in 2.07s
Ground truth ready: 1000 queries pre-computed.

Collecting initial disk statistics...

============================================================
Benchmark Execution
============================================================
Starting benchmark: 2 processes × 500 queries/process
Recall: 1000 pre-generated queries, recall@10
NOTE: batch_end timing is placed BEFORE recall capture — performance unaffected.
NOTE: recall hits written to per-worker recall_hits_p<N>.jsonl files.
Staggering process startup by 0.500s
Starting process 0...
Process 0 initialized
Process 0 - Loading collection
Process 0: Writing results to vdbbench_results/20260526_010852/milvus_benchmark_p0.csv
Process 0: Starting benchmark ...
Process 0: Completed 100 queries in 0.31 seconds.
Starting process 1...
Process 1 initialized
Process 1 - Loading collection
Process 1: Writing results to vdbbench_results/20260526_010852/milvus_benchmark_p1.csv
Process 1: Starting benchmark ...
Process 0: Completed 200 queries in 0.58 seconds.
Process 1: Completed 100 queries in 0.25 seconds.
Process 0: Completed 300 queries in 0.87 seconds.
Process 1: Completed 200 queries in 0.51 seconds.
Process 0: Completed 400 queries in 1.13 seconds.
Process 1: Completed 300 queries in 0.77 seconds.
Process 0: Completed 500 queries in 1.41 seconds.
Process 0: Finished. Executed 500 queries in 1.44 seconds
Process 1: Completed 400 queries in 1.03 seconds.
Process 1: Completed 500 queries in 1.28 seconds.
Process 1: Finished. Executed 500 queries in 1.31 seconds
Reading final disk statistics...

Calculating recall from per-worker JSONL files...
  Loaded ANN hits for 500 unique query indices from 2 worker(s).
Calculating benchmark statistics...

============================================================
BENCHMARK SUMMARY
============================================================
Total Queries: 1000
Total Batches: 100
Total Runtime: 1.83s

QUERY STATISTICS
------------------------------------------------------------
Mean Latency:      2.70 ms
Median Latency:    2.56 ms
P95 Latency:       3.78 ms
P99 Latency:       4.01 ms
P99.9 Latency:     4.15 ms
P99.99 Latency:    4.15 ms
Throughput:        547.92 queries/second

BATCH STATISTICS
------------------------------------------------------------
Mean Batch Time:   26.97 ms
Median Batch Time: 25.62 ms
P95 Batch Time:    37.83 ms
P99 Batch Time:    40.07 ms
P99.9 Batch Time:  41.35 ms
P99.99 Batch Time: 41.48 ms
Max Batch Time:    41.49 ms
Batch Throughput:  37.07 batches/second

RECALL STATISTICS (recall@10)
------------------------------------------------------------
Mean Recall:       0.7292
Median Recall:     0.7000
Min Recall:        0.2000
Max Recall:        1.0000
P95 Recall:        0.9000
P99 Recall:        1.0000
Queries Evaluated: 500

DISK I/O DURING BENCHMARK
------------------------------------------------------------
Total Read:        679.21 MB  (372.15 MB/s,  47601 IOPS)
Total Write:       776.00 KB  (0.42 MB/s,  5 IOPS)

Per-Device Breakdown:
  sda:
    Read:  188.00 KB  (0.10 MB/s, 2 IOPS)
    Write: 252.00 KB  (0.13 MB/s, 0 IOPS)
  sda3:
    Read:  188.00 KB  (0.10 MB/s, 2 IOPS)
    Write: 252.00 KB  (0.13 MB/s, 0 IOPS)
  dm-0:
    Read:  188.00 KB  (0.10 MB/s, 2 IOPS)
    Write: 252.00 KB  (0.13 MB/s, 1 IOPS)
  nvme3n1:
    Read:  678.66 MB  (371.85 MB/s, 47596 IOPS)
    Write: 20.00 KB  (0.01 MB/s, 3 IOPS)

Detailed results: vdbbench_results/20260526_010852
Recall details:   vdbbench_results/20260526_010852/recall_stats.json
============================================================
smrc@dskbd029:~/Storage_Repo_Tests/storage_vdb375$ uv run python vdb_benchmark/vdbbench/list_collections.py --host 127.0.0.1 \
  | grep -i flat_gt        # expect ~50000 entities, not ~10000
2026-05-26 01:11:00,324 - INFO - Connected to Milvus server at 127.0.0.1:19530
2026-05-26 01:11:00,326 - INFO - Found 2 collections
2026-05-26 01:11:00,326 - INFO - Getting information for collection: test375_smoke
2026-05-26 01:11:00,740 - INFO - Getting information for collection: test375_smoke_flat_gt
2026-05-26 01:11:01,166 - INFO - Disconnected from Milvus server
| test375_smoke_flat_gt |          50000 |        1536 | FLAT          | COSINE         |            1 |

```
