### PR TITLE
YAML Schema - Update power values

### DIFF
--- a/mlpstorage_py/system_description/example_NAS.yaml
+++ b/mlpstorage_py/system_description/example_NAS.yaml
@@ -27,9 +27,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           networking:
@@ -69,9 +67,7 @@ system_under_test:
           power:
              min_psus_active: 1
              psus_configured:
-                 - vendor_name: Sparkle
-                   model_name: S100
-                   power_capacity_watts: 1800
+                 - power_capacity_watts: 1800
                    efficiency: Platinum
                    unit_count: 2
           unit_count: 2
@@ -89,9 +85,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           networking:

--- a/mlpstorage_py/system_description/example_NFS.yaml
+++ b/mlpstorage_py/system_description/example_NFS.yaml
@@ -27,9 +27,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           networking:
@@ -78,9 +76,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           networking:

--- a/mlpstorage_py/system_description/example_PFS.yaml
+++ b/mlpstorage_py/system_description/example_PFS.yaml
@@ -27,9 +27,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           networking:
@@ -64,9 +62,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           networking:
@@ -104,9 +100,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           networking:

--- a/mlpstorage_py/system_description/example_drive.yaml
+++ b/mlpstorage_py/system_description/example_drive.yaml
@@ -27,9 +27,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           operating_system:
@@ -49,9 +47,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           operating_system:

--- a/mlpstorage_py/system_description/example_remote_block.yaml
+++ b/mlpstorage_py/system_description/example_remote_block.yaml
@@ -27,9 +27,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           networking:
@@ -76,9 +74,7 @@ system_under_test:
              power:
                 min_psus_active: 1
                 psus_configured:
-                    - vendor_name: Sparkle
-                      model_name: S100
-                      power_capacity_watts: 1800
+                    - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
           networking:

--- a/mlpstorage_py/system_description/schema.yaml
+++ b/mlpstorage_py/system_description/schema.yaml
@@ -138,8 +138,6 @@ power_device:
 #
 power_supply:
     unit_count:                 int( min=1 )        # Number of power supplies that look like this
-    vendor_name:                str( min=1 )        # The name of the vendor who supplies this power supply
-    model_name:                 str( min=1 )        # The vendor's model name for this power supply
-    power_capacity_watts:       int( min=1 )        # The total output capacity of the power supply
+    power_capacity_watts:       int( min=1 )        # The nameplate (regulatory rated) input power of the power supply
     efficiency:                 enum( 'Gold', 'Platinum', 'Titanium', 'Ruby' )
 


### PR DESCRIPTION
As mentioned in #404, this updates the validation schema to drop power supply make and model, and clarifies that we are collecting nameplate (input) power rather than output power.