### PR TITLE
Persist datasize calculations into metadata file

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -394,6 +394,15 @@ class TrainingBenchmark(DLIOBenchmark):
         num_files_train, num_subfolders_train, total_disk_bytes = calculate_training_data_size(
             self.args, self.cluster_information, self.combined_params['dataset'], self.combined_params['reader'], self.logger
         )
+
+        # Persist calculated sizing into params_dict so the values flow into the
+        # written metadata file via the dotted-key override mechanism in
+        # Benchmark.metadata (#208). Without this, the metadata reflects only
+        # the YAML defaults and downstream automation cannot read back the
+        # num_files_train that datasize reported on stderr.
+        self.params_dict['dataset.num_files_train'] = num_files_train
+        self.params_dict['dataset.num_subfolders_train'] = num_subfolders_train
+
         self.logger.result(f'Number of training files: {num_files_train}')
         self.logger.result(f'Number of training subfolders: {num_subfolders_train}')
         self.logger.result(f'Total disk space required for training: {total_disk_bytes / 1024**3:.2f}GiB')


### PR DESCRIPTION
## Summary

Resolves #208.

The `training datasize` command computed `num_files_train` and `num_subfolders_train`, logged them to stderr, but never wrote them anywhere that reached the metadata JSON. As reported in the issue, the metadata kept the YAML defaults (e.g. `num_files_train: 168`) while the stderr output reported the actual required value (e.g. `28000`). This blocks automation that wants to feed `dataset.num_files_train` from the metadata file into a subsequent `datagen` run.

## Fix

In `TrainingBenchmark.datasize`, write the calculated values into `self.params_dict` using dotted keys:

```python
self.params_dict['dataset.num_files_train'] = num_files_train
self.params_dict['dataset.num_subfolders_train'] = num_subfolders_train
```

`Benchmark.metadata` already folds `params_dict` overrides into the written `parameters` section via `_apply_dotted_overrides` (`benchmarks/base.py:297-316`). This is the idiomatic propagation path and matches how `add_datadir_param` and `add_checkpoint_params` publish their values.

## Test plan

- [x] Existing unit tests pass (`test_dlio_object_storage.py`, `test_benchmarks_base.py`, `test_rules_calculations.py` — 131 passed)
- [x] End-to-end: `mlpstorage closed training unet3d datasize --max-accelerators 2 --accelerator-type b200 --num-client-hosts 1 --client-host-memory-in-gb 64` now writes `num_files_train: 7000` into the metadata JSON, matching the `RESULT: Number of training files: 7000` stderr line.
- [x] Confirmed both `parameters.dataset.num_files_train` and `override_parameters["dataset.num_files_train"]` in the metadata reflect the calculated value.