### PR TITLE
Fix CLI --version reporting unknown package version

### DIFF
--- a/mlpstorage_py/__init__.py
+++ b/mlpstorage_py/__init__.py
@@ -1,11 +1,46 @@
-from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PkgNF
-try:
-    VERSION = _pkg_version("mlpstorage_py")
-except _PkgNF:
-    VERSION = "unknown"
+from importlib.metadata import PackageNotFoundError as _PkgNF, version as _pkg_version
+from pathlib import Path
+import tomllib
+
+_DIST_NAME = "mlpstorage"
+
+
+def _version_from_pyproject() -> str | None:
+    """Return the project version when running directly from a source checkout."""
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if not pyproject.is_file():
+        return None
+
+    try:
+        with pyproject.open("rb") as f:
+            project = tomllib.load(f).get("project", {})
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    if project.get("name") != _DIST_NAME:
+        return None
+
+    version = project.get("version")
+    return version if isinstance(version, str) else None
+
+
+def _resolve_version() -> str:
+    """Resolve the version from source metadata, installed metadata, or unknown."""
+    source_version = _version_from_pyproject()
+    if source_version:
+        return source_version
+
+    try:
+        return _pkg_version(_DIST_NAME)
+    except _PkgNF:
+        return "unknown"
+
+
+VERSION = _resolve_version()
 __version__ = VERSION
 
 # boto3/botocore are banned — install the blocker immediately so any
 # transitive import attempt is caught regardless of which module triggers it.
 from mlpstorage_py.ban_boto3 import install as _ban_boto3
+
 _ban_boto3()

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+import sys
+import tomllib
+
+import pytest
+
+
+def _pyproject_version() -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    with (repo_root / "pyproject.toml").open("rb") as f:
+        return tomllib.load(f)["project"]["version"]
+
+
+def test_package_version_matches_pyproject():
+    import mlpstorage_py
+
+    expected = _pyproject_version()
+    assert mlpstorage_py.VERSION == expected
+    assert mlpstorage_py.__version__ == expected
+    assert mlpstorage_py.VERSION != "unknown"
+
+
+def test_version_from_pyproject_matches_project_version():
+    import mlpstorage_py
+
+    assert mlpstorage_py._version_from_pyproject() == _pyproject_version()
+
+
+def test_resolve_version_uses_distribution_name_when_pyproject_missing(monkeypatch):
+    import mlpstorage_py
+
+    seen = {}
+
+    def fake_pkg_version(name: str) -> str:
+        seen["name"] = name
+        return "9.8.7"
+
+    monkeypatch.setattr(mlpstorage_py, "_version_from_pyproject", lambda: None)
+    monkeypatch.setattr(mlpstorage_py, "_pkg_version", fake_pkg_version)
+
+    assert mlpstorage_py._resolve_version() == "9.8.7"
+    assert seen["name"] == "mlpstorage"
+
+
+def test_resolve_version_returns_unknown_when_no_metadata(monkeypatch):
+    import mlpstorage_py
+
+    def missing_distribution(name: str) -> str:
+        raise mlpstorage_py._PkgNF(name)
+
+    monkeypatch.setattr(mlpstorage_py, "_version_from_pyproject", lambda: None)
+    monkeypatch.setattr(mlpstorage_py, "_pkg_version", missing_distribution)
+
+    assert mlpstorage_py._resolve_version() == "unknown"
+
+
+def test_cli_version_prints_project_version(monkeypatch, capsys):
+    from mlpstorage_py.cli_parser import parse_arguments
+
+    monkeypatch.setattr(sys, "argv", ["mlpstorage", "--version"])
+
+    with pytest.raises(SystemExit) as exc:
+        parse_arguments()
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out.strip()
+    assert out == f"mlpstorage {_pyproject_version()}"
+    assert "unknown" not in out


### PR DESCRIPTION
Resolve VERSION from the mlpstorage distribution metadata instead of mlpstorage_py, with a pyproject.toml fallback for source-tree execution.

Fixes #407

### Changes
1. Resolve package version metadata using the correct distribution name: mlpstorage.
2. Add a pyproject.toml fallback so version resolution also works when running directly from a source checkout.
3. Keep VERSION and __version__ aligned.
4. Add regression tests for:
  - package version matching pyproject.toml
  - version lookup using the correct distribution name
  - fallback behavior when installed metadata is unavailable
  - CLI --version output

### Testing Output
```
smrc@dskbd029:~/Storage_Repo_Tests/storage_pr407$ uv run pytest tests/unit/test_version.py -q
=============================================================== test session starts ================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/smrc/Storage_Repo_Tests/storage_pr407
configfile: pyproject.toml
plugins: hydra-core-1.3.2, anyio-4.13.0, mock-3.15.1, cov-7.1.0
collected 5 items                                                                                                                                  

tests/unit/test_version.py 
        tests/unit/test_version.py::test_package_version_matches_pyproject.
        tests/unit/test_version.py::test_version_from_pyproject_matches_project_version.
        SETUP    F monkeypatch
        tests/unit/test_version.py::test_resolve_version_uses_distribution_name_when_pyproject_missing (fixtures used: monkeypatch).
        TEARDOWN F monkeypatch
        SETUP    F monkeypatch
        tests/unit/test_version.py::test_resolve_version_returns_unknown_when_no_metadata (fixtures used: monkeypatch).
        TEARDOWN F monkeypatch
        SETUP    F monkeypatch
        SETUP    F capsys
        tests/unit/test_version.py::test_cli_version_prints_project_version (fixtures used: capsys, monkeypatch, request).
        TEARDOWN F capsys
        TEARDOWN F monkeypatch

================================================================ 5 passed in 0.04s =================================================================
smrc@dskbd029:~/Storage_Repo_Tests/storage_pr407$ PYTHONPATH=$PWD uv run python -m mlpstorage_py.main --version
mlpstorage 3.0.3
smrc@dskbd029:~/Storage_Repo_Tests/storage_pr407$ uv run mlpstorage --version
mlpstorage 3.0.3
```