### PR TITLE
feat: better mid-tree help — hint at -h/--help_all and print SYNOPSIS on -h

### DIFF
--- a/mlpstorage_py/cli/help_formatter.py
+++ b/mlpstorage_py/cli/help_formatter.py
@@ -524,6 +524,12 @@ VERSION
   Resolution order: importlib.metadata("mlpstorage") → pyproject.toml → "unknown"
 """
 
+# Extract the SYNOPSIS block from HELP_ALL_TEXT so it can be printed
+# standalone when the user passes -h at a mid-tree position.
+_syn_start = HELP_ALL_TEXT.index('\nSYNOPSIS\n') + 1
+_syn_end = HELP_ALL_TEXT.index('\nmlpstorage\n│', _syn_start)
+SYNOPSIS_TEXT = HELP_ALL_TEXT[_syn_start:_syn_end].rstrip()
+
 # ---------------------------------------------------------------------------
 # get_context_help_tokens
 #

--- a/mlpstorage_py/cli/help_formatter.py
+++ b/mlpstorage_py/cli/help_formatter.py
@@ -12,11 +12,13 @@ Exports:
 # Section headers between blocks are included as plain text (no markdown).
 # ---------------------------------------------------------------------------
 
-HELP_ALL_TEXT = """\
+_HEADER_TEXT = """\
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  MLPSTORAGE — COMPLETE COMMAND REFERENCE
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+"""
 
+SYNOPSIS_TEXT = """\
 SYNOPSIS
   mlpstorage <closed|open|whatif> <benchmark> <model|algorithm> <command> <file|object> [OPTIONS]
   mlpstorage (reports|history|lockfile|version) [subcommand] [OPTIONS]
@@ -24,8 +26,9 @@ SYNOPSIS
   <closed|open|whatif>  — required first positional for benchmark commands
   <model|algorithm>     — required second positional (see per-benchmark choices below)
   <file|object>         — required storage selector for commands that touch storage
-                          (absent on datasize; absent on all kvcache commands)
+                          (absent on datasize; absent on all kvcache commands)"""
 
+_TREE_AND_BODY_TEXT = """\
 mlpstorage
 │
 ├── closed ──────────────────────────────────────────────────────
@@ -524,11 +527,9 @@ VERSION
   Resolution order: importlib.metadata("mlpstorage") → pyproject.toml → "unknown"
 """
 
-# Extract the SYNOPSIS block from HELP_ALL_TEXT so it can be printed
-# standalone when the user passes -h at a mid-tree position.
-_syn_start = HELP_ALL_TEXT.index('\nSYNOPSIS\n') + 1
-_syn_end = HELP_ALL_TEXT.index('\nmlpstorage\n│', _syn_start)
-SYNOPSIS_TEXT = HELP_ALL_TEXT[_syn_start:_syn_end].rstrip()
+# HELP_ALL_TEXT is composed from three pieces so that SYNOPSIS_TEXT can be
+# printed standalone (mid-tree -h) without parsing the combined string.
+HELP_ALL_TEXT = _HEADER_TEXT + "\n" + SYNOPSIS_TEXT + "\n\n" + _TREE_AND_BODY_TEXT
 
 # ---------------------------------------------------------------------------
 # get_context_help_tokens

--- a/mlpstorage_py/cli_parser.py
+++ b/mlpstorage_py/cli_parser.py
@@ -97,11 +97,14 @@ def parse_arguments():
     _help_flags = {'-h', '--help'}
     _stripped = [a for a in _argv if a not in _help_flags]
     _positionals = [a for a in _stripped if not a.startswith('-')]
-    from mlpstorage_py.cli.help_formatter import get_context_help_tokens
+    from mlpstorage_py.cli.help_formatter import get_context_help_tokens, SYNOPSIS_TEXT
     _msg = get_context_help_tokens(_positionals)
     if _msg is not None:
         # Fire for: bare invocation, --help at any level, AND bare incomplete paths
         # (e.g., 'mlpstorage closed training' with no --help still shows "next: unet3d | retinanet")
+        if _help_flags.intersection(_argv):
+            print(SYNOPSIS_TEXT)
+            print()
         print(_msg + '  (or -h or --help_all for details)')
         sys.exit(0)
     # _msg is None → leaf level OR unrecognized token → fall through to argparse (HELP-03)

--- a/mlpstorage_py/cli_parser.py
+++ b/mlpstorage_py/cli_parser.py
@@ -102,7 +102,7 @@ def parse_arguments():
     if _msg is not None:
         # Fire for: bare invocation, --help at any level, AND bare incomplete paths
         # (e.g., 'mlpstorage closed training' with no --help still shows "next: unet3d | retinanet")
-        print(_msg)
+        print(_msg + '  (or -h or --help_all for details)')
         sys.exit(0)
     # _msg is None → leaf level OR unrecognized token → fall through to argparse (HELP-03)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.6"
+version = "3.0.7"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.6"
+version = "3.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
## Summary

Two small UX improvements for users navigating the nested command tree:

- **Mid-tree hint**: every context-sensitive `next: X | Y | Z` prompt now appends `  (or -h or --help_all for details)`, so users discover the available help flags without having to stumble upon them.
- **Mid-tree `-h` prints SYNOPSIS**: when `-h` (or `--help`) is passed at an incomplete command path, the SYNOPSIS block from `--help_all` is printed above the existing `next:` hint. Bare invocations without a help flag are unchanged.
- Version bumped 3.0.6 → 3.0.7; `uv.lock` updated to match.

## Stacking

This PR is stacked on **#418** (which is stacked on #412). The base branch is `FileSystemGuy-kvcache-profile`; merge order is 412 → 418 → 419.

## Test plan

- [x] `./mlpstorage` outputs `next: closed | open | ...  (or -h or --help_all for details)`
- [x] `./mlpstorage closed` outputs `next: training | ...  (or -h or --help_all for details)`
- [x] `./mlpstorage open training` outputs `next: unet3d | retinanet  (or -h or --help_all for details)`
- [x] `./mlpstorage -h` prints the SYNOPSIS block above the `next:` line
- [x] `./mlpstorage closed training -h` prints the SYNOPSIS block above the `next:` line
- [x] All 45 existing `test_help_behavior.py` tests pass (substring assertions are unaffected by the appended hint)