### PR TITLE
Fix --mpi-params rejecting dash-led MPI flags in training run (#422)

### DIFF
--- a/mlpstorage_py/cli/common_args.py
+++ b/mlpstorage_py/cli/common_args.py
@@ -296,10 +296,18 @@ def add_mpi_arguments(parser):
     )
     mpi_options.add_argument(
         '--mpi-params',
-        nargs="+",
-        type=str,
         action="append",
-        help="Other MPI parameters that will be passed to MPI"
+        type=str,
+        default=None,
+        metavar="MPI_PARAMS",
+        help=(
+            "Additional parameters passed verbatim to the MPI launcher. "
+            "Pass them as a single quoted string, e.g. "
+            "--mpi-params=\"-genv PMI_VERSION=2 -genv FI_PROVIDER=tcp\". "
+            "Because MPI flags begin with '-', use the '--mpi-params=...' "
+            "(equals) form so argparse does not mistake them for options. "
+            "May be supplied multiple times; values are concatenated."
+        )
     )
 
 

--- a/mlpstorage_py/cli_parser.py
+++ b/mlpstorage_py/cli_parser.py
@@ -7,6 +7,7 @@ using modular argument builders from the cli package.
 
 import argparse
 import re
+import shlex
 import sys
 
 from mlpstorage_py import VERSION
@@ -248,8 +249,22 @@ def update_args(args):
         setattr(args, 'params', flattened_params)
 
     if hasattr(args, 'mpi_params') and args.mpi_params:
-        flattened_mpi_params = [item for sublist in args.mpi_params for item in sublist]
-        setattr(args,'mpi_params', flattened_mpi_params)
+        # --mpi-params is collected with action="append" as a list of raw
+        # strings, each potentially containing several space-separated MPI
+        # flags, e.g. ["-genv PMI_VERSION=2 -genv FI_PROVIDER=tcp"].
+        # MPI flags begin with '-', so nargs="+" used to reject them with
+        # "expected at least one argument" (see issue #422). We now accept the
+        # whole string and tokenize it here with shlex so quoting is honored
+        # and downstream (generate_mpi_prefix_cmd) receives a flat token list.
+        flattened_mpi_params = []
+        for chunk in args.mpi_params:
+            if isinstance(chunk, (list, tuple)):
+                # Backwards-compat: tolerate the old nested-list shape.
+                for item in chunk:
+                    flattened_mpi_params.extend(shlex.split(item))
+            else:
+                flattened_mpi_params.extend(shlex.split(chunk))
+        setattr(args, 'mpi_params', flattened_mpi_params)
 
     if hasattr(args, 'hosts') and args.hosts is not None:
         # Accept any of the following equivalent forms and normalize to a clean list:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -144,10 +144,23 @@ class TestAddMpiArguments:
         assert args.allow_run_as_root is True
 
     def test_adds_mpi_params_argument(self, parser):
-        """Should add --mpi-params argument."""
+        """Should add --mpi-params argument that accepts a single string.
+
+        MPI flags begin with '-', so --mpi-params now takes one string value
+        (use the '=' form) rather than nargs='+', which rejected dash-led
+        values with "expected at least one argument" (issue #422).
+        """
         add_mpi_arguments(parser)
-        args = parser.parse_args(['--mpi-params', 'param1', 'param2'])
-        assert args.mpi_params == [['param1', 'param2']]
+        args = parser.parse_args(['--mpi-params=-genv FI_PROVIDER=tcp'])
+        assert args.mpi_params == ['-genv FI_PROVIDER=tcp']
+
+    def test_mpi_params_appends_multiple(self, parser):
+        """Multiple --mpi-params should accumulate via action='append'."""
+        add_mpi_arguments(parser)
+        args = parser.parse_args(
+            ['--mpi-params=-x FOO=1', '--mpi-params=-genv BAR=2']
+        )
+        assert args.mpi_params == ['-x FOO=1', '-genv BAR=2']
 
 
 class TestAddTrainingArguments:
@@ -464,8 +477,28 @@ class TestUpdateArgs:
         update_args(args)
         assert args.params == ['key1=val1', 'key2=val2', 'key3=val3']
 
+    def test_tokenizes_mpi_params_string(self):
+        """Should shlex-split each --mpi-params string into a flat token list."""
+        args = argparse.Namespace(
+            params=None,
+            mpi_params=['-genv FI_PROVIDER=tcp', '--bind-to core']
+        )
+        update_args(args)
+        assert args.mpi_params == [
+            '-genv', 'FI_PROVIDER=tcp', '--bind-to', 'core'
+        ]
+
+    def test_mpi_params_honors_quoting(self):
+        """shlex tokenization must keep inner-quoted values as one token."""
+        args = argparse.Namespace(
+            params=None,
+            mpi_params=['-x LD_PRELOAD="/opt/my lib/foo.so"']
+        )
+        update_args(args)
+        assert args.mpi_params == ['-x', 'LD_PRELOAD=/opt/my lib/foo.so']
+
     def test_flattens_mpi_params_list(self):
-        """Should flatten nested mpi_params list."""
+        """Legacy nested-list shape (old nargs='+') is still tolerated."""
         args = argparse.Namespace(
             params=None,
             mpi_params=[['--bind-to', 'core'], ['--map-by', 'socket']]

--- a/tests/unit/test_cli_kvcache.py
+++ b/tests/unit/test_cli_kvcache.py
@@ -215,9 +215,13 @@ class TestKVCacheMPIArguments:
         assert args.allow_run_as_root is True
 
     def test_mpi_params_argument(self, parser):
-        """Run should accept --mpi-params argument."""
-        args = parser.parse_args(['run', '--mpi-params', 'param1', 'param2'])
-        assert args.mpi_params == [['param1', 'param2']]
+        """Run should accept --mpi-params as a single string.
+
+        MPI flags begin with '-', so --mpi-params takes one string value
+        (use the '=' form). See issue #422.
+        """
+        args = parser.parse_args(['run', '--mpi-params=-genv FI_PROVIDER=tcp'])
+        assert args.mpi_params == ['-genv FI_PROVIDER=tcp']
 
 
 class TestKVCacheDatasizeNoDistributedArgs:


### PR DESCRIPTION
## Summary
Fixes #422. mlpstorage training run `--mpi-params` "-genv ..." failed with argument `--mpi-params`: expected at least one argument, while training datagen appeared to work.

## Root cause
`--mpi-params` was defined with nargs="+" + action="append" in `mlpstorage_py/cli/common_args.py`. Every MPI flag begins with - (-genv, -x, --mca), so argparse treats those tokens as new options and, with nargs="+", reports "expected at least one argument" whenever the value reaches argparse as separate tokens. Even when a single quoted token parsed, the value was stored as one un-split string rather than a token list.

## Fix
`--mpi-params` now takes a single string value (action="append", no nargs) and the help text directs users to the `--mpi-params="..." ` equals form, which binds dash-led values reliably.

`update_args()` tokenizes each value with `shlex.split`, honoring quoting and producing the flat token list `generate_mpi_prefix_cmd()` expects. The old nested-list shape is still tolerated for backward compatibility.

## Testing

1. Reproduced the failure against repo code; confirmed the equals form now parses and builds a correct MPI prefix end-to-end.
`pytest tests/unit/test_cli.py tests/unit/test_cli_kvcache.py `→ 126 passed.
```
smrc@dskbd029:~/Storage_Repo_Tests/storage$ uv run python3 -m pytest tests/unit/test_cli.py tests/unit/test_cli_kvcache.py -q
========================================================================= test session starts =========================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/smrc/Storage_Repo_Tests/storage
configfile: pyproject.toml
plugins: hydra-core-1.3.2
collected 126 items                                                                                                                                                   

tests/unit/test_cli.py 
        tests/unit/test_cli.py::TestHelpMessages::test_help_messages_is_dict.
        tests/unit/test_cli.py::TestHelpMessages::test_help_messages_has_required_keys.
        tests/unit/test_cli.py::TestHelpMessages::test_prog_descriptions_has_benchmark_types.
        SETUP    F parser
        tests/unit/test_cli.py::TestAddUniversalArguments::test_adds_results_dir_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddUniversalArguments::test_adds_loops_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddUniversalArguments::test_adds_debug_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddUniversalArguments::test_adds_verbose_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddUniversalArguments::test_adds_what_if_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddUniversalArguments::test_closed_open_mutually_exclusive (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddUniversalArguments::test_adds_allow_invalid_params (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddUniversalArguments::test_adds_config_file_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddMpiArguments::test_adds_mpi_bin_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddMpiArguments::test_adds_oversubscribe_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddMpiArguments::test_adds_allow_run_as_root_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddMpiArguments::test_adds_mpi_params_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddMpiArguments::test_mpi_params_appends_multiple (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddTrainingArguments::test_datasize_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddTrainingArguments::test_datagen_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddTrainingArguments::test_run_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddTrainingArguments::test_configview_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddTrainingArguments::test_hosts_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddTrainingArguments::test_params_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddCheckpointingArguments::test_datasize_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddCheckpointingArguments::test_run_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddCheckpointingArguments::test_num_checkpoints_read_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddCheckpointingArguments::test_num_checkpoints_write_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddVectordbArguments::test_datagen_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddVectordbArguments::test_run_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddVectordbArguments::test_datagen_dimension_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddVectordbArguments::test_datagen_num_vectors_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddVectordbArguments::test_run_batch_size_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddReportsArguments::test_reportgen_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddReportsArguments::test_output_dir_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddHistoryArguments::test_show_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddHistoryArguments::test_show_limit_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddHistoryArguments::test_show_id_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli.py::TestAddHistoryArguments::test_rerun_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        tests/unit/test_cli.py::TestValidateArgs::test_valid_checkpointing_args.
        tests/unit/test_cli.py::TestValidateArgs::test_invalid_llm_model_exits.
        tests/unit/test_cli.py::TestValidateArgs::test_negative_checkpoints_read_exits.
        tests/unit/test_cli.py::TestValidateArgs::test_negative_checkpoints_write_exits.
        tests/unit/test_cli.py::TestValidateArgs::test_training_args_pass_validation.
        tests/unit/test_cli.py::TestUpdateArgs::test_sets_num_processes_from_num_accelerators.
        tests/unit/test_cli.py::TestUpdateArgs::test_sets_num_processes_from_max_accelerators.
        tests/unit/test_cli.py::TestUpdateArgs::test_flattens_params_list.
        tests/unit/test_cli.py::TestUpdateArgs::test_tokenizes_mpi_params_string.
        tests/unit/test_cli.py::TestUpdateArgs::test_mpi_params_honors_quoting.
        tests/unit/test_cli.py::TestUpdateArgs::test_flattens_mpi_params_list.
        tests/unit/test_cli.py::TestUpdateArgs::test_splits_comma_separated_hosts.
        tests/unit/test_cli.py::TestUpdateArgs::test_hosts_space_separated_list_unchanged.
        tests/unit/test_cli.py::TestUpdateArgs::test_hosts_single_quoted_space_separated_string.
        tests/unit/test_cli.py::TestUpdateArgs::test_hosts_equals_quoted_space_separated.
        tests/unit/test_cli.py::TestUpdateArgs::test_hosts_mixed_comma_and_space.
        tests/unit/test_cli.py::TestUpdateArgs::test_hosts_mixed_list_and_internal_split.
        tests/unit/test_cli.py::TestUpdateArgs::test_hosts_preserves_slots_suffix.
        tests/unit/test_cli.py::TestUpdateArgs::test_hosts_strips_stray_whitespace_and_empty_tokens.
        tests/unit/test_cli.py::TestUpdateArgs::test_hosts_empty_after_parsing_exits.
        tests/unit/test_cli.py::TestUpdateArgs::test_num_client_hosts_derived_when_none.
        tests/unit/test_cli.py::TestUpdateArgs::test_num_client_hosts_respected_when_set.
        tests/unit/test_cli.py::TestUpdateArgs::test_sets_num_client_hosts_from_hosts.
        tests/unit/test_cli.py::TestUpdateArgs::test_sets_default_runtime_for_vectordb.
        tests/unit/test_cli.py::TestUpdateArgs::test_num_client_hosts_zero_is_preserved.
SETUP    S tmp_path_factory
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        tests/unit/test_cli.py::TestApplyYamlConfigOverrides::test_applies_simple_overrides (fixtures used: request, tmp_path, tmp_path_factory).
        TEARDOWN F tmp_path
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        SETUP    F capsys
        tests/unit/test_cli.py::TestApplyYamlConfigOverrides::test_skips_unknown_params (fixtures used: capsys, request, tmp_path, tmp_path_factory).
        TEARDOWN F capsys
        TEARDOWN F tmp_path
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        SETUP    F capsys
        tests/unit/test_cli.py::TestApplyYamlConfigOverrides::test_handles_empty_config (fixtures used: capsys, request, tmp_path, tmp_path_factory).
        TEARDOWN F capsys
        TEARDOWN F tmp_path
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        tests/unit/test_cli.py::TestApplyYamlConfigOverrides::test_converts_hosts_string_to_list (fixtures used: request, tmp_path, tmp_path_factory).
        TEARDOWN F tmp_path
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        tests/unit/test_cli.py::TestApplyYamlConfigOverrides::test_converts_params_dict_to_list (fixtures used: request, tmp_path, tmp_path_factory).
        TEARDOWN F tmp_path
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        tests/unit/test_cli.py::TestApplyYamlConfigOverrides::test_exits_on_file_not_found (fixtures used: request, tmp_path, tmp_path_factory).
        TEARDOWN F tmp_path
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        tests/unit/test_cli.py::TestApplyYamlConfigOverrides::test_exits_on_invalid_yaml (fixtures used: request, tmp_path, tmp_path_factory).
        TEARDOWN F tmp_path
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        tests/unit/test_cli.py::TestApplyYamlConfigOverrides::test_skips_none_values (fixtures used: request, tmp_path, tmp_path_factory).
        TEARDOWN F tmp_path
        SETUP    F monkeypatch
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        tests/unit/test_cli.py::TestParseArgumentsStorageFlagConsolidation::test_reportgen_does_not_crash_without_storage_flags (fixtures used: monkeypatch, request, .
        TEARDOWN F tmp_path
        TEARDOWN F monkeypatch
        SETUP    F monkeypatch
        tests/unit/test_cli.py::TestParseArgumentsStorageFlagConsolidation::test_history_does_not_crash_without_storage_flags (fixtures used: monkeypatch).
        TEARDOWN F monkeypatch
        SETUP    F monkeypatch
        tests/unit/test_cli.py::TestParseArgumentsStorageFlagConsolidation::test_lockfile_does_not_crash_without_storage_flags (fixtures used: monkeypatch).
        TEARDOWN F monkeypatch
        SETUP    F monkeypatch
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        tests/unit/test_cli.py::TestParseArgumentsStorageFlagConsolidation::test_training_run_consolidates_file_flag (fixtures used: monkeypatch, request, tmp_path, t.
        TEARDOWN F tmp_path
        TEARDOWN F monkeypatch
        SETUP    F monkeypatch
        SETUP    F tmp_path (fixtures used: tmp_path_factory)
        tests/unit/test_cli.py::TestParseArgumentsStorageFlagConsolidation::test_training_run_consolidates_object_flag (fixtures used: monkeypatch, request, tmp_path,.
        TEARDOWN F tmp_path
        TEARDOWN F monkeypatch
tests/unit/test_cli_kvcache.py 
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheSubcommands::test_run_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheSubcommands::test_datasize_subcommand_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheModelArguments::test_model_argument_default (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheModelArguments::test_model_argument_choices (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheModelArguments::test_num_users_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheModelArguments::test_num_users_default (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheCacheArguments::test_gpu_mem_gb_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheCacheArguments::test_cpu_mem_gb_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheCacheArguments::test_cache_dir_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunArguments::test_duration_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunArguments::test_generation_mode_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunArguments::test_performance_profile_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunArguments::test_seed_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDistributedArguments::test_hosts_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDistributedArguments::test_hosts_short_flag (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDistributedArguments::test_hosts_default (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDistributedArguments::test_exec_type_argument_mpi (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDistributedArguments::test_exec_type_argument_docker (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDistributedArguments::test_exec_type_default (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDistributedArguments::test_exec_type_short_flag (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDistributedArguments::test_num_processes_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDistributedArguments::test_num_processes_short_flag (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheMPIArguments::test_mpi_bin_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheMPIArguments::test_mpi_bin_mpiexec (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheMPIArguments::test_oversubscribe_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheMPIArguments::test_allow_run_as_root_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheMPIArguments::test_mpi_params_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDatasizeNoDistributedArgs::test_datasize_no_hosts_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDatasizeNoDistributedArgs::test_datasize_no_exec_type_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDatasizeNoDistributedArgs::test_datasize_no_num_processes_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDatasizeNoDistributedArgs::test_datasize_no_mpi_bin_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheDatasizeNoDistributedArgs::test_datasize_basic_args_work (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheOptionalFeatures::test_disable_multi_turn_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheOptionalFeatures::test_disable_prefix_caching_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheOptionalFeatures::test_enable_rag_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheOptionalFeatures::test_rag_num_docs_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheOptionalFeatures::test_enable_autoscaling_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheOptionalFeatures::test_autoscaler_mode_argument (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_validate_subcommand_no_longer_exists (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_npernode_default_is_1 (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_npernode_accepts_value (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_npernode_long_form_accepted (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_seed_default_is_none (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_seed_accepts_value (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_trials_default_is_none (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_trials_accepts_value (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_inter_option_delay_default_is_none (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_inter_option_delay_accepts_value (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_config_default_is_none (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_config_argument_accepted (fixtures used: parser).
        TEARDOWN F parser
        SETUP    F parser
        tests/unit/test_cli_kvcache.py::TestKVCacheRunMLPerfArguments::test_kvcache_bin_path_accepted (fixtures used: parser).
        TEARDOWN F parser
TEARDOWN S tmp_path_factory

========================================================================= 126 passed in 0.27s =========================================================================
```
### Training test
```
smrc@dskbd029:~/Storage_Repo_Tests/storage$ ./mlpstorage training run --hosts localhost --num-client-hosts 1 --num-accelerators 8 --model retinanet --data-dir /mnt/drives/nvme3n1/training --results-dir /mnt/drives/nvme3n1/results --param dataset.num_files_train=10 --client-host-memory-in-gb 1024 --accelerator-type b200 --open --debug --file --exec-type mpi --mpi-bin mpiexec --mpi-params="-x PMI_VERSION=2 -x FI_PROVIDER=tcp -x FI_TCP_IFACE=ens8f0np0 -x TF_ENABLE_ONEDNN_OPTS=0 -x DLIO_LOG_LEVEL=debug"
2026-06-10 20:04:08|DEBUG:history:31: Parsing history line: 163,20260610_195452,/home/smrc/Storage_Repo_Tests/storage/mlpstorage_py/main.py training run --hosts localhost

2026-06-10 20:04:08|VERBOSER:mlps_logging:101: Adding command to history: 164,20260610_200408,/home/smrc/Storage_Repo_Tests/storage/mlpstorage_py/main.py training run 
Setting attr from num_accelerators to 8
⠋ Validating environment... 0:00:002026-06-10 20:04:08|DEBUG:validation_helpers:572: Starting environment validation (OS: Linux)
2026-06-10 20:04:08|DEBUG:validation_helpers:591: Checking DLIO benchmark availability...
2026-06-10 20:04:08|DEBUG:validation_helpers:596: DLIO check passed
2026-06-10 20:04:08|INFO:validation_helpers:686: Environment validation passed
2026-06-10 20:04:08|STATUS:mlps_logging:101: Benchmark results directory: /mnt/drives/nvme3n1/results/training/retinanet/run/20260610_200408
2026-06-10 20:04:08|DEBUG:dependency_check:276: Checking for MPI runtime (mpiexec)...
2026-06-10 20:04:08|DEBUG:dependency_check:279: Found MPI at: /usr/bin/mpiexec
2026-06-10 20:04:08|DEBUG:dependency_check:283: Checking for DLIO benchmark...
2026-06-10 20:04:08|DEBUG:dependency_check:286: Found DLIO at: /home/smrc/Storage_Repo_Tests/storage/.venv/bin/dlio_benchmark
2026-06-10 20:04:08|DEBUG:base:463: Collecting cluster information via MPI...
2026-06-10 20:04:08|DEBUG:cluster_collector:1446: Starting MPI cluster collection on 1 hosts
2026-06-10 20:04:08|INFO:cluster_collector:1468: Collector script staged at /mnt/drives/nvme3n1/results/training/retinanet/run/20260610_200408/collector-staging/mlps_c
2026-06-10 20:04:08|INFO:cluster_collector:1499: Running MPI collection across 1 host(s)
2026-06-10 20:04:08|DEBUG:cluster_collector:1502: MPI command: mpiexec -n 1 -host localhost:1 --bind-to none --map-by node python3 /mnt/drives/nvme3n1/results/training
2026-06-10 20:04:09|INFO:cluster_collector:1553: MPI collection completed successfully (1 hosts reported)
2026-06-10 20:04:09|DEBUG:base:492: Cluster info collected via mpi: 1 hosts, 1007.3GiB total memory, 48 total cores
2026-06-10 20:04:09|VERBOSE:mlps_logging:101: Using MPI-collected cluster info: 1 hosts, 1007.3GiB total memory
2026-06-10 20:04:09|DEBUG:dlio:221: yaml params: 
{'dataset': {'data_folder': 'data/retinanet/',
             'format': 'jpeg',
             'num_files_train': 1170301,
             'num_samples_per_file': 1,
             'record_length_bytes': 322957},
 'framework': 'pytorch',
 'metric': {'au': 0.85},
 'model': {'name': 'retinanet', 'type': 'cnn'},
 'reader': {'batch_size': 24,
            'data_loader': 'pytorch',
            'file_shuffle': 'seed',
            'read_threads': 8,
            'sample_shuffle': 'seed'},
 'train': {'computation_time': 0.04755, 'epochs': 8},
 'workflow': {'checkpoint': False, 'generate_data': False, 'train': True}}
2026-06-10 20:04:09|DEBUG:dlio:222: combined params: 
{'dataset': {'data_folder': 'data/retinanet/',
             'format': 'jpeg',
             'num_files_train': '10',
             'num_samples_per_file': 1,
             'record_length_bytes': 322957},
 'framework': 'pytorch',
 'metric': {'au': 0.85},
 'model': {'name': 'retinanet', 'type': 'cnn'},
 'reader': {'batch_size': 24,
            'data_loader': 'pytorch',
            'file_shuffle': 'seed',
            'read_threads': 8,
            'sample_shuffle': 'seed'},
 'train': {'computation_time': 0.04755, 'epochs': 8},
 'workflow': {'checkpoint': False, 'generate_data': False, 'train': True}}
2026-06-10 20:04:09|DEBUG:dlio:223: Instance params: 
{'_cluster_collector': None,
 '_config_name': 'retinanet_b200',
 '_timeseries_collector': None,
 '_timeseries_data': None,
 '_validator': None,
 'args': Namespace(program='training', command='run', hosts=['localhost'], model='retinanet', client_host_memory_in_gb=1024, exec_type=<EXEC_TYPE.MPI: 'mpi'>, mpi_bin=
 'base_command': 'dlio_benchmark',
 'base_command_path': '/home/smrc/Storage_Repo_Tests/storage/.venv/bin/dlio_benchmark',
 'base_path': '/home/smrc/Storage_Repo_Tests/storage/mlpstorage_py',
 'benchmark_run_verifier': None,
 'cluster_information': <mlpstorage_py.rules.models.ClusterInformation object at 0x730055c920f0>,
 'cmd_executor': <mlpstorage_py.utils.CommandExecutor object at 0x730055d0f620>,
 'command_method_map': {'configview': <bound method DLIOBenchmark.execute_command of <mlpstorage_py.benchmarks.dlio.TrainingBenchmark object at 0x730055d43e60>>,
                        'datagen': <bound method DLIOBenchmark.execute_command of <mlpstorage_py.benchmarks.dlio.TrainingBenchmark object at 0x730055d43e60>>,
                        'datasize': <bound method TrainingBenchmark.datasize of <mlpstorage_py.benchmarks.dlio.TrainingBenchmark object at 0x730055d43e60>>,
                        'reportgen': <bound method DLIOBenchmark.execute_command of <mlpstorage_py.benchmarks.dlio.TrainingBenchmark object at 0x730055d43e60>>,
                        'run': <bound method DLIOBenchmark.execute_command of <mlpstorage_py.benchmarks.dlio.TrainingBenchmark object at 0x730055d43e60>>},
 'command_output_files': [],
 'config_file': 'retinanet_b200.yaml',
 'config_path': '/home/smrc/Storage_Repo_Tests/storage/configs/dlio',
 'debug': True,
 'logger': <Logger MLPerfStorage (DEBUG)>,
 'metadata_file_path': '/mnt/drives/nvme3n1/results/training/retinanet/run/20260610_200408/training_20260610_200408_metadata.json',
 'metadata_filename': 'training_20260610_200408_metadata.json',
 'per_host_mem_kB': None,
 'run_datetime': '20260610_200408',
 'run_number': 0,
 'run_result_output': '/mnt/drives/nvme3n1/results/training/retinanet/run/20260610_200408',
 'runtime': 0,
 'timeseries_file_path': '/mnt/drives/nvme3n1/results/training/retinanet/run/20260610_200408/training_20260610_200408_timeseries.json',
 'timeseries_filename': 'training_20260610_200408_timeseries.json',
 'total_mem_kB': None,
 'verification': None}
2026-06-10 20:04:09|VERBOSER:mlps_logging:101: Verifying benchmark parameters: Namespace(program='training', command='run', hosts=['localhost'], model='retinanet', cli
2026-06-10 20:04:09|INFO:models:880: Created benchmark run: training_run_retinanet_20260610_200408
2026-06-10 20:04:09|STATUS:mlps_logging:101: Verifying benchmark run for training_run_retinanet_20260610_200408
2026-06-10 20:04:09|DEBUG:base:64: Running check check_allowed_params
2026-06-10 20:04:09|DEBUG:training:118: Processing override parameter: dataset.num_files_train = 10
2026-06-10 20:04:09|DEBUG:base:64: Running check check_benchmark_type
2026-06-10 20:04:09|DEBUG:base:64: Running check check_checkpoint_files_in_code
2026-06-10 20:04:09|DEBUG:base:64: Running check check_file_system_caching
2026-06-10 20:04:09|DEBUG:base:64: Running check check_inter_test_times
2026-06-10 20:04:09|DEBUG:base:64: Running check check_model_recognized
2026-06-10 20:04:09|DEBUG:base:64: Running check check_num_epochs
2026-06-10 20:04:09|DEBUG:base:64: Running check check_num_files_train
2026-06-10 20:04:09|RESULT:mlps_logging:101: Minimum file count dictated by dataset size to memory size ratio.
2026-06-10 20:04:09|DEBUG:base:64: Running check check_odirect_supported_model
2026-06-10 20:04:09|DEBUG:base:64: Running check check_workflow_parameters
2026-06-10 20:04:09|STATUS:mlps_logging:101: Closed: [CLOSED] Closed parameter override allowed: dataset.num_files_train = 10 (Parameter: Overrode Parameters)
2026-06-10 20:04:09|ERROR:verifier:146: INVALID: [INVALID] Insufficient number of training files (Parameter: dataset.num_files_train, Expected: >= 16745325, Actual: 10
2026-06-10 20:04:09|STATUS:mlps_logging:101: Benchmark run is INVALID due to 1 issues ([RunID(program='training', command='run', model='retinanet', run_datetime='20260
2026-06-10 20:04:09|VERBOSER:mlps_logging:101: Benchmark verification result: PARAM_VALIDATION.INVALID
2026-06-10 20:04:09|ERROR:base:845: Invalid configuration found. Aborting benchmark run.
```
2. Added tests for multi-append accumulation and shlex quoting; updated tests asserting the legacy shape.

## Note
Use the equals form so the shell delivers one token: `--mpi-params="-genv PMI_VERSION=2 -genv FI_PROVIDER=tcp"`.

One caveat worth stating plainly in the PR or issue comment: this fixes the = form, which is the correct and documented way to pass dash-led MPI flags. The bare `--mpi-params -genv` ... (space-separated, unquoted/separate tokens) fundamentally cannot be made to parse in argparse, since those tokens are indistinguishable from options — hence the help-text guidance is part of the fix, not just the code change.