### PR TITLE
feat(kvcache): default --performance-profile to 'throughput'; hide in closed

### DIFF
--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -105,7 +105,7 @@ class KVCacheBenchmark(Benchmark):
 
         # Benchmark configuration
         self.generation_mode = getattr(args, 'generation_mode', 'realistic')
-        self.performance_profile = getattr(args, 'performance_profile', 'latency')
+        self.performance_profile = getattr(args, 'performance_profile', 'throughput')
 
         # Find the kv-cache.py script
         self.kvcache_bin_path = self._find_kvcache_script()

--- a/mlpstorage_py/cli/help_formatter.py
+++ b/mlpstorage_py/cli/help_formatter.py
@@ -433,7 +433,7 @@ KV_RUN_CLOSED
   + MPI_ARGS
   + CORE_STD
   Note: the following are fixed in closed and not shown:
-    duration=60s, generation-mode=realistic, performance-profile=latency,
+    duration=60s, generation-mode=realistic, performance-profile=throughput,
     seed=42, trials=3, inter-option-delay=20s,
     disable-multi-turn=False, disable-prefix-caching=False,
     enable-rag=True, rag-num-docs=10,
@@ -454,7 +454,7 @@ KV_RUN_OPEN
     --cpu-mem-gb FLOAT              (default: 32.0)
     --duration/-d N                 Seconds (default: 60)
     --generation-mode {none,fast,realistic}  (default: realistic)
-    --performance-profile {latency,throughput}  (default: latency)
+    --performance-profile {latency,throughput}  (default: throughput)
     --disable-multi-turn
     --disable-prefix-caching
     --enable-rag

--- a/mlpstorage_py/cli/kvcache_args.py
+++ b/mlpstorage_py/cli/kvcache_args.py
@@ -173,7 +173,7 @@ def _add_kvcache_cache_arguments(parser, mode):
             loops=1,
             duration=KVCACHE_DEFAULT_DURATION,
             generation_mode='realistic',
-            performance_profile='latency',
+            performance_profile='throughput',
             disable_multi_turn=False,
             disable_prefix_caching=False,
             enable_rag=True,
@@ -241,7 +241,7 @@ def _add_kvcache_open_args(parser):
     run_group.add_argument(
         '--performance-profile',
         choices=KVCACHE_PERFORMANCE_PROFILES,
-        default='latency',
+        default='throughput',
         help=KVCACHE_HELP_MESSAGES['performance_profile']
     )
     run_group.add_argument(

--- a/tests/unit/test_cli_kvcache.py
+++ b/tests/unit/test_cli_kvcache.py
@@ -122,6 +122,11 @@ class TestKVCacheRunArguments:
             args = parser.parse_args(['run', '--results-dir', '/tmp', '--performance-profile', profile])
             assert args.performance_profile == profile
 
+    def test_performance_profile_default_is_throughput(self, parser):
+        """performance_profile should default to 'throughput' in open/whatif mode."""
+        args = parser.parse_args(['run', '--results-dir', '/tmp'])
+        assert args.performance_profile == 'throughput'
+
     def test_seed_argument(self, parser):
         """Should accept --seed argument."""
         args = parser.parse_args(['run', '--results-dir', '/tmp', '--seed', '42'])
@@ -425,3 +430,24 @@ class TestKVCacheClosedMode:
         """Closed kvcache must reject --cpu-mem-gb (open/whatif only)."""
         with pytest.raises(SystemExit):
             parser.parse_args(['run', '--results-dir', '/tmp', '--cpu-mem-gb', '64.0'])
+
+
+class TestKVCacheClosedModePerformanceProfile:
+    """Tests for --performance-profile in closed mode: fixed to 'throughput', not a visible arg."""
+
+    @pytest.fixture
+    def closed_parser(self):
+        parser = argparse.ArgumentParser()
+        add_kvcache_arguments(parser, 'closed')
+        return parser
+
+    def test_performance_profile_fixed_to_throughput(self, closed_parser):
+        """In closed mode performance_profile is silently fixed to 'throughput'."""
+        args = closed_parser.parse_args(['run', '--results-dir', '/tmp'])
+        assert args.performance_profile == 'throughput'
+
+    def test_performance_profile_not_a_registered_arg_in_closed(self, closed_parser):
+        """In closed mode --performance-profile is hidden and must not be accepted."""
+        with pytest.raises(SystemExit):
+            closed_parser.parse_args(['run', '--results-dir', '/tmp',
+                                      '--performance-profile', 'latency'])


### PR DESCRIPTION
## Summary

- **closed**: `performance_profile` fixed to `'throughput'` via `set_defaults` — the flag is not registered and will be rejected if supplied
- **open**: `--performance-profile` is visible with default changed from `'latency'` to `'throughput'`
- **whatif**: same as open — fully available, defaults to `'throughput'`
- Fallback default in `KVCacheBenchmark.__init__` updated to match
- `HELP_ALL_TEXT` in `help_formatter.py` updated for the closed note and open/whatif listing

## Test plan

- [ ] `pytest tests/unit/test_cli_kvcache.py -v` — all 54 tests pass
- [ ] New `TestKVCacheClosedModePerformanceProfile` class pins closed behaviour: fixed value and rejected argument
- [ ] `test_performance_profile_default_is_throughput` pins open/whatif default

---

Replaces #418, which was auto-closed when the `FileSystemGuy-cli-refactor` base branch was deleted after #412 merged. Branch has been rebased onto `main` (single commit, same diff as #418).