### PR TITLE
fix: add EXIT_CODE.INTERRUPTED to resolve AttributeError on SIGTERM (fixes #392, #393)

### DIFF
--- a/mlpstorage_py/config.py
+++ b/mlpstorage_py/config.py
@@ -147,7 +147,7 @@ class EXIT_CODE(enum.IntEnum):
     CONFIGURATION_ERROR = 5
     FAILURE = 6
     TIMEOUT = 7
-    # Add more as needed
+    INTERRUPTED = 8
     
     def __str__(self):
         return f"{self.name} ({self.value})"


### PR DESCRIPTION
## Summary

When `dlio_benchmark` finishes (successfully or with an error), OpenMPI sends
`SIGTERM` to the parent process group as part of its normal cleanup. The
`mlpstorage` signal handler catches this and calls `sys.exit(EXIT_CODE.INTERRUPTED)`.
That call crashed with:

```
AttributeError: type object 'EXIT_CODE' has no attribute 'INTERRUPTED'
```

because the `INTERRUPTED` member was missing from the `EXIT_CODE` enum in
`mlpstorage_py/config.py`. The enum had `SUCCESS` through `TIMEOUT` (0–7) and a
`# Add more as needed` comment where `INTERRUPTED` should have been.

## Root Cause

`main.py` references `EXIT_CODE.INTERRUPTED` in two places (the signal handler at
lines 63 and 319), but the enum value was never defined. Any benchmark invocation
that reaches the MPI cleanup phase triggers the SIGTERM → signal handler →
`AttributeError` crash path, which was misreported as a general failure rather
than a clean interrupted exit.

## Fix

`mlpstorage_py/config.py` — add `INTERRUPTED = 8` to the `EXIT_CODE` enum:

```diff
-    # Add more as needed
+    INTERRUPTED = 8
```

## Issues Fixed

- Fixes #392 — Datagen to S3 via s3dlio reports `AttributeError: EXIT_CODE has no attribute 'INTERRUPTED'`
- Fixes #393 — Datagen to S3 via MinIO/s3torchconnector same crash

## Testing

- 1027 unit tests pass (`uv run python -m pytest tests/unit/ -q`)
- Manually verified: `EXIT_CODE.INTERRUPTED == 8` and `str(EXIT_CODE.INTERRUPTED) == "INTERRUPTED (8)"`

## Files Changed

| File | Change |
|------|--------|
| `mlpstorage_py/config.py` | Added `INTERRUPTED = 8` to `EXIT_CODE` enum |
