### PR TITLE
fix: resolve 11 high/medium severity bugs from broad codebase scan

### DIFF
--- a/mlpstorage_py/benchmarks/base.py
+++ b/mlpstorage_py/benchmarks/base.py
@@ -45,9 +45,8 @@ from typing import Tuple, Dict, Any, List, Optional, Callable, Set, TYPE_CHECKIN
 
 from functools import wraps
 
-from pyarrow.ipc import open_stream
 
-from mlpstorage_py.config import PARAM_VALIDATION, DATETIME_STR, MLPS_DEBUG, EXEC_TYPE
+from mlpstorage_py.config import PARAM_VALIDATION, DATETIME_STR, MLPS_DEBUG, EXEC_TYPE, EXIT_CODE
 from mlpstorage_py.debug import debug_tryer_wrapper
 from mlpstorage_py.interfaces import BenchmarkInterface, BenchmarkConfig, BenchmarkCommand
 from mlpstorage_py.mlps_logging import setup_logging, apply_logging_options
@@ -928,6 +927,7 @@ class Benchmark(BenchmarkInterface, abc.ABC):
             # Note: Stage progress remains visible showing elapsed time
             # during this phase. DLIO output flows through directly.
             start_time = time.time()
+            result = EXIT_CODE.FAILURE
             try:
                 result = self._run()
             finally:

--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -214,7 +214,7 @@ class DLIOBenchmark(Benchmark, abc.ABC):
         )
 
     def process_dlio_params(self, config_file):
-        params_dict = dict() if not self.args.params else {k: v for k, v in (item.split("=") for item in self.args.params)}
+        params_dict = dict() if not self.args.params else {k: v for k, v in (item.split("=", 1) for item in self.args.params)}
         yaml_params = read_config_from_file(os.path.join(self.DLIO_CONFIG_PATH, "workload", config_file))
         combined_params = update_nested_dict(yaml_params, create_nested_dict(params_dict))
 
@@ -239,7 +239,9 @@ class DLIOBenchmark(Benchmark, abc.ABC):
         if hasattr(self.args, "command"):
             output_file_prefix += f"_{self.args.command}"
 
-        self._execute_command(cmd, output_file_prefix=output_file_prefix)
+        _, _, return_code = self._execute_command(cmd, output_file_prefix=output_file_prefix)
+        if return_code != 0:
+            raise RuntimeError(f'DLIO exited with return code {return_code}')
 
     @abc.abstractmethod
     def add_workflow_to_cmd(self, cmd) -> str:
@@ -457,6 +459,7 @@ class CheckpointingBenchmark(DLIOBenchmark):
                 self.logger.error(f'Invalid command: {self.args.command}')
                 return EXIT_CODE.INVALID_ARGUMENTS
         except Exception as e:
+            self.logger.error(f'Checkpointing benchmark failed: {e}')
             return EXIT_CODE.FAILURE
         return EXIT_CODE.SUCCESS
 

--- a/mlpstorage_py/config.py
+++ b/mlpstorage_py/config.py
@@ -147,8 +147,9 @@ class EXIT_CODE(enum.IntEnum):
     CONFIGURATION_ERROR = 5
     FAILURE = 6
     TIMEOUT = 7
-    # Add more as needed
-    
+    INTERRUPTED = 8
+    ERROR = 9
+
     def __str__(self):
         return f"{self.name} ({self.value})"
 class EXEC_TYPE(enum.Enum):

--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -149,7 +149,7 @@ class CheckpointingCheck(BaseCheck):
                     if num_processes != 8:
                         self.log.error(
                             "CLOSED submission with model %s in subset mode requires %d processes, got %d",
-                            model_key,
+                            model_name,
                             8,
                             num_processes
                         )

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -110,9 +110,7 @@ class TrainingCheck(BaseCheck):
                     continue
                 
                 # Calculate min samples from steps per epoch
-                num_steps_per_epoch = max(MIN_STEPS_PER_EPOCH, 
-                                        num_files_train * num_samples_per_file // (batch_size * num_accelerators))
-                min_samples_steps = num_steps_per_epoch * batch_size * num_accelerators
+                min_samples_steps = MIN_STEPS_PER_EPOCH * batch_size * num_accelerators
                 
                 # Calculate min samples from host memory
                 total_host_memory = num_hosts * host_memory_gb
@@ -218,19 +216,23 @@ class TrainingCheck(BaseCheck):
         valid = True
         if self.mode != "training":
             return valid
+        MIN_AU_PERCENTAGE = 90.0
         for summary, metadata, _ in self.submissions_logs.run_files:
             metrics = summary.get("metric", {})
-            au_mean = metrics.get("train_au_mean_percentage", 0)
-            au_expectation = metrics.get("train_au_meet_expectation", "")
-            
-            if au_expectation != "success":
+            au_values = metrics.get("train_au_percentage", [])
+            if not au_values:
+                self.log.error("AU check failed: train_au_percentage missing from summary")
+                valid = False
+                continue
+            au_mean = sum(au_values) / len(au_values)
+            if au_mean < MIN_AU_PERCENTAGE:
                 self.log.error(
-                    "AU check failed: expected 'success', got '%s' (AU: %.2f%%)",
-                    au_expectation,
-                    au_mean
+                    "AU check failed: mean AU %.2f%% is below minimum %.2f%%",
+                    au_mean,
+                    MIN_AU_PERCENTAGE
                 )
                 valid = False
-        
+
         return valid
     
     def single_host_simulated_accelerators(self):

--- a/mlpstorage_py/submission_checker/loader.py
+++ b/mlpstorage_py/submission_checker/loader.py
@@ -117,6 +117,7 @@ class Loader:
                                 for timestamp in list_dir(run_path):
                                     timestamp_path = os.path.join(run_path, timestamp)
                                     summary_path = os.path.join(timestamp_path, "summary.json")
+                                    metadata_path = self.find_metadata_path(timestamp_path)
                                     metadata_file = self.load_single_log(metadata_path, "Metadata")
                                     run_file = self.load_single_log(summary_path, "Summary")
                                     run_files.append((run_file, metadata_file, timestamp))

--- a/mlpstorage_py/submission_checker/parsers/json_parser.py
+++ b/mlpstorage_py/submission_checker/parsers/json_parser.py
@@ -49,7 +49,7 @@ class JSONParser:
         return self.keys
 
     def __contains__(self, key):
-        return key in self.messages
+        return key in self.d
 
     def __repr__(self):
         return f"<SummaryParser path={self.path!r} keys={len(self.keys)}>"


### PR DESCRIPTION
## Summary

This PR fixes 11 bugs identified in a broad static analysis of the codebase. The findings span core framework stability, submission validation correctness, and benchmark execution reliability. Every change is a targeted fix — no refactoring or feature additions.

Issues are grouped by subsystem below. Each entry includes the root cause and what was done to fix it.

---

## Core Framework

### CORE-1 — Ctrl+C raises `AttributeError` instead of exiting cleanly
**File:** `mlpstorage_py/config.py`

`EXIT_CODE.INTERRUPTED` and `EXIT_CODE.ERROR` were referenced in `main.py` but absent from the `EXIT_CODE` enum. Pressing Ctrl+C triggered the SIGINT handler which called `sys.exit(EXIT_CODE.INTERRUPTED)`, raising `AttributeError: INTERRUPTED is not a valid EXIT_CODE` and crashing with a traceback instead of exiting cleanly.

**Fix:** Added `INTERRUPTED = 8` and `ERROR = 9` to the `EXIT_CODE` enum in `config.py`.

---

### CORE-2 — Run entries validated against datagen metadata
**File:** `mlpstorage_py/submission_checker/loader.py`

In the submission loader, `metadata_path` was set inside the outer loop over datagen timestamps and never updated in the inner loop over run timestamps. Every run entry was therefore loaded with the datagen's metadata file. Checks such as `closed_submission_parameters` and `verify_datasize_usage` were reading datagen invocation arguments instead of run invocation arguments, silently corrupting all parameter validation for training runs.

**Fix:** Added `metadata_path = self.find_metadata_path(timestamp_path)` as the first statement inside the inner run-timestamp loop. Cross-phase checks that need datagen params already iterate `self.submissions_logs.datagen_files` explicitly and are unaffected.

---

### CORE-3 — `--params` values containing `=` crash before benchmark starts
**File:** `mlpstorage_py/benchmarks/dlio.py`

`process_dlio_params()` split each `--params` argument on every `=` character with no `maxsplit`. Any param value containing `=` (base64 credentials, S3 endpoint URIs, connection strings) produced more than 2 parts, causing `ValueError: too many values to unpack` before the benchmark started. Object-storage workloads with credential parameters were entirely blocked.

**Fix:** Changed `item.split("=")` to `item.split("=", 1)`.

---

### CORE-4 — `CheckpointingBenchmark._run()` swallows all exceptions silently
**File:** `mlpstorage_py/benchmarks/dlio.py`

The `except Exception as e` block in `CheckpointingBenchmark._run()` discarded the caught exception without logging it, returning `EXIT_CODE.FAILURE` with no diagnostic output. Any failure in `execute_command()` or `datasize()` was invisible to the operator. `TrainingBenchmark._run()` already logged `str(e)` correctly.

**Fix:** Added `self.logger.error(f'Checkpointing benchmark failed: {e}')` before the `return`.

---

### CORE-5 — `UnboundLocalError` replaces original exception from `_run()`
**File:** `mlpstorage_py/benchmarks/base.py`

In `Benchmark.run()`, `result = self._run()` was inside a `try` with a `finally` that performed cleanup. If `_run()` raised an exception, the `finally` block ran correctly but execution then fell through to `return result`. Since `result` was never assigned, Python raised `UnboundLocalError: local variable 'result' referenced before assignment`, replacing the original diagnostic exception with a secondary one and destroying failure information.

**Fix:** Initialized `result = EXIT_CODE.FAILURE` immediately before the `try` block. Also added `EXIT_CODE` to the import from `mlpstorage_py.config` in `base.py`.

---

### CORE-6 — `JSONParser.__contains__` raises `AttributeError` on any `in` test
**File:** `mlpstorage_py/submission_checker/parsers/json_parser.py`

`__contains__` returned `key in self.messages`, but `self.messages` does not exist on `JSONParser` — the parsed JSON dict is stored in `self.d`. Any `key in parser` test raised `AttributeError: 'JSONParser' object has no attribute 'messages'`.

**Fix:** Changed `self.messages` to `self.d`.

---

### CORE-12 — Unused `pyarrow` import makes it a hard dependency of all benchmarks
**File:** `mlpstorage_py/benchmarks/base.py`

`from pyarrow.ipc import open_stream` was present at the top of `base.py` but `open_stream` was never referenced anywhere in the file. Because it was a top-level import, any environment without `pyarrow` installed would fail to import the benchmark base class entirely, breaking all benchmarks with `ImportError`. `pyarrow` is retained in `pyproject.toml` as it is needed by DLIO and parquet handling elsewhere.

**Fix:** Removed the unused import line.

---

### CORE-13 — DLIO exit code discarded; failed runs report `EXIT_CODE.SUCCESS`
**File:** `mlpstorage_py/benchmarks/dlio.py`

`execute_command()` called `self._execute_command(...)` but discarded the `(stdout, stderr, return_code)` return value. If DLIO exited with a non-zero code (OOM, assertion failure, I/O error), `execute_command()` returned silently and `TrainingBenchmark._run()` returned `EXIT_CODE.SUCCESS`. Results validation then proceeded against nonexistent or incomplete output files.

**Fix:** `execute_command()` now unpacks the return value and raises `RuntimeError` if the return code is non-zero. The existing `except Exception` handler in `_run()` (improved by CORE-4) catches and logs this.

---

## Submission Validation

### RULES-1 — 500-steps dataset minimum formula is circular; constraint never fires
**File:** `mlpstorage_py/submission_checker/checks/training_checks.py`

The dataset minimum size check computed:
```python
num_steps_per_epoch = max(MIN_STEPS_PER_EPOCH,
                          num_files_train * num_samples_per_file // (batch_size * num_accelerators))
min_samples_steps = num_steps_per_epoch * batch_size * num_accelerators
```
Because the second argument to `max()` is derived from the actual file count, `num_steps_per_epoch` is always ≥ the actual steps, making `min_samples_steps` always ≥ the actual sample count. The steps constraint could never produce a "too few files" error. The canonical computation in `rules/utils.py` does not have this defect.

**Fix:** Replaced the two-line calculation with the direct formula:
```python
min_samples_steps = MIN_STEPS_PER_EPOCH * batch_size * num_accelerators
```

---

### RULES-3 — `NameError` in subset-mode process count check; check silently passes
**File:** `mlpstorage_py/submission_checker/checks/checkpointing_checks.py`

In the closed-submission process count check, `model_key` was used in the error log inside the `if checkpoint_mode == "subset":` branch, but `model_key` was only assigned inside the `else:` branch (after a regex match on the model name). When a CLOSED subset-mode submission had the wrong process count, the code hit `NameError`, which was silently swallowed, and the check returned as if it passed. The required 8-process count for subset mode was never enforced.

**Fix:** Replaced `model_key` with `model_name` in the subset-mode error log. `model_name` is assigned unconditionally at the top of the loop body and is the correct identifier for the message.

---

### RULES-4 — AU check reads nonexistent DLIO fields; every submission fails spuriously
**File:** `mlpstorage_py/submission_checker/checks/training_checks.py`

The accelerator utilization check read `train_au_mean_percentage` and `train_au_meet_expectation` from the DLIO summary JSON. Neither field exists in actual DLIO output. The real field is `train_au_percentage`, a list of per-epoch AU percentage values. Both `.get()` calls always returned their defaults (0 and `""`), causing `au_expectation != "success"` to always be `True`. Every training submission was flagged as an AU failure regardless of actual utilization, making it impossible to distinguish passing from failing submissions.

**Fix:** Replaced the broken field lookups with logic that reads `train_au_percentage`, computes the mean, and compares it against the 90% minimum threshold specified in the MLPerf Storage rules (Rules.md §3.3.2):
```python
au_values = metrics.get("train_au_percentage", [])
au_mean = sum(au_values) / len(au_values)
if au_mean < 90.0:
    # log and fail
```

---

## Test plan

- [ ] `pytest tests/unit -v` passes with no new failures
- [ ] `pytest tests/integration -v` passes where applicable
- [ ] Ctrl+C during a benchmark run exits cleanly with a non-zero code (not a traceback)
- [ ] A `--params` argument containing `=` in the value (e.g. `key=val=extra`) is parsed correctly
- [ ] A submission with `train_au_percentage` values above 90% passes the AU check; values below 90% fail it
- [ ] A checkpointing run that fails produces a logged error message, not a silent failure