### PR TITLE
fix: pin dlio-benchmark to PR #22 head to resolve issue #415

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.7"
+version = "3.0.9"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -122,7 +122,9 @@ environments = ["sys_platform == 'linux'"]
 torch = [{ index = "pytorch-cpu" }]
 torchvision = [{ index = "pytorch-cpu" }]
 torchaudio = [{ index = "pytorch-cpu" }]
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", branch = "main" }
+# Pinned to PR #22 head (fix for issue #415: mpi4py auto-init aborts in PyTorch
+# DataLoader spawn-workers). Revert to branch = "main" once the PR merges upstream.
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?branch=main#e4c9b7aa3ffa96fae0054b92ea6629996dbd5f23" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6#60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.7"
+version = "3.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?branch=main" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?branch=main" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary

Fixes #415. DLIO PyTorch DataLoader workers were aborting at the start of epoch 1 with `MPI_Init_thread` on a NULL communicator whenever `reader.read_threads > 0` (retinanet_b200, unet3d_*, etc.).

Root cause lives in `dlio_benchmark`, not here:

- `dlio_benchmark/utils/statscounter.py:29` does `from mpi4py import MPI` at module top level.
- `dlio_benchmark/utils/utility.py:176` has a comment documenting that auto-init is unsafe for spawn-context workers, but the `mpi4py.rc.initialize` / `rc.finalize` flags that actually disable auto-init were never set.
- With the default `mpi4py.rc.initialize == True`, every spawn-context DataLoader child re-imports `statscounter`, triggers `MPI_Init_thread()` outside `mpirun`'s PMIX namespace, and aborts with `No permission (-17)`.

The upstream fix is mlcommons/DLIO_local_changes#22 (+2 lines). This PR re-pins our `dlio-benchmark` source from `branch = "main"` to `rev = 60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6` (PR #22 head) so storage picks up the fix immediately. The lockfile is regenerated to match.

## Changes

- `pyproject.toml`: switch dlio-benchmark source from `branch = "main"` → `rev = <PR #22 head SHA>`.
- `uv.lock`: regenerated via `uv lock --upgrade-package dlio-benchmark`.

## Follow-up

Once mlcommons/DLIO_local_changes#22 merges to `main`, revert this file change back to `branch = "main"` and re-lock.

## Test plan

- [x] `uv sync` succeeds on a fresh checkout
- [x] `mlpstorage training run --model retinanet -g b200 -na 8 ...` no longer aborts with `MPI_Init_thread on a NULL communicator`
- [x] `mlpstorage training run --model unet3d` (which uses `read_threads: 4`) completes epoch 1
- [x] No regression in existing unit tests: `pytest tests/unit -v`