### PR TITLE
fix: HIGH severity measurement and correctness bugs in vector DB benchmark

### DIFF
--- a/vdb_benchmark/tests/tests/test_vdb4_elasticsearch_batch.py
+++ b/vdb_benchmark/tests/tests/test_vdb4_elasticsearch_batch.py
@@ -1,0 +1,65 @@
+"""Regression test for VDB-4: Elasticsearch search() batch path.
+
+Isolated from the other VDB tests so it does not transitively import the
+Milvus backend (pymilvus): only the Elasticsearch backend is needed here.
+
+* len == 1 -> single fast-path self._client.search() call, shape [[...]].
+* len  > 1 -> one self._client.msearch() call, results unpacked from
+             response["responses"] in query order.
+"""
+from __future__ import annotations
+
+from unittest import mock
+
+import numpy as np
+
+from vdbbench.benchmark.backends.elasticsearch.backend import ElasticsearchBackend
+
+
+def _hit(_id):
+    return {"_id": str(_id)}
+
+
+def _make_backend():
+    be = ElasticsearchBackend()
+    be._client = mock.MagicMock()
+    return be
+
+
+def test_vdb4_single_query_uses_search_fastpath():
+    be = _make_backend()
+    be._client.search.return_value = {"hits": {"hits": [_hit(7), _hit(3)]}}
+
+    qv = np.zeros((1, 8), dtype=np.float32)
+    out = be.search(name="idx", query_vectors=qv, top_k=2)
+
+    assert out == [[7, 3]]
+    be._client.search.assert_called_once()
+    be._client.msearch.assert_not_called()
+
+
+def test_vdb4_multi_query_uses_single_msearch_call():
+    be = _make_backend()
+    # Two query vectors -> two response entries, preserving order.
+    be._client.msearch.return_value = {
+        "responses": [
+            {"hits": {"hits": [_hit(1), _hit(2)]}},
+            {"hits": {"hits": [_hit(9)]}},
+        ]
+    }
+
+    qv = np.zeros((2, 8), dtype=np.float32)
+    out = be.search(name="idx", query_vectors=qv, top_k=2)
+
+    assert out == [[1, 2], [9]]
+    # Exactly one HTTP round-trip for the whole batch, not one per vector.
+    be._client.msearch.assert_called_once()
+    be._client.search.assert_not_called()
+
+    # Body is header+body interleaved: 2 vectors -> 4 entries.
+    body = be._client.msearch.call_args.kwargs.get("body")
+    if body is None and be._client.msearch.call_args.args:
+        body = be._client.msearch.call_args.args[0]
+    assert len(body) == 4
+    assert body[0] == {"index": "idx"}
+    assert "knn" in body[1]

--- a/vdb_benchmark/tests/tests/test_vdb_high_fixes.py
+++ b/vdb_benchmark/tests/tests/test_vdb_high_fixes.py
@@ -1,0 +1,162 @@
+"""Regression tests for the HIGH-severity VDB fixes in PR #399.
+
+These tests use in-process fakes only -- no Milvus / Elasticsearch / pgvector
+server is required. They lock in the behavior of three fixes:
+
+* VDB-1 -- batch latency percentiles are no longer fabricated
+          (P50 != P99 when batch wall-times actually vary).
+* VDB-2 -- truth_mode="flat_index" rebuilds ground truth from the live
+          index and never reads the precomputed .npz.
+* VDB-4 -- the Elasticsearch search() len==1 fast path and the len>1
+          _msearch batch path both return correctly-shaped results and
+          issue the expected number of client calls.
+"""
+from __future__ import annotations
+
+import os
+import time
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from vdbbench.benchmark import orchestrator as orch_mod
+from vdbbench.benchmark.orchestrator import BenchmarkConfig, BenchmarkOrchestrator
+from vdbbench.benchmark.search_runner import SearchRunner
+
+
+# ----------------------------------------------------------------------
+# VDB-1: batch latency percentiles must not collapse to a single value
+# ----------------------------------------------------------------------
+class _VariableLatencyBackend:
+    """Fake backend whose search() sleeps a different amount per call.
+
+    SearchRunner times the wall clock around backend.search(), so injecting
+    a controlled per-batch delay lets us assert on the resulting percentile
+    spread without a real vector database.
+    """
+
+    def __init__(self, per_batch_sleep_s, top_k):
+        self._delays = list(per_batch_sleep_s)
+        self._i = 0
+        self._top_k = top_k
+
+    def search(self, name, query_vectors, top_k, search_params=None):
+        delay = self._delays[self._i % len(self._delays)]
+        self._i += 1
+        time.sleep(delay)
+        n = len(query_vectors)
+        # Return arbitrary-but-valid neighbor id lists (recall is not asserted).
+        return [[0] * top_k for _ in range(n)]
+
+
+def test_vdb1_batch_latency_percentiles_not_fabricated():
+    """With varied batch wall-times, P50 and P99 must differ.
+
+    Before the fix, the same elapsed_ms/batch_n value was appended once per
+    query, forcing P50 == P90 == P99. After the fix one entry is recorded
+    per batch, so a genuinely skewed set of batch times produces a genuine
+    spread.
+    """
+    n_queries = 12
+    batch_size = 3  # -> 4 batches per round
+    top_k = 5
+
+    # One slow batch among fast ones => a real tail.
+    delays = [0.002, 0.002, 0.002, 0.040]
+    backend = _VariableLatencyBackend(delays, top_k)
+
+    rng = np.random.default_rng(0)
+    query_vectors = rng.random((n_queries, 8), dtype=np.float32)
+    truth_table = np.zeros((n_queries, top_k), dtype=np.int64)
+
+    runner = SearchRunner(
+        backend=backend,
+        collection_name="unit_test",
+        query_vectors=query_vectors,
+        truth_table=truth_table,
+        search_k=top_k,
+        num_rounds=1,
+        batch_size=batch_size,
+        log_interval=10_000,  # single interval; keep output quiet
+    )
+    result = runner.run()
+
+    # The distribution must not be collapsed.
+    assert result.latency_p99_ms > result.latency_p50_ms, (
+        "P99 should exceed P50 when batch times vary; a collapsed "
+        "distribution is the VDB-1 regression."
+    )
+    # QPS must still reflect actual query count, not batch count.
+    assert result.total_queries == n_queries
+
+
+# ----------------------------------------------------------------------
+# VDB-2: flat_index mode rebuilds truth and skips the .npz load
+# ----------------------------------------------------------------------
+def _write_query_vectors_only(tmp_path, n=4, dim=8):
+    qpath = os.path.join(tmp_path, "query_vectors.npy")
+    np.save(qpath, np.zeros((n, dim), dtype=np.float32))
+    return n
+
+
+def test_vdb2_flat_index_rebuilds_and_skips_npz(tmp_path):
+    """flat_index mode must call build_truth_from_flat and never load .npz.
+
+    The artifacts dir deliberately contains *no* ground_truth.npz. Before the
+    fix the rebuild branch was dead code and the loader would have raised
+    FileNotFoundError (or silently used a stale file if present).
+    """
+    n = _write_query_vectors_only(str(tmp_path))
+
+    cfg = BenchmarkConfig(
+        mode="search",
+        truth_mode="flat_index",
+        artifacts_dir=str(tmp_path),
+        collection_name="bench_vectors",
+        truth_k=3,
+    )
+    backend = mock.MagicMock()
+    orchestrator = BenchmarkOrchestrator(config=cfg, backend=backend)
+
+    fake_truth = np.zeros((n, cfg.truth_k), dtype=np.int64)
+
+    # Patch the symbol as imported into the orchestrator module namespace.
+    with mock.patch.object(
+        orch_mod, "build_truth_from_flat", return_value=fake_truth
+    ) as m_build, mock.patch.object(orch_mod.np, "load", wraps=np.load) as m_load:
+        orchestrator._load_artifacts()
+
+    # Rebuild path was taken exactly once, against the *_flat collection.
+    m_build.assert_called_once()
+    assert m_build.call_args.kwargs["flat_collection_name"] == "bench_vectors_flat"
+
+    # np.load was used for query_vectors.npy but NEVER for a .npz file.
+    loaded_paths = [c.args[0] for c in m_load.call_args_list if c.args]
+    assert any(p.endswith("query_vectors.npy") for p in loaded_paths)
+    assert not any(p.endswith(".npz") for p in loaded_paths), (
+        "flat_index mode must not read the precomputed ground_truth.npz"
+    )
+    assert orchestrator.truth_table is fake_truth
+
+
+def test_vdb2_precomputed_mode_still_loads_npz(tmp_path):
+    """Guard the non-regression: precomputed mode must still read the .npz."""
+    n = _write_query_vectors_only(str(tmp_path))
+    gtpath = os.path.join(str(tmp_path), "ground_truth.npz")
+    truth = np.zeros((n, 3), dtype=np.int64)
+    np.savez(gtpath, truth_table=truth, query_vectors=np.zeros((n, 8), np.float32))
+
+    cfg = BenchmarkConfig(
+        mode="search",
+        truth_mode="precomputed",
+        artifacts_dir=str(tmp_path),
+        collection_name="bench_vectors",
+    )
+    orchestrator = BenchmarkOrchestrator(config=cfg, backend=mock.MagicMock())
+
+    with mock.patch.object(orch_mod, "build_truth_from_flat") as m_build:
+        orchestrator._load_artifacts()
+
+    m_build.assert_not_called()
+    assert orchestrator.truth_table.shape == (n, 3)

--- a/vdb_benchmark/vdbbench/benchmark/backends/elasticsearch/backend.py
+++ b/vdb_benchmark/vdbbench/benchmark/backends/elasticsearch/backend.py
@@ -208,23 +208,35 @@ class ElasticsearchBackend(VectorDBBackend):
         params = search_params or {}
         num_candidates = params.get("num_candidates", 100)
 
-        results: List[List[int]] = []
-        for qvec in query_vectors:
+        if len(query_vectors) == 1:
             resp = self._client.search(
                 index=name,
                 knn={
                     "field": "vector",
-                    "query_vector": qvec.tolist(),
+                    "query_vector": query_vectors[0].tolist(),
                     "k": top_k,
                     "num_candidates": num_candidates,
                 },
                 size=top_k,
                 _source=False,
             )
-            ids = [int(hit["_id"]) for hit in resp["hits"]["hits"]]
-            results.append(ids)
+            return [[int(hit["_id"]) for hit in resp["hits"]["hits"]]]
 
-        return results
+        msearch_body = []
+        for qvec in query_vectors:
+            msearch_body.append({"index": name})
+            msearch_body.append({
+                "knn": {
+                    "field": "vector",
+                    "query_vector": qvec.tolist(),
+                    "k": top_k,
+                    "num_candidates": num_candidates,
+                },
+                "size": top_k,
+                "_source": False,
+            })
+        response = self._client.msearch(body=msearch_body)
+        return [[int(h["_id"]) for h in r["hits"]["hits"]] for r in response["responses"]]
 
     # ------------------------------------------------------------------
     # Status / info

--- a/vdb_benchmark/vdbbench/benchmark/backends/elasticsearch/backend.py
+++ b/vdb_benchmark/vdbbench/benchmark/backends/elasticsearch/backend.py
@@ -205,6 +205,18 @@ class ElasticsearchBackend(VectorDBBackend):
         top_k: int,
         search_params: Optional[Dict[str, Any]] = None,
     ) -> List[List[int]]:
+        """k-NN search over one or more query vectors.
+
+        A single vector uses the regular ``_search`` fast path; multiple
+        vectors are sent as one ``_msearch`` (multi-search) request rather
+        than a serial loop of HTTP round-trips.
+
+        Note (VDB-4): batching here makes per-query HTTP overhead *more
+        comparable* to Milvus's single-RPC batch search, but it does not make
+        cross-backend QPS strictly equivalent -- ``_msearch`` and Milvus's RPC
+        still differ in execution model, so cross-backend QPS should be read as
+        indicative, not as an apples-to-apples measurement.
+        """
         params = search_params or {}
         num_candidates = params.get("num_candidates", 100)
 

--- a/vdb_benchmark/vdbbench/benchmark/backends/milvus/backend.py
+++ b/vdb_benchmark/vdbbench/benchmark/backends/milvus/backend.py
@@ -245,8 +245,11 @@ class MilvusBackend(VectorDBBackend):
         return utility.list_collections()
 
     def get_collection_info(self, name: str) -> Dict[str, Any]:
+        # NOTE (VDB-3): introspection must not mutate storage state. row_count
+        # here reads col.num_entities directly; call flush_collection(name)
+        # explicitly beforehand if you need the count to reflect unflushed
+        # in-memory segments.
         col = self._get_collection(name)
-        col.flush()
 
         # Extract schema fields
         schema = []
@@ -301,8 +304,9 @@ class MilvusBackend(VectorDBBackend):
         logger.info("Dropped index on field '%s' from '%s'", field, name)
 
     def get_collection_stats(self, name: str) -> Dict[str, Any]:
+        # NOTE (VDB-3): monitoring/stats must not mutate storage state. See
+        # flush_collection(name) for intentional pre-benchmark flushing.
         col = self._get_collection(name)
-        col.flush()
         prog = self.get_index_progress(name)
         stats: Dict[str, Any] = {
             "name": name,

--- a/vdb_benchmark/vdbbench/benchmark/backends/milvus/backend.py
+++ b/vdb_benchmark/vdbbench/benchmark/backends/milvus/backend.py
@@ -218,8 +218,11 @@ class MilvusBackend(VectorDBBackend):
     # ------------------------------------------------------------------
     def row_count(self, name: str) -> int:
         col = self._get_collection(name)
-        col.flush()
         return col.num_entities
+
+    def flush_collection(self, name: str) -> None:
+        col = self._get_collection(name)
+        col.flush()
 
     def get_index_progress(self, name: str) -> IndexProgress:
         """Query Milvus ``index_building_progress`` and return a snapshot."""

--- a/vdb_benchmark/vdbbench/benchmark/orchestrator.py
+++ b/vdb_benchmark/vdbbench/benchmark/orchestrator.py
@@ -506,25 +506,20 @@ class BenchmarkOrchestrator:
         qpath = os.path.join(d, "query_vectors.npy")
         gtpath = os.path.join(d, "ground_truth.npz")
 
-        if not os.path.isfile(qpath) or not os.path.isfile(gtpath):
+        if not os.path.isfile(qpath):
             raise FileNotFoundError(
                 f"Expected artifacts not found in '{d}'.  "
-                f"Looking for query_vectors.npy and ground_truth.npz"
+                f"Looking for query_vectors.npy"
+            )
+        if self.cfg.truth_mode != "flat_index" and not os.path.isfile(gtpath):
+            raise FileNotFoundError(
+                f"Expected artifacts not found in '{d}'.  "
+                f"Looking for ground_truth.npz (required when truth_mode != flat_index)"
             )
 
         self.query_vectors = np.load(qpath)
-        gt = np.load(gtpath)
-        self.truth_table = gt["truth_table"]
 
-        logger.info(
-            "Loaded artifacts from '%s': queries=%s, truth=%s",
-            d, self.query_vectors.shape, self.truth_table.shape,
-        )
-
-        # If truth_mode is flat_index and we don't have precomputed truth,
-        # build it on-the-fly
-        if (self.cfg.truth_mode == "flat_index"
-                and self.truth_table is None):
+        if self.cfg.truth_mode == "flat_index":
             flat_name = f"{self.cfg.collection_name}_flat"
             self.truth_table = build_truth_from_flat(
                 backend=self.backend,
@@ -533,6 +528,14 @@ class BenchmarkOrchestrator:
                 truth_k=self.cfg.truth_k,
                 metric_type=self.cfg.metric_type,
             )
+        else:
+            gt = np.load(gtpath)
+            self.truth_table = gt["truth_table"]
+
+        logger.info(
+            "Loaded artifacts from '%s': queries=%s, truth=%s",
+            d, self.query_vectors.shape, self.truth_table.shape,
+        )
 
     # ------------------------------------------------------------------
     # Helpers

--- a/vdb_benchmark/vdbbench/benchmark/search_runner.py
+++ b/vdb_benchmark/vdbbench/benchmark/search_runner.py
@@ -292,15 +292,18 @@ class SearchRunner:
             k, self.batch_size, f"{self.log_interval:,}",
         )
 
-        all_latencies: list[float] = []
+        batch_latencies: list[float] = []
         all_predicted: list[np.ndarray] = []
         all_truth: list[np.ndarray] = []
         intervals: list[IntervalStats] = []
+        total_per_query_ms: float = 0.0
+        total_batches: int = 0
 
         # Latencies for the current logging interval
         interval_latencies: list[float] = []
         interval_predicted: list[np.ndarray] = []
         interval_truth: list[np.ndarray] = []
+        interval_query_count: int = 0
         interval_idx = 0
 
         total_queries = 0
@@ -332,12 +335,13 @@ class SearchRunner:
                 elapsed_ms = (time.perf_counter() - t0) * 1000.0
 
                 batch_n = batch_end - batch_start
-                per_query_ms = elapsed_ms / batch_n
+                mean_per_query_ms = elapsed_ms / batch_n
 
-                # Record per-query latency
-                for _ in range(batch_n):
-                    all_latencies.append(per_query_ms)
-                    interval_latencies.append(per_query_ms)
+                # Record batch latency (one entry per batch, not per query)
+                batch_latencies.append(elapsed_ms)
+                interval_latencies.append(elapsed_ms)
+                total_per_query_ms += mean_per_query_ms
+                total_batches += 1
 
                 predicted_arr = np.array(result_ids, dtype=np.int64)
                 all_predicted.append(predicted_arr)
@@ -346,6 +350,7 @@ class SearchRunner:
                 interval_truth.append(batch_truth)
 
                 total_queries += batch_n
+                interval_query_count += batch_n
 
                 # Check if we should log an interval
                 if total_queries >= (interval_idx + 1) * self.log_interval:
@@ -357,6 +362,7 @@ class SearchRunner:
                         interval_latencies=interval_latencies,
                         interval_predicted=interval_predicted,
                         interval_truth=interval_truth,
+                        interval_query_count=interval_query_count,
                     )
                     intervals.append(stats)
                     self._log_stats(stats)
@@ -365,13 +371,14 @@ class SearchRunner:
                     interval_latencies = []
                     interval_predicted = []
                     interval_truth = []
+                    interval_query_count = 0
                     interval_start = time.time()
                     interval_idx += 1
 
         wall_elapsed = time.time() - wall_start
 
-        # Final stats across all queries
-        lat_arr = np.array(all_latencies)
+        # Final stats across all batches (batch latency percentiles)
+        lat_arr = np.array(batch_latencies)
         pred_all = np.concatenate(all_predicted, axis=0)
         truth_all = np.concatenate(all_truth, axis=0)
         recall = _recall_at_k(pred_all, truth_all, k)
@@ -386,15 +393,15 @@ class SearchRunner:
             latency_p50_ms=float(np.percentile(lat_arr, 50)),
             latency_p90_ms=float(np.percentile(lat_arr, 90)),
             latency_p99_ms=float(np.percentile(lat_arr, 99)),
-            latency_mean_ms=float(np.mean(lat_arr)),
+            latency_mean_ms=total_per_query_ms / total_batches if total_batches > 0 else 0.0,
             intervals=[asdict(s) for s in intervals],
         )
 
         logger.info(
             "Search benchmark complete: %s queries in %.2f s "
-            "(%.1f QPS, recall@%d=%.4f)",
+            "(%.1f QPS, recall@%d=%.4f, batch latency P50=%.2fms P99=%.2fms)",
             f"{total_queries:,}", wall_elapsed, self.result.qps,
-            k, recall,
+            k, recall, self.result.latency_p50_ms, self.result.latency_p99_ms,
         )
         return self.result
 
@@ -422,16 +429,19 @@ class SearchRunner:
         interval_latencies: list[float],
         interval_predicted: list[np.ndarray],
         interval_truth: list[np.ndarray],
+        interval_query_count: int = 0,
     ) -> IntervalStats:
         now = time.time()
         wall_elapsed = now - wall_start
         interval_elapsed = now - interval_start
 
+        # interval_latencies contains one batch latency per batch (not per query)
         lat_arr = np.array(interval_latencies)
         pred = np.concatenate(interval_predicted, axis=0)
         truth = np.concatenate(interval_truth, axis=0)
         recall = _recall_at_k(pred, truth, self.search_k)
-        iq = len(interval_latencies)
+        # Use actual query count for QPS; fall back to batch count if not provided
+        iq = interval_query_count if interval_query_count > 0 else len(interval_latencies)
 
         return IntervalStats(
             interval_index=interval_idx,


### PR DESCRIPTION
## Summary

This PR fixes 4 HIGH severity bugs identified in a broad codebase scan (BROAD_SCAN.md) in the vector database benchmark subsystem. The bugs produce fabricated latency distributions, silently skip correctness checks, perturb storage state during timed runs, and invalidate cross-backend QPS comparisons.

---

## VDB-1 — P50/P90/P99 latency percentiles fabricated when batch_size > 1
**File:** `vdb_benchmark/vdbbench/benchmark/search_runner.py`

Wall-clock time for an entire batch was divided by `batch_n` to produce `per_query_ms`, and that same constant was appended once per query. All queries in a batch received an identical latency value, collapsing the distribution: P50 = P99 = average batch time / batch_size. True tail latency was invisible. The default `search_batch_size` is 1 so this was inactive at defaults, but the `enhanced_bench.py` multi-process path uses batched queries.

**Fix:**
- Renamed `all_latencies` → `batch_latencies`; records one `elapsed_ms` per batch instead of N identical averages.
- P50/P90/P99 are now labelled as batch latency percentiles.
- Mean per-query latency (`elapsed_ms / batch_n`) is tracked as a separate scalar.
- `interval_query_count` tracks actual query count separately so QPS calculations remain correct.

---

## VDB-2 — flat_index ground-truth rebuild path was permanently dead code
**File:** `vdb_benchmark/vdbbench/benchmark/orchestrator.py`

The guard `if self.cfg.truth_mode == "flat_index" and self.truth_table is None:` could never be True: `self.truth_table` was unconditionally assigned from the `.npz` file three lines earlier. The flat_index path — intended to rebuild ground truth live from the actual index state as a correctness check against stale precomputed files — never executed. Users in `flat_index` mode silently received recall computed against potentially stale or incorrect precomputed ground truth.

**Fix:** Restructured to trigger the rebuild unconditionally when `truth_mode == "flat_index"` before any `truth_table` assignment. The `.npz` load is skipped entirely in this mode. The file-existence guard is updated to only require `gtpath` when `truth_mode != "flat_index"`.

---

## VDB-3 — row_count() triggered full Milvus flush on every call
**File:** `vdb_benchmark/vdbbench/benchmark/backends/milvus/backend.py`

`row_count()` called `col.flush()` — a synchronous network + disk operation that seals all in-memory segments and persists them to object storage — on every invocation. `row_count()` is called from monitoring loops and admin introspection paths during benchmarking, so any such call triggered an unintended flush mid-run, perturbing storage state and potentially inflating or deflating subsequent I/O latency measurements.

**Fix:** Removed `col.flush()` from `row_count()`. Added explicit `flush_collection(name)` method for intentional pre-benchmark flushing. Callers that relied on the implicit flush side effect should call `flush_collection()` explicitly before `row_count()`.

---

## VDB-4 — Elasticsearch uses serial HTTP loop; cross-backend QPS comparisons invalid
**File:** `vdb_benchmark/vdbbench/benchmark/backends/elasticsearch/backend.py`

The Elasticsearch `search()` method sent one HTTP request per query vector in a serial `for` loop. Milvus accepts batched queries natively via a single RPC. `SearchRunner` measures wall-clock time for the entire `backend.search()` call and divides by `batch_size` for QPS. For Elasticsearch that wall time included a full HTTP round-trip (DNS + TCP + TLS + server + response) **per query**, making Elasticsearch appear far slower than Milvus for any `batch_size > 1`. Cross-backend QPS comparisons were invalid.

**Fix:** Rewrote `search()` to use the Elasticsearch `_msearch` (multi-search) API when `len(query_vectors) > 1`:
- Single-vector queries use the existing fast path.
- Multi-vector queries build an `_msearch` request body (one header + `knn` body per query vector) and send it in a single HTTP call, unpacking per-query hit lists from `response["responses"]`.

---

## Test plan

- [x] Run existing unit tests: `pytest tests/unit -v`
- [x] Run a batched VDB search (`search_batch_size > 1`) and verify P50 ≠ P99 in latency output (VDB-1)
- [x] Configure `truth_mode = flat_index` and verify ground truth is rebuilt from the live index rather than the precomputed `.npz` (VDB-2)
- [x] Verify `row_count()` calls during a Milvus benchmark run do not trigger unexpected flush operations (VDB-3)
- [x] Run an Elasticsearch search with `batch_size > 1` and verify a single `_msearch` request is issued rather than N serial requests (VDB-4)