### PR TITLE
Restrict closed/open training workloads to {unet3d, retinanet} (depends on #432)

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ The essence of OPEN division results is that for a given benchmark area, they ar
 
 Changes to DLIO itself are allowed in OPEN division submissions.  Any changes to DLIO code or command line options must be disclosed. 
 
-While changes to DLIO are allowed, changing the workload itself is not.  Ie: how the workload is processed can be changed, but those changes cannot fundamentally change the purpose and result of the training.  For example, changing the workload imposed upon storage by a ResNet-50 training task into 3D-Unet training task is not allowed.
+While changes to DLIO are allowed, changing the workload itself is not.  Ie: how the workload is processed can be changed, but those changes cannot fundamentally change the purpose and result of the training.  For example, changing the workload imposed upon storage by a RetinaNet training task into a 3D-Unet training task is not allowed.
 
 ### System Description YAML - Structured Description
 

--- a/Rules.md
+++ b/Rules.md
@@ -82,7 +82,7 @@ configuration of storage system and to link together those results with the .pdf
 
 2.1.10. **workloadCategories** --  Within a *system name* directory in the "results" directory, there must be one or both of the following directories, and nothing else: "training", and/or "checkpointing".  These names are case-sensitive.
 
-2.1.11. **trainingWorkloads** --  Within the "training" directory, there must be one or more of the following *workload directories*, and nothing else: "unet3d", "resnet50" and/or "cosmoflow".  These names are case-sensitive.
+2.1.11. **trainingWorkloads** --  Within the "training" directory, there must be one or more of the following *workload directories*, and nothing else: "unet3d" and/or "retinanet".  These names are case-sensitive.
 
 2.1.12. **trainingPhases** --  Within the *workload directories* in the "training" hierarchy, there must exist *phase directories* named "datagen" and "run", and nothing else.  These names are case-sensitive.
 
@@ -134,18 +134,7 @@ root_folder (or any name you prefer)
 │	  	│		│	│		... (5x Runs per Emulated Accelerator Type)
 │	  	│		│	│		└── YYYYMMDD_HHmmss
 │	  	│		│	│			└── dlio_config
-│	  	│	 	│	├── resnet50
-│	  	│		│	│	├── datagen
-│	  	│		│	│	│	└── YYYYMMDD_HHmmss
-│	  	│		│	│	│		└── dlio_config
-│	  	│		│	│	└── run
-│	  	│		│	│		├──results.json
-│	  	│		│	│		├── YYYYMMDD_HHmmss
-│	  	│		│	│		│	└── dlio_config 
-│	  	│		│	│		... (5x Runs per Emulated Accelerator Type)
-│	  	│		│	│		└── YYYYMMDD_HHmmss
-│	  	│		│	│			└── dlio_config
-│	  	│	 	│	└── cosmoflow
+│	  	│	 	│	└── retinanet
 │	  	│		│	 	├── datagen
 │	  	│		│	 	│	└── YYYYMMDD_HHmmss
 │	  	│		│	 	│		└── dlio_config
@@ -227,18 +216,7 @@ root_folder (or any name you prefer)
 		│		│	│		... (5x Runs per Emulated Accelerator Type)
 		│		│	│		└── YYYYMMDD_HHmmss
 		│		│	│			└── dlio_config
-		│	 	│	├── resnet50
-		│		│	│	├── datagen
-		│		│	│	│	└── YYYYMMDD_HHmmss
-		│		│	│	│		└── dlio_config
-		│		│	│	└── run
-		│		│	|		├──results.json
-		│		│	│		├── YYYYMMDD_HHmmss
-		│		│	│		│	└── dlio_config 
-		│		│	│		... (5x Runs per Emulated Accelerator Type)
-		│		│	│		└── YYYYMMDD_HHmmss
-		│		│	│			└── dlio_config
-		│	 	│	└── cosmoflow
+		│	 	│	└── retinanet
 		│		│	 	├── datagen
 		│		│	 	│	└── YYYYMMDD_HHmmss
 		│		│	 	│		└── dlio_config

--- a/mlpstorage_py/reporting/directory_validator.py
+++ b/mlpstorage_py/reporting/directory_validator.py
@@ -38,7 +38,7 @@ class ResultsDirectoryValidator:
     Expected structure:
     results_dir/
         <benchmark_type>/           # training, checkpointing, vector_database, kv_cache
-            <model>/                # unet3d, resnet50, llama3-8b, etc.
+            <model>/                # unet3d, retinanet, llama3-8b, etc.
                 <command>/          # run, datagen (for training)
                     <datetime>/     # YYYYMMDD_HHMMSS format
                         *_metadata.json

--- a/mlpstorage_py/rules/submission_checkers/training.py
+++ b/mlpstorage_py/rules/submission_checkers/training.py
@@ -6,7 +6,7 @@ Validates training benchmark submissions (multiple runs).
 
 from typing import Optional
 
-from mlpstorage_py.config import MODELS, PARAM_VALIDATION
+from mlpstorage_py.config import MODELS_CLOSED, PARAM_VALIDATION
 from mlpstorage_py.rules.issues import Issue
 from mlpstorage_py.rules.submission_checkers.base import MultiRunRulesChecker
 
@@ -14,7 +14,9 @@ from mlpstorage_py.rules.submission_checkers.base import MultiRunRulesChecker
 class TrainingSubmissionRulesChecker(MultiRunRulesChecker):
     """Rules checker for training benchmark submissions."""
 
-    supported_models = MODELS
+    # Rules.md 2.1.11 trainingWorkloads — closed/open submissions accept
+    # only {unet3d, retinanet}.
+    supported_models = MODELS_CLOSED
     REQUIRED_RUNS = 5
 
     def check_num_runs(self) -> Optional[Issue]:

--- a/mlpstorage_py/rules_legacy.py
+++ b/mlpstorage_py/rules_legacy.py
@@ -1797,7 +1797,7 @@ def generate_output_location(benchmark, datetime_str=None, **kwargs):
         benchmark (Benchmark): benchmark (e.g., 'training', 'vectordb', 'checkpoint')
         datetime_str (str, optional): Datetime string for the run. If None, current datetime is used.
         **kwargs: Additional benchmark-specific parameters:
-            - model (str): For training benchmarks, the model name (e.g., 'unet3d', 'resnet50')
+            - model (str): For training benchmarks, the model name (e.g., 'unet3d', 'retinanet')
             - category (str): For vectordb benchmarks, the category (e.g., 'throughput', 'latency')
 
     Returns:

--- a/mlpstorage_py/submission_checker/checks/submission_structure_checks.py
+++ b/mlpstorage_py/submission_checker/checks/submission_structure_checks.py
@@ -45,7 +45,7 @@ _REQUIRED_SUBMITTER_SUBDIRS = frozenset({"code", "results", "systems"})
 _VALID_WORKLOAD_CATEGORIES = frozenset({"training", "checkpointing"})
 
 # Valid training workload names under training/
-_VALID_TRAINING_WORKLOADS = frozenset({"unet3d", "resnet50", "cosmoflow"})
+_VALID_TRAINING_WORKLOADS = frozenset({"unet3d", "retinanet"})
 
 # Valid training phase directories under training/<workload>/
 _VALID_TRAINING_PHASES = frozenset({"datagen", "run"})
@@ -726,7 +726,7 @@ class SubmissionStructureCheck(BaseCheck):
 
     @rule("2.1.11", "trainingWorkloads")
     def training_workloads_check(self):
-        """STRUCT-11: training/ must contain only {unet3d, resnet50, cosmoflow}."""
+        """STRUCT-11: training/ must contain only {unet3d, retinanet}."""
         valid = True
         for _division, _submitter, sub_path in self._iter_submitter_dirs():
             results_path = os.path.join(sub_path, "results")
@@ -744,7 +744,7 @@ class SubmissionStructureCheck(BaseCheck):
                             "2.1.11", "trainingWorkloads",
                             os.path.join(training_path, workload),
                             "unknown training workload %r "
-                            "(valid: unet3d, resnet50, cosmoflow)",
+                            "(valid: unet3d, retinanet)",
                             workload,
                         )
                         valid = False

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -254,7 +254,7 @@ class TrainingCheck(BaseCheck):
 
         # Resolve expected dataset cardinalities up front. Returns None if
         # the workload directory name does not match a known model
-        # ({unet3d, resnet50, cosmoflow}); 2.1.11 trainingWorkloads already
+        # ({unet3d, retinanet}); 2.1.11 trainingWorkloads already
         # flags the structural complaint for the non-conforming name, so
         # skip the cardinality cross-check rather than crash on the dict
         # lookup or on a None comparison below.
@@ -264,7 +264,7 @@ class TrainingCheck(BaseCheck):
             self.log.info(
                 "[3.3.1 trainingRunDataMatchesDatasize] %s: skipping "
                 "cardinality cross-check — workload %r is not in known "
-                "models {unet3d, resnet50, cosmoflow}; see 2.1.11 violation "
+                "models {unet3d, retinanet}; see 2.1.11 violation "
                 "for the structural complaint",
                 self.path, self.model,
             )

--- a/mlpstorage_py/submission_checker/configuration/configuration.py
+++ b/mlpstorage_py/submission_checker/configuration/configuration.py
@@ -39,7 +39,7 @@ class Config:
         # .get returns None for unknown model names — the caller decides
         # whether the per-model lookup is critical (skip with a diagnostic)
         # or expected to always resolve. Non-conforming workload directory
-        # names (e.g. "unet3d_a100", "cosmoflow-20N-6PPN-A100") flagged by
+        # names (e.g. "unet3d_a100", "retinanet-20N-6PPN-A100") flagged by
         # 2.1.11 trainingWorkloads would otherwise crash this dict lookup.
         return NUM_DATASET_TRAIN_FILES.get(model)
 

--- a/mlpstorage_py/submission_checker/constants.py
+++ b/mlpstorage_py/submission_checker/constants.py
@@ -99,27 +99,23 @@ CHECKPOINT_REQUIRED_FOLDERS = {
 
 # TODO: Ask for correct values
 NUM_DATASET_TRAIN_FILES = {
-    "cosmoflow": 524288,
-    "resnet50": 10391,
-    "unet3d": 14000
+    "unet3d": 14000,
+    "retinanet": 0
 }
 
 NUM_DATASET_EVAL_FILES = {
-    "cosmoflow": 0,
-    "resnet50": 0,
-    "unet3d": 0
+    "unet3d": 0,
+    "retinanet": 0
 }
 
 NUM_DATASET_TRAIN_FOLDERS = {
-    "cosmoflow": 0,
-    "resnet50": 0,
-    "unet3d": 0
+    "unet3d": 0,
+    "retinanet": 0
 }
 
 NUM_DATASET_EVAL_FOLDERS = {
-    "cosmoflow": 0,
-    "resnet50": 0,
-    "unet3d": 0
+    "unet3d": 0,
+    "retinanet": 0
 }
 
 CHECKPOINT_FILE_MAP = {

--- a/mlpstorage_py/validation_helpers.py
+++ b/mlpstorage_py/validation_helpers.py
@@ -135,7 +135,7 @@ def _validate_required_params(args) -> List[Exception]:
             errors.append(ConfigurationError(
                 "Missing required parameter: model",
                 parameter="model",
-                suggestion="Specify --model (cosmoflow, resnet50, or unet3d)",
+                suggestion="Specify --model (unet3d or retinanet)",
                 code=ErrorCode.CONFIG_MISSING_REQUIRED
             ))
 

--- a/tests/unit/test_rules_checkers.py
+++ b/tests/unit/test_rules_checkers.py
@@ -766,14 +766,16 @@ class TestTrainingSubmissionRulesChecker:
 
     def test_supported_models_includes_training_models(self, mock_logger):
         """TrainingSubmissionRulesChecker has correct supported models."""
-        from mlpstorage_py.config import MODELS
+        from mlpstorage_py.config import MODELS_CLOSED
 
         # Create empty checker to check class attribute
         checker = TrainingSubmissionRulesChecker([], logger=mock_logger)
 
+        # Rules.md 2.1.11 — closed/open accept only {unet3d, retinanet}.
         assert 'unet3d' in checker.supported_models
-        assert 'resnet50' in checker.supported_models
-        assert 'cosmoflow' in checker.supported_models
+        assert 'retinanet' in checker.supported_models
+        assert 'resnet50' not in checker.supported_models
+        assert 'cosmoflow' not in checker.supported_models
 
 
 class TestTrainingParquetFormat:


### PR DESCRIPTION
## Summary

Update the official training-workload set for closed/open submission from `{unet3d, resnet50, cosmoflow}` to `{unet3d, retinanet}` (Rules.md 2.1.11). Propagate the new set through the runtime validator, submission validator, dataset constants, error suggestions, result directory examples, and unit tests.

The `whatif` exploration mode is **unchanged** and still accepts the full superset: `unet3d, retinanet, cosmoflow, resnet50, dlrm, flux`.

## Dependency

**This PR depends on #432** and is stacked on top of `FileSystemGuy-rules-validator`. The base will be retargeted to `main` once #432 merges. Reviewing now: please review only the diff specific to this PR (the GitHub UI will show this automatically while #432 is open).

Marked **draft** until #432 is merged.

## Changes

- `Rules.md` — 2.1.11 text rule + Closed/Open result tree examples reduced to the two-workload set.
- `mlpstorage_py/submission_checker/`
  - `constants.py`: `NUM_DATASET_{TRAIN,EVAL}_{FILES,FOLDERS}` keyed by `{unet3d, retinanet}`.
  - `checks/submission_structure_checks.py`: `_VALID_TRAINING_WORKLOADS`, STRUCT-11 docstring, violation message.
  - `checks/training_checks.py` (3.3.1): updated comments / skip-diagnostic message.
  - `configuration/configuration.py`: updated comment example.
- `mlpstorage_py/rules/submission_checkers/training.py`: `supported_models = MODELS_CLOSED` (was `MODELS`, the whatif superset).
- `mlpstorage_py/validation_helpers.py`: `--model` suggestion now mentions `(unet3d or retinanet)`.
- `mlpstorage_py/reporting/directory_validator.py`: example workload list.
- `mlpstorage_py/rules_legacy.py`: docstring example.
- `tests/unit/test_rules_checkers.py`: updated `TrainingSubmissionRulesChecker.supported_models` test to assert the new closed/open set and explicitly reject `resnet50`/`cosmoflow`.

## Out of scope (intentionally unchanged)

- `MODELS = [cosmoflow, resnet50, unet3d, dlrm, retinanet, flux]` constant — still the full whatif superset.
- `whatif` CLI choices and the whatif test parameterizations.
- `training/README.md` and the top-level `README.md` — already reflect the new set.

## Test plan

- [x] `pytest tests/unit` against changed-area suites: 257 passed (rules_checkers, config, validation_helpers, cli_parser, parser_modes, help_behavior).
- [x] Full unit-test pass (skipping modules requiring `pyarrow`/`numpy` not installed locally): 1172 passed, 2 skipped, 1 unrelated pre-existing failure (`test_version_lookup_uses_correct_distribution_name` — needs `pip install -e .`).
- [ ] CI to re-run on full env.
- [ ] Manual: run `mlpstorage closed training --help` → shows `unet3d | retinanet`; `mlpstorage whatif training --help` → still shows all six.