### PR TITLE
fix(kvcache): count per-tier bytes when data reaches a tier via eviction

### DIFF
--- a/kv_cache_benchmark/kv_cache/cache.py
+++ b/kv_cache_benchmark/kv_cache/cache.py
@@ -409,10 +409,20 @@ class MultiTierCache:
 
                 with self.stats_lock:
                     self.stats['evictions'] += 1
+
+                    # An eviction reads the entry out of from_tier and writes
+                    # it into to_tier.  Track both so the per-tier byte counters
+                    # (and the bandwidth derived from them) reflect data that
+                    # reaches a tier via eviction, not just direct allocation.
+                    from_stats_name = 'storage' if from_tier == 'nvme' else from_tier
+                    self.stats[f'tier_{from_stats_name}_kv_bytes_read'] += size
+
                     if to_tier == 'cpu':
                         self.stats['offloads_cpu'] += 1
+                        self.stats['tier_cpu_kv_bytes_written'] += size
                     elif to_tier == 'nvme':
                         self.stats['offloads_storage'] += 1
+                        self.stats['tier_storage_kv_bytes_written'] += size
                         bytes_per_token = (self.model_config.kv_cache_size_per_token
                                           // max(1, self.tensor_parallel))
                         if bytes_per_token > 0:

--- a/kv_cache_benchmark/tests/test_kv_cache.py
+++ b/kv_cache_benchmark/tests/test_kv_cache.py
@@ -2492,6 +2492,43 @@ class TestThreeTierEvictionCascade:
         assert cache.stats['offloads_storage'] > 0, \
             "At least one CPU → NVMe demotion should have occurred"
 
+        # --- Per-tier byte counters must reflect eviction-driven I/O ---
+        # New entries are always admitted to GPU (the top tier); data only
+        # reaches CPU and NVMe here via _demote_entry().  Regression guard for
+        # issue #408: those demote paths must increment the destination tier's
+        # written-bytes counter (and the source tier's read-bytes counter),
+        # otherwise tier_{cpu,storage}_kv_bytes_written_gb report 0 even though
+        # offloads_{cpu,storage} prove data is moving.
+        assert cache.stats['tier_cpu_kv_bytes_written'] > 0, \
+            "GPU → CPU demotions must increment tier_cpu_kv_bytes_written"
+        assert cache.stats['tier_storage_kv_bytes_written'] > 0, \
+            "CPU → NVMe demotions must increment tier_storage_kv_bytes_written"
+        assert cache.stats['tier_gpu_kv_bytes_read'] > 0, \
+            "GPU → CPU demotions read out of GPU; tier_gpu_kv_bytes_read must rise"
+        assert cache.stats['tier_cpu_kv_bytes_read'] > 0, \
+            "CPU → NVMe demotions read out of CPU; tier_cpu_kv_bytes_read must rise"
+
+        # Byte conservation: this test only allocates (no access_cache reads),
+        # and every admit lands on GPU, so the only reads out of GPU/CPU are
+        # demotions and the only writes into CPU/NVMe are demotions.  Each
+        # demote moves exactly `size` bytes from from_tier to to_tier, so the
+        # read-out total of a tier must equal the written-in total of the tier
+        # below it.  This pins the accounting to demotion specifically.
+        assert cache.stats['tier_gpu_kv_bytes_read'] == cache.stats['tier_cpu_kv_bytes_written'], \
+            "Every byte read out of GPU during demotion must be written into CPU"
+        assert cache.stats['tier_cpu_kv_bytes_read'] == cache.stats['tier_storage_kv_bytes_written'], \
+            "Every byte read out of CPU during demotion must be written into NVMe"
+
+        # The user-facing summary (results.json → cache_stats) must expose the
+        # non-zero GB values and the bandwidth derived from them.
+        summary = cache.get_stats(duration=1.0)
+        assert summary['tier_cpu_kv_bytes_written_gb'] > 0, \
+            "tier_cpu_kv_bytes_written_gb must be non-zero when CPU receives evictions"
+        assert summary['tier_storage_kv_bytes_written_gb'] > 0, \
+            "tier_storage_kv_bytes_written_gb must be non-zero when NVMe receives evictions"
+        assert summary['tier_storage_write_bandwidth_gbps'] > 0, \
+            "tier_storage_write_bandwidth_gbps is derived from the byte counter and must be non-zero"
+
         # --- Phase 3: Verify early keys were deleted from all tiers ---
         # With 50 entries and ~24 capacity, about half should be gone
         total_entries = len(cache.cache_entries)


### PR DESCRIPTION
Fixes #408

## Summary

`MultiTierCache._demote_entry()` (`kv_cache_benchmark/kv_cache/cache.py`) increments the offload counters and `storage_tokens_processed` when it evicts an entry into a lower tier, but it never increments the **destination tier's byte counter**. As a result, `tier_cpu_kv_bytes_written` / `tier_storage_kv_bytes_written` — and the `*_gb` and `*_write_bandwidth_gbps` values derived from them in `results.json → summary.cache_stats` — report `0` on any multi-tier setup where data reaches CPU or NVMe through **eviction** rather than direct allocation (the typical GPU-first configuration). The read side of the demotion (data read out of the source tier) was likewise untracked.

This is the bug reported in #408, where `offloads_storage` was `810` (data demonstrably written to storage) yet `tier_storage_kv_bytes_written_gb` and `tier_storage_write_bandwidth_gbps` were `0.0`.

## Fix

Inside the existing `stats_lock` block in `_demote_entry()`:
- increment the source tier's `tier_*_kv_bytes_read` counter (the eviction reads the entry out of `from_tier`), and
- increment the destination tier's `tier_*_kv_bytes_written` counter for the `cpu` / `nvme` branches.

This mirrors the accounting already performed on the direct-allocation path (`_allocate_cache_inner`) and the read path (`access_cache`), reusing the same `nvme → storage` stat-name mapping.

## Test

Strengthens `TestThreeTierEvictionCascade::test_full_cascade_gpu_to_cpu_to_nvme_to_delete`, which already forces a GPU→CPU→NVMe cascade (every new entry is admitted to GPU, so CPU/NVMe bytes can only arrive via demotion). New assertions verify:
- the demote-only byte counters (`tier_cpu_kv_bytes_written`, `tier_storage_kv_bytes_written`, `tier_gpu_kv_bytes_read`, `tier_cpu_kv_bytes_read`) are non-zero;
- the user-facing summary exposes non-zero `tier_{cpu,storage}_kv_bytes_written_gb` and `tier_storage_write_bandwidth_gbps`;
- byte conservation — bytes read out of a tier equal the bytes written into the tier below it — pinning the accounting to the demotion path specifically.

This test **fails before** the fix (counters `0` while `offloads_cpu`/`offloads_storage` are non-zero) and **passes after**.

## Verification

- Full KV cache suite: `206 passed, 28 skipped` (skips are CUDA-only).
- The before/after counters were also cross-checked against the `darshan`-measured ground truth in #408 (~1% delta, attributable to `.npy` header bytes excluded from bench size accounting).
- No new `ruff` findings on the changed lines.