### PR TITLE
docs (vdb_benchmark): restructure README for new-user clarity

### DIFF
--- a/vdb_benchmark/README.md
+++ b/vdb_benchmark/README.md
@@ -1,84 +1,101 @@
 # Vector Database Benchmark Tool
 
-This tool benchmarks and compares vector database performance for MLPerf Storage,
-with current support for Milvus using DiskANN, HNSW, AISAQ, FLAT, and IVF-style
-indexes.
+Benchmarks and compares vector database performance for MLPerf Storage. Currently
+supports Milvus with DiskANN, HNSW, AISAQ, FLAT, and IVF-style indexes.
 
-The benchmark can be run in two ways:
+> **Preview Status:** The VectorDB benchmark is in preview. All runs qualify for
+> OPEN category only. Pass `--open` to acknowledge this.
 
-1. Directly with the scripts in `vdb_benchmark/vdbbench/`
-2. Through the MLPerf Storage CLI with `./mlpstorage vectordb`
-
-The `mlpstorage` path is recommended for standard benchmark workflows.
+> **Modular Runner (Preview):** A backend-agnostic runner is available as a
+> standalone preview via `python -m vdbbench.benchmark`. The `./mlpstorage vectordb`
+> command continues to use the Milvus-oriented scripts until the modular runner is
+> integrated.
 
 ---
 
-> The modular backend-agnostic runner is currently a standalone preview.
-> It is invoked with `python -m vdbbench.benchmark`.
-> The existing `./mlpstorage vectordb` command continues to use the Milvus-oriented scripts until the modular runner is integrated.
+## Table of Contents
 
-## Installation
+- [1. Prerequisites](#1-prerequisites)
+- [2. Deploy Milvus](#2-deploy-milvus)
+  - [Option A: Local Storage with MinIO](#option-a-local-storage-with-minio)
+  - [Option B: S3 Storage](#option-b-s3-storage)
+- [3. Quick Start — First Benchmark in 10 Minutes](#3-quick-start--first-benchmark-in-10-minutes)
+- [4. Recommended Path: mlpstorage CLI](#4-recommended-path-mlpstorage-cli)
+  - [4.1 Installation](#41-installation)
+  - [4.2 Estimate Storage (datasize)](#42-estimate-storage-datasize)
+  - [4.3 Load Vectors (datagen)](#43-load-vectors-datagen)
+  - [4.4 Compact](#44-compact)
+  - [4.5 Run Benchmarks](#45-run-benchmarks)
+  - [4.6 View Results](#46-view-results)
+- [5. Alternative Path: Direct Scripts](#5-alternative-path-direct-scripts)
+  - [5.1 Installation](#51-installation)
+  - [5.2 Load Vectors](#52-load-vectors)
+  - [5.3 Compact](#53-compact)
+  - [5.4 Run Simple Benchmark](#54-run-simple-benchmark)
+  - [5.5 Run Enhanced Benchmark](#55-run-enhanced-benchmark)
+- [6. CLI Reference](#6-cli-reference)
+  - [Important Terminology](#important-terminology)
+  - [Config Files](#config-files)
+  - [Dimension Consistency](#dimension-consistency)
+- [7. Distributed Execution (Multi-Node)](#7-distributed-execution-multi-node)
+  - [7.1 Prerequisites](#71-prerequisites)
+  - [7.2 Distributed Load](#72-distributed-load)
+  - [7.3 Distributed Simple Benchmark](#73-distributed-simple-benchmark)
+  - [7.4 Distributed Enhanced / Sweep Benchmark](#74-distributed-enhanced--sweep-benchmark)
+  - [7.5 Metrics Aggregation](#75-metrics-aggregation)
+  - [7.6 Disk I/O Deduplication](#76-disk-io-deduplication)
+  - [7.7 Ground Truth and Recall](#77-ground-truth-and-recall)
+  - [7.8 Open MPI Alternative](#78-open-mpi-alternative)
+- [8. End-to-End Examples](#8-end-to-end-examples)
+- [9. Enhanced Benchmark Full Reference](#9-enhanced-benchmark-full-reference)
+- [10. Metrics and Measurement](#10-metrics-and-measurement)
+- [11. Testing and Validation](#11-testing-and-validation)
+- [12. Troubleshooting](#12-troubleshooting)
+- [13. Contributing](#13-contributing)
 
-### Clone the repository
+---
+
+## 1. Prerequisites
+
+### System Requirements
+
+| Requirement | Version | Notes |
+|-------------|---------|-------|
+| Python | 3.12+ | Required |
+| Docker & Docker Compose | Latest | For running Milvus |
+| Git | Any | To clone the repository |
+| `uv` | Latest | Recommended package manager |
+| MPI (MPICH or OpenMPI) | Any | Only for distributed/multi-node runs |
+
+### Python Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `pymilvus` | Milvus client |
+| `numpy` | Vector generation and recall math |
+| `pyyaml` | YAML config support |
+| `tabulate` | Collection info table display |
+| `pandas` | Latency/statistics aggregation |
+
+The `datasize` command does not require Milvus or `pymilvus`. Load and run
+commands require a running Milvus server.
+
+### Clone the Repository
 
 ```bash
 git clone https://github.com/mlcommons/storage.git
 cd storage
 ```
 
-### Setup a virtual environment
-
-The Python environment can be set up with the repository's environment setup
-scripts, or through `uv`.
-
-### Manual installation
-
-```bash
-cd storage/vdb_benchmark
-
-# For development, use editable installation.
-pip3 install -e ./
-```
-
-### Installation via `mlpstorage` recommended
-
-From the repository root:
-
-```bash
-cd storage
-
-# Install MLPerf Storage with VectorDB dependencies.
-uv sync --extra vectordb
-
-# Install the vdbbench package into the uv-managed environment.
-uv pip install -e ./vdb_benchmark
-```
-
-This makes the following commands available in the same locked environment:
-
-```bash
-./mlpstorage vectordb --help
-uv run load-vdb --help
-uv run vdbbench --help
-uv run enhanced-bench --help
-uv run vdb-mpi-wrapper --help
-uv run vdb-aggregate --help
-```
-
-The distributed VectorDB launcher requires the new console scripts:
-
-```text
-vdb-mpi-wrapper
-vdb-aggregate
-```
-
-These are installed from `vdb_benchmark/pyproject.toml`.
-
 ---
 
-## Deploying a Standalone Milvus Instance
+## 2. Deploy Milvus
 
-Standalone Milvus stacks are available in the `stacks` directory.
+A running Milvus instance is required for all load (`datagen`) and benchmark
+(`run`) commands. This section applies to both the mlpstorage CLI and direct
+script paths.
+
+Standalone Milvus stacks are available in the `stacks` directory:
 
 ```text
 stacks/
@@ -96,30 +113,24 @@ stacks/
 For each specific instance, copy the `.env.example` file to `.env` and update
 the values as needed.
 
+### Option A: Local Storage with MinIO
+
 ```bash
 cp stacks/milvus/standalone/minio/.env.example \
    stacks/milvus/standalone/minio/.env
 ```
 
-### Local Storage — MinIO
+The compose file uses `/mnt/vdb` as the root directory for Docker volumes. Set
+`DOCKER_VOLUME_DIRECTORY` in the `.env` file or edit the compose file to point to
+your target storage location.
 
-The configuration file:
-
-```text
-stacks/milvus/standalone/minio/docker-compose.yml
-```
-
-creates a 3-container Milvus stack using local storage:
+The stack creates three containers:
 
 * Milvus database
 * MinIO object storage
 * etcd metadata store
 
-The compose file uses `/mnt/vdb` as the root directory for Docker volumes. Set
-`DOCKER_VOLUME_DIRECTORY` or edit the compose file to point to your target
-storage location.
-
-Start the container:
+Start:
 
 ```bash
 docker compose -f stacks/milvus/standalone/minio/docker-compose.yml up -d
@@ -131,29 +142,16 @@ or:
 docker-compose -f stacks/milvus/standalone/minio/docker-compose.yml up -d
 ```
 
-Check that Milvus is healthy:
+### Option B: S3 Storage
+
+Copy and configure environment (fill in your S3 credentials):
 
 ```bash
-docker ps -a
+cp stacks/milvus/standalone/s3/.env.example \
+   stacks/milvus/standalone/s3/.env
 ```
 
-The default Milvus endpoint is:
-
-```text
-127.0.0.1:19530
-```
-
-### S3 Storage
-
-The configuration file:
-
-```text
-stacks/milvus/standalone/s3/docker-compose-s3.yml
-```
-
-creates a Milvus stack using external S3-compatible object storage.
-
-Start the container:
+Start:
 
 ```bash
 docker compose -f stacks/milvus/standalone/s3/docker-compose-s3.yml up -d
@@ -165,9 +163,512 @@ or:
 docker-compose -f stacks/milvus/standalone/s3/docker-compose-s3.yml up -d
 ```
 
+### Verify Milvus is Healthy
+
+```bash
+docker ps -a
+```
+
+All three containers (`milvus-etcd`, `milvus-minio`, `milvus-standalone`) should
+show healthy/running.
+
+The default Milvus endpoint is:
+
+```text
+127.0.0.1:19530
+```
+
+> **Note:** All `stacks/` paths above are relative to the `vdb_benchmark/`
+> directory. If running from the repository root (`storage/`), prefix with
+> `vdb_benchmark/` (e.g., `vdb_benchmark/stacks/milvus/standalone/minio/...`).
+
 ---
 
-## Important CLI Terminology
+## 3. Quick Start — First Benchmark in 10 Minutes
+
+This section gets you from zero to a working benchmark result on a single machine.
+Every command is copy-paste ready. Assumes you have already deployed Milvus
+([Section 2](#2-deploy-milvus)).
+
+### Step 1 — Install
+
+```bash
+cd storage
+uv sync --extra vectordb
+uv pip install -e ./vdb_benchmark
+```
+
+Verify:
+
+```bash
+./mlpstorage vectordb --help
+```
+
+### Step 2 — Start Milvus
+
+```bash
+cp vdb_benchmark/stacks/milvus/standalone/minio/.env.example \
+   vdb_benchmark/stacks/milvus/standalone/minio/.env
+
+docker compose -f vdb_benchmark/stacks/milvus/standalone/minio/docker-compose.yml up -d
+```
+
+Wait for healthy status:
+
+```bash
+docker ps -a
+```
+
+All three containers (`milvus-etcd`, `milvus-minio`, `milvus-standalone`) should
+show healthy/running. The default endpoint is `127.0.0.1:19530`.
+
+### Step 3 — Load 50K vectors (smoke test)
+
+```bash
+./mlpstorage vectordb datagen \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config default \
+  --collection mlps_smoke \
+  --num-vectors 50000 \
+  --dimension 1536 \
+  --num-shards 1 \
+  --force \
+  --results-dir /tmp/vdb_results
+```
+
+### Step 4 — Run a 30-second benchmark
+
+```bash
+./mlpstorage vectordb run \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config default \
+  --collection mlps_smoke \
+  --mode timed \
+  --runtime 30 \
+  --num-query-processes 2 \
+  --batch-size 10 \
+  --results-dir /tmp/vdb_results
+```
+
+### Step 5 — Check results
+
+```bash
+python - <<'PY'
+import json
+from pathlib import Path
+
+stats_files = sorted(
+    Path("/tmp/vdb_results").glob("**/vectordb/simple/statistics.json")
+)
+assert stats_files, "No statistics.json found"
+
+stats = json.loads(stats_files[-1].read_text())
+print(f"Throughput: {stats['throughput_qps']:.1f} QPS")
+print(f"P95 latency: {stats['p95_latency_ms']:.2f} ms")
+print(f"Total queries: {stats['total_queries']}")
+PY
+```
+
+If you see QPS and latency numbers, your setup is working. Continue to
+[Section 4](#4-recommended-path-mlpstorage-cli) for full documentation.
+
+---
+
+## 4. Recommended Path: mlpstorage CLI
+
+This section covers the complete workflow using the `mlpstorage` CLI. This is the
+recommended approach for standard benchmark workflows.
+
+### 4.1 Installation
+
+From the repository root:
+
+```bash
+cd storage
+
+# Install MLPerf Storage with VectorDB dependencies.
+uv sync --extra vectordb
+
+# Install the vdbbench package into the uv-managed environment.
+uv pip install -e ./vdb_benchmark
+```
+
+This makes the following commands available:
+
+```bash
+./mlpstorage vectordb --help
+./mlpstorage vectordb datasize --help
+./mlpstorage vectordb datagen --help
+./mlpstorage vectordb run --help
+```
+
+The distributed VectorDB launcher additionally provides:
+
+```text
+vdb-mpi-wrapper
+vdb-aggregate
+```
+
+These are installed from `vdb_benchmark/pyproject.toml`.
+
+Verify installation:
+
+```bash
+uv run vdb-mpi-wrapper --help
+uv run vdb-aggregate --help
+```
+
+---
+
+### 4.2 Estimate Storage (datasize)
+
+This step is optional. It is pure math and does not require a running Milvus
+instance.
+
+```bash
+./mlpstorage vectordb datasize \
+  --file \
+  --open \
+  --dimension 1536 \
+  --num-vectors 10000000 \
+  --index-type DISKANN \
+  --num-shards 10
+```
+
+Example output:
+
+```text
+Vectors: 10,000,000 x dim=1536 x 4B
+Raw data: 61.44 GB
+Index type: DISKANN (130% overhead)
+Shards: 10
+Estimated total: 798.72 GB
+```
+
+---
+
+### 4.3 Load Vectors (datagen)
+
+#### Load using the default config (1M vectors)
+
+```bash
+./mlpstorage vectordb datagen \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config default \
+  --collection mlps_1m_1536dim_uniform_diskann \
+  --force \
+  --results-dir /tmp/vdb_results
+```
+
+#### Load using the 10M config
+
+```bash
+./mlpstorage vectordb datagen \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config 10m \
+  --collection mlps_10m_1536dim_uniform_diskann \
+  --force \
+  --results-dir /tmp/vdb_results
+```
+
+#### Override vector count for quick testing
+
+```bash
+./mlpstorage vectordb datagen \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config default \
+  --collection mlps_smoke_50k \
+  --num-vectors 50000 \
+  --dimension 1536 \
+  --num-shards 1 \
+  --force \
+  --results-dir /tmp/vdb_results
+```
+
+#### Notes
+
+- The `--config` argument refers to YAML files in `configs/vectordbbench/`
+  without the `.yaml` extension.
+- The `--force` flag drops and recreates the collection if it already exists.
+- See [Dimension Consistency](#dimension-consistency) for important rules about
+  keeping dimensions aligned between load and run.
+
+---
+
+### 4.4 Compact
+
+The load script performs compaction automatically when enabled in the config or
+when `--compact` is passed.
+
+Compaction runs as part of the `datagen` workflow. No separate command is needed
+unless the load command exits early. See
+[Section 5.3](#53-compact) for manual compaction if needed.
+
+---
+
+### 4.5 Run Benchmarks
+
+#### Simple benchmark modes
+
+| `mlpstorage` mode | Script | Purpose |
+|-------------------|--------|---------|
+| `timed` | `vdbbench` | Run for a fixed duration |
+| `query_count` | `vdbbench` | Run exactly N total queries |
+
+##### Timed mode
+
+```bash
+./mlpstorage vectordb run \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config default \
+  --collection mlps_1m_1536dim_uniform_diskann \
+  --mode timed \
+  --runtime 120 \
+  --num-query-processes 4 \
+  --batch-size 10 \
+  --report-count 100 \
+  --results-dir /tmp/vdb_results
+```
+
+##### Query-count mode
+
+```bash
+./mlpstorage vectordb run \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config default \
+  --collection mlps_1m_1536dim_uniform_diskann \
+  --mode query_count \
+  --queries 10000 \
+  --num-query-processes 4 \
+  --batch-size 10 \
+  --report-count 100 \
+  --results-dir /tmp/vdb_results
+```
+
+#### Enhanced benchmark / sweep mode
+
+Use enhanced mode for:
+
+* parameter sweeps
+* warm/cold cache comparisons
+* recall-target optimization
+* richer disk and memory reporting
+* comparing index/search configurations
+
+Enhanced mode is selected with `--mode sweep`:
+
+```bash
+./mlpstorage vectordb run \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config default \
+  --collection mlps_1m_1536dim_uniform_diskann \
+  --mode sweep \
+  --queries 10000 \
+  --num-query-processes 4 \
+  --results-dir /tmp/vdb_results
+```
+
+---
+
+### 4.6 View Results
+
+```bash
+./mlpstorage history show
+```
+
+---
+
+## 5. Alternative Path: Direct Scripts
+
+This section covers the complete workflow using the Python scripts directly,
+without the `mlpstorage` CLI wrapper.
+
+### 5.1 Installation
+
+```bash
+cd storage/vdb_benchmark
+
+# For development, use editable installation.
+pip3 install -e ./
+```
+
+Or with `uv`:
+
+```bash
+cd storage
+uv pip install -e ./vdb_benchmark
+```
+
+Verify:
+
+```bash
+uv run load-vdb --help
+uv run vdbbench --help
+uv run enhanced-bench --help
+```
+
+**Note:** You still need a running Milvus instance. Follow the Docker setup
+in [Section 2](#2-deploy-milvus).
+
+---
+
+### 5.2 Load Vectors
+
+#### Load using a YAML config
+
+```bash
+python vdbbench/load_vdb.py \
+  --config vdbbench/configs/10m_diskann.yaml
+```
+
+Or via the console script:
+
+```bash
+uv run load-vdb \
+  --config vdbbench/configs/10m_diskann.yaml
+```
+
+#### Load with overrides for quick testing
+
+```bash
+python vdbbench/load_vdb.py \
+  --config vdbbench/configs/10m_diskann.yaml \
+  --collection-name mlps_500k_10shards_1536dim_uniform_diskann \
+  --num-vectors 500000
+```
+
+#### Key parameters
+
+```text
+--collection-name
+--dimension
+--num-vectors
+--chunk-size
+--distribution
+--batch-size
+```
+
+#### Config file location
+
+Direct script configs live in:
+
+```text
+vdb_benchmark/vdbbench/configs/
+├── 10m_diskann.yaml       (10M vectors, 10 shards, 1536 dim)
+├── 10m_hnsw.yaml
+├── 1m_diskann.yaml        (1M vectors, 1 shard, 1536 dim)
+├── 1m_diskann_512dim.yaml
+├── 1m_hnsw.yaml
+└── 1m_aisaq_512dim.yaml
+```
+
+---
+
+### 5.3 Compact
+
+The load script performs compaction automatically when enabled in the config or
+when `--compact` is passed.
+
+If the load command exits early, run compaction manually:
+
+```bash
+python vdbbench/compact_and_watch.py \
+  --config vdbbench/configs/10m_diskann.yaml \
+  --interval 5
+```
+
+Or via the console script:
+
+```bash
+uv run compact-and-watch \
+  --config vdbbench/configs/10m_diskann.yaml \
+  --interval 5
+```
+
+---
+
+### 5.4 Run Simple Benchmark
+
+```bash
+python vdbbench/simple_bench.py \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --collection-name mlps_1m_1536dim_uniform_diskann \
+  --processes 4 \
+  --batch-size 10 \
+  --runtime 120 \
+  --output-dir /tmp/vdbbench_results
+```
+
+Or via the console script:
+
+```bash
+uv run vdbbench \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --collection-name mlps_1m_1536dim_uniform_diskann \
+  --processes 4 \
+  --batch-size 10 \
+  --runtime 120 \
+  --output-dir /tmp/vdbbench_results
+```
+
+---
+
+### 5.5 Run Enhanced Benchmark
+
+```bash
+uv run enhanced-bench \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --collection mlps_1m_1536dim_uniform_diskann \
+  --sweep \
+  --queries 10000 \
+  --processes 4 \
+  --out-dir /tmp/vdbbench_results
+```
+
+See [Section 9](#9-enhanced-benchmark-full-reference) for full parameter
+reference and execution paths.
+
+---
+
+## 6. CLI Reference
+
+### Available Commands
+
+```bash
+./mlpstorage vectordb --help
+./mlpstorage vectordb datasize --help
+./mlpstorage vectordb datagen --help
+./mlpstorage vectordb run --help
+```
+
+### Important Terminology
 
 VectorDB uses two similar-looking host flags with different meanings.
 
@@ -182,9 +683,7 @@ VectorDB uses two similar-looking host flags with different meanings.
 | `--open` | Acknowledge OPEN category execution |
 | `--results-dir` | Root directory for benchmark output |
 
-Do not confuse `--host` and `--hosts`.
-
-Example:
+**Do not confuse `--host` and `--hosts`.**
 
 ```bash
 --host 10.0.0.10        # Milvus server endpoint
@@ -212,142 +711,102 @@ starts:
 2 hosts * 2 MPI ranks per host * 4 Python workers per rank = 16 query workers
 ```
 
----
+### Config Files
 
-## Running the Benchmark
-
-The benchmark workflow has four main steps:
-
-1. Estimate storage requirements
-2. Load vectors
-3. Compact, if needed
-4. Run simple or enhanced benchmark modes
-
----
-
-## Step 0 — Estimate Storage Requirements
-
-This step is optional. It is pure math and does not require a running Milvus
-instance.
-
-```bash
-./mlpstorage vectordb datasize \
-  --file \
-  --open \
-  --dimension 1536 \
-  --num-vectors 10000000 \
-  --index-type DISKANN \
-  --num-shards 10
-```
-
-Example output:
-
-```text
-Vectors: 10,000,000 x dim=1536 x 4B
-Raw data: 61.44 GB
-Index type: DISKANN (130% overhead)
-Shards: 10
-Estimated total: 798.72 GB
-```
-
----
-
-## Step 1 — Load Vectors
-
-### Direct script load
-
-Load vectors directly with the script:
-
-```bash
-python vdbbench/load_vdb.py \
-  --config vdbbench/configs/10m_diskann.yaml
-```
-
-For faster testing with a smaller dataset:
-
-```bash
-python vdbbench/load_vdb.py \
-  --config vdbbench/configs/10m_diskann.yaml \
-  --collection-name mlps_500k_10shards_1536dim_uniform_diskann \
-  --num-vectors 500000
-```
-
-Key parameters:
-
-```text
---collection-name
---dimension
---num-vectors
---chunk-size
---distribution
---batch-size
-```
-
-### Single-node load with `mlpstorage`
-
-Load using the default config:
-
-```bash
-./mlpstorage vectordb datagen \
-  --file \
-  --open \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --config default \
-  --collection mlps_1m_1536dim_uniform_diskann \
-  --force \
-  --results-dir /tmp/vdb_results
-```
-
-Load using the 10M config:
-
-```bash
-./mlpstorage vectordb datagen \
-  --file \
-  --open \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --config 10m \
-  --collection mlps_10m_1536dim_uniform_diskann \
-  --force \
-  --results-dir /tmp/vdb_results
-```
-
-Override vector count for quick testing:
-
-```bash
-./mlpstorage vectordb datagen \
-  --file \
-  --open \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --config default \
-  --collection mlps_smoke_50k \
-  --num-vectors 50000 \
-  --dimension 1536 \
-  --num-shards 1 \
-  --force \
-  --results-dir /tmp/vdb_results
-```
-
-The `--config` argument refers to YAML files in:
+VectorDB `mlpstorage` configs live in:
 
 ```text
 configs/vectordbbench/
 ```
 
-without the `.yaml` extension.
+The `--config` flag takes the filename without `.yaml`.
 
-The `--force` flag drops and recreates the collection if it already exists.
+Example:
+
+```bash
+--config default
+```
+
+loads:
+
+```text
+configs/vectordbbench/default.yaml
+```
+
+Available configs:
+
+| Config | Vectors | Dimension | Shards | Index |
+|--------|---------|-----------|--------|-------|
+| `default` | 1M | 1536 | 1 | DiskANN |
+| `10m` | 10M | 1536 | 10 | DiskANN |
+
+Custom configs can be added to the same directory.
+
+### Dimension Consistency
+
+The vector dimension must be consistent between data loading and benchmarking.
+
+If you override `--dimension` during `datagen`, the config YAML used for `run`
+must specify the same dimension. Otherwise, Milvus will reject queries with a
+vector dimension mismatch.
+
+The safest approach is to use the same `--config` for both `datagen` and `run`,
+or create a dedicated config YAML for non-default dimensions.
 
 ---
 
-## Distributed Load with MPICH
+## 7. Distributed Execution (Multi-Node)
+
+### 7.1 Prerequisites
+
+For multi-node runs:
+
+1. Run `./mlpstorage vectordb ...` from one launcher host.
+2. The launcher host participates in the benchmark.
+3. Passwordless SSH must work from the launcher to all hosts listed in `--hosts`.
+4. The repository path must be identical on every benchmark client host.
+5. The same `uv` environment must be installed on every benchmark client host.
+6. `mpiexec` must be installed and available on every benchmark client host.
+7. The `--results-dir` path must be visible at the same path from every host.
+8. The Milvus endpoint given by `--host` and `--port` must be reachable from
+   every benchmark client host.
+
+#### Install on every benchmark client host
+
+```bash
+cd /path/to/storage
+uv sync --extra vectordb
+uv pip install -e ./vdb_benchmark
+```
+
+#### Verify MPICH launch
+
+```bash
+mpiexec -n 2 -hosts node01,node02 hostname
+```
+
+#### Verify VectorDB package import
+
+```bash
+mpiexec -n 2 -hosts node01,node02 \
+  uv run python -c "import vdbbench; print('vdbbench import ok')"
+```
+
+#### Verify MPI rank detection
+
+```bash
+mpiexec -n 2 -hosts node01,node02 \
+  uv run python -c "from vdbbench.mpi_common import get_mpi_context; print(get_mpi_context())"
+```
+
+---
+
+### 7.2 Distributed Load
 
 Distributed load uses MPI to start one or more VectorDB loader ranks across
 benchmark client hosts.
 
-Rank behavior:
+#### Rank behavior
 
 ```text
 rank 0:
@@ -368,49 +827,7 @@ rank 0:
   aggregate global load metrics
 ```
 
-### Distributed load prerequisites
-
-For multi-node runs:
-
-1. Run `./mlpstorage vectordb ...` from one launcher host.
-2. The launcher host participates in the benchmark.
-3. Passwordless SSH must work from the launcher to all hosts listed in `--hosts`.
-4. The repository path must be identical on every benchmark client host.
-5. The same `uv` environment must be installed on every benchmark client host.
-6. `mpiexec` must be installed and available on every benchmark client host.
-7. The `--results-dir` path must be visible at the same path from every host.
-8. The Milvus endpoint given by `--host` and `--port` must be reachable from
-   every benchmark client host.
-
-Install dependencies on every benchmark client host:
-
-```bash
-cd /path/to/storage
-uv sync --extra vectordb
-uv pip install -e ./vdb_benchmark
-```
-
-Verify MPICH launch before running the benchmark:
-
-```bash
-mpiexec -n 2 -hosts node01,node02 hostname
-```
-
-Verify that each host can import the VectorDB package:
-
-```bash
-mpiexec -n 2 -hosts node01,node02 \
-  uv run python -c "import vdbbench; print('vdbbench import ok')"
-```
-
-Verify MPI rank detection:
-
-```bash
-mpiexec -n 2 -hosts node01,node02 \
-  uv run python -c "from vdbbench.mpi_common import get_mpi_context; print(get_mpi_context())"
-```
-
-### Distributed load command
+#### Command
 
 ```bash
 ./mlpstorage vectordb datagen \
@@ -436,7 +853,7 @@ mpiexec -n 2 -hosts node01,node02 \
   --results-dir /shared/vdb_results
 ```
 
-Example with two MPI ranks per benchmark client host:
+#### Example with two MPI ranks per host
 
 ```bash
 ./mlpstorage vectordb datagen \
@@ -460,16 +877,10 @@ Example with two MPI ranks per benchmark client host:
   --results-dir /shared/vdb_results
 ```
 
-With:
+With `--hosts node01 node02` and `--npernode 2`, the distributed load starts
+four MPI ranks.
 
-```text
---hosts node01 node02
---npernode 2
-```
-
-the distributed load starts four MPI ranks.
-
-### Distributed load output
+#### Output structure
 
 ```text
 /shared/vdb_results/<run_id>/vectordb/load/
@@ -484,7 +895,7 @@ the distributed load starts four MPI ranks.
 └── ...
 ```
 
-Global load metrics:
+#### Global load metrics
 
 ```text
 inserted_vectors
@@ -499,7 +910,7 @@ mpi.missing_ranks
 mpi.partial_failure
 ```
 
-Aggregation rules:
+#### Aggregation rules
 
 ```text
 inserted_vectors = sum(rank inserted vectors)
@@ -509,127 +920,13 @@ vectors_per_second = inserted_vectors / total_time_seconds
 
 ---
 
-## Dimension Consistency
-
-The vector dimension must be consistent between data loading and benchmarking.
-
-If you override `--dimension` during `datagen`, the config YAML used for `run`
-must specify the same dimension. Otherwise, Milvus will reject queries with a
-vector dimension mismatch.
-
-The safest approach is to use the same `--config` for both `datagen` and `run`,
-or create a dedicated config YAML for non-default dimensions.
-
----
-
-## Step 2 — Compact
-
-The load script performs compaction automatically when enabled in the config or
-when `--compact` is passed.
-
-If the load command exits early, run compaction manually:
-
-```bash
-python vdbbench/compact_and_watch.py \
-  --config vdbbench/configs/10m_diskann.yaml \
-  --interval 5
-```
-
-or:
-
-```bash
-uv run compact-and-watch \
-  --config vdbbench/configs/10m_diskann.yaml \
-  --interval 5
-```
-
----
-
-## Step 3 — Run Simple Benchmark Modes
-
-Simple benchmark modes use:
-
-```text
-vdbbench
-```
-
-which maps to:
-
-```text
-vdb_benchmark/vdbbench/simple_bench.py
-```
-
-Simple benchmark modes:
-
-| `mlpstorage` mode | Script | Purpose |
-|-------------------|--------|---------|
-| `timed` | `vdbbench` | Run for a fixed duration |
-| `query_count` | `vdbbench` | Run exactly N total queries |
-
----
-
-## Simple Benchmark — Direct Script
-
-```bash
-python vdbbench/simple_bench.py \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --collection-name mlps_1m_1536dim_uniform_diskann \
-  --processes 4 \
-  --batch-size 10 \
-  --runtime 120 \
-  --output-dir /tmp/vdbbench_results
-```
-
----
-
-## Simple Benchmark — Single Node, Timed Mode with `mlpstorage`
-
-```bash
-./mlpstorage vectordb run \
-  --file \
-  --open \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --config default \
-  --collection mlps_1m_1536dim_uniform_diskann \
-  --mode timed \
-  --runtime 120 \
-  --num-query-processes 4 \
-  --batch-size 10 \
-  --report-count 100 \
-  --results-dir /tmp/vdb_results
-```
-
----
-
-## Simple Benchmark — Single Node, Query-Count Mode with `mlpstorage`
-
-```bash
-./mlpstorage vectordb run \
-  --file \
-  --open \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --config default \
-  --collection mlps_1m_1536dim_uniform_diskann \
-  --mode query_count \
-  --queries 10000 \
-  --num-query-processes 4 \
-  --batch-size 10 \
-  --report-count 100 \
-  --results-dir /tmp/vdb_results
-```
-
----
-
-## Distributed Simple Benchmark with MPICH
+### 7.3 Distributed Simple Benchmark
 
 Distributed simple benchmark mode starts one `vdbbench` instance per MPI rank.
 Each rank writes rank-local CSV, recall, and statistics files. The launcher then
 aggregates the rank outputs.
 
-### Distributed simple timed mode
+#### Timed mode
 
 In timed mode, every MPI rank runs for the requested runtime.
 
@@ -660,7 +957,7 @@ This starts:
 2 hosts * 2 MPI ranks per host * 2 query processes per rank = 8 query workers
 ```
 
-### Distributed simple query-count mode
+#### Query-count mode
 
 In query-count mode, `--queries` is interpreted as the global query count. The
 MPI wrapper splits the query count across ranks.
@@ -696,7 +993,7 @@ starts four MPI ranks, and each rank receives approximately 25,000 queries.
   --results-dir /shared/vdb_results
 ```
 
-### Distributed simple output
+#### Output structure
 
 ```text
 /shared/vdb_results/<run_id>/vectordb/simple/
@@ -717,7 +1014,7 @@ starts four MPI ranks, and each rank receives approximately 25,000 queries.
 └── ...
 ```
 
-Global simple-bench metrics:
+#### Global metrics
 
 ```text
 total_queries
@@ -739,7 +1036,7 @@ disk_io
 mpi
 ```
 
-Aggregation rules:
+#### Aggregation rules
 
 ```text
 global_start_time = min(timestamp)
@@ -764,76 +1061,13 @@ recall_by_query
 
 ---
 
-## Step 4 — Run Enhanced Benchmark / Sweep Mode
-
-Enhanced benchmark mode uses:
-
-```text
-enhanced-bench
-```
-
-which maps to:
-
-```text
-vdb_benchmark/vdbbench/enhanced_bench.py
-```
-
-Use enhanced mode for:
-
-* parameter sweeps
-* warm/cold cache comparisons
-* recall-target optimization
-* richer disk and memory reporting
-* comparing index/search configurations
-
-In `mlpstorage`, enhanced mode is selected with:
-
-```text
---mode sweep
-```
-
----
-
-## Enhanced Benchmark — Direct Script
-
-```bash
-uv run enhanced-bench \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --collection mlps_1m_1536dim_uniform_diskann \
-  --sweep \
-  --queries 10000 \
-  --processes 4 \
-  --out-dir /tmp/vdbbench_results
-```
-
----
-
-## Enhanced Benchmark — Single Node with `mlpstorage`
-
-```bash
-./mlpstorage vectordb run \
-  --file \
-  --open \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --config default \
-  --collection mlps_1m_1536dim_uniform_diskann \
-  --mode sweep \
-  --queries 10000 \
-  --num-query-processes 4 \
-  --results-dir /tmp/vdb_results
-```
-
----
-
-## Distributed Enhanced / Sweep Benchmark with MPICH
+### 7.4 Distributed Enhanced / Sweep Benchmark
 
 Distributed enhanced benchmark mode starts one `enhanced-bench` instance per MPI
 rank. Each rank writes enhanced-bench output under a rank-local output directory.
 The launcher then groups and aggregates rank outputs by parameter set.
 
-### Distributed enhanced sweep command
+#### Command
 
 ```bash
 ./mlpstorage vectordb run \
@@ -854,7 +1088,7 @@ The launcher then groups and aggregates rank outputs by parameter set.
   --results-dir /shared/vdb_results
 ```
 
-Example with four total MPI ranks:
+#### Example with four total MPI ranks
 
 ```bash
 ./mlpstorage vectordb run \
@@ -875,21 +1109,13 @@ Example with four total MPI ranks:
   --results-dir /shared/vdb_results
 ```
 
-With:
-
-```text
---hosts node01 node02
---npernode 2
---num-query-processes 2
-```
-
-this starts:
+With `--hosts node01 node02`, `--npernode 2`, and `--num-query-processes 2`:
 
 ```text
 2 hosts * 2 MPI ranks per host * 2 query processes per rank = 8 query workers
 ```
 
-### Distributed enhanced output
+#### Output structure
 
 ```text
 /shared/vdb_results/<run_id>/vectordb/enhanced/
@@ -908,7 +1134,7 @@ this starts:
 └── ...
 ```
 
-Global enhanced-bench metrics:
+#### Global metrics
 
 ```text
 benchmark_phase
@@ -934,7 +1160,7 @@ search parameters
 index parameters
 ```
 
-Aggregation rules:
+#### Aggregation rules
 
 ```text
 total_queries = sum(rank queries)
@@ -951,7 +1177,7 @@ unless raw latency samples are also emitted by the enhanced output.
 
 ---
 
-## Distributed Metrics Aggregation
+### 7.5 Metrics Aggregation
 
 Distributed VectorDB runs use rank-local output directories and a final
 aggregation step.
@@ -965,7 +1191,7 @@ uv run vdb-aggregate
 It is normally invoked automatically by `./mlpstorage vectordb`. It can also be
 run manually.
 
-### Manual load aggregation
+#### Manual load aggregation
 
 ```bash
 uv run vdb-aggregate \
@@ -974,7 +1200,7 @@ uv run vdb-aggregate \
   --expected-ranks 2
 ```
 
-### Manual simple aggregation
+#### Manual simple aggregation
 
 ```bash
 uv run vdb-aggregate \
@@ -983,7 +1209,7 @@ uv run vdb-aggregate \
   --expected-ranks 2
 ```
 
-### Manual enhanced aggregation
+#### Manual enhanced aggregation
 
 ```bash
 uv run vdb-aggregate \
@@ -994,7 +1220,7 @@ uv run vdb-aggregate \
 
 ---
 
-## Disk I/O Aggregation in Distributed Runs
+### 7.6 Disk I/O Deduplication
 
 Disk I/O counters are node-local. If multiple MPI ranks run on the same host,
 summing every rank's `/proc/diskstats` delta would double-count that host's disk
@@ -1011,7 +1237,7 @@ The aggregated `disk_io` field records this policy.
 
 ---
 
-## Ground Truth and Recall in Distributed Runs
+### 7.7 Ground Truth and Recall
 
 Recall is computed outside the timed query loop so it does not inflate latency
 measurements.
@@ -1063,7 +1289,7 @@ multi-rank recall aggregation.
 
 ---
 
-## Open MPI Alternative
+### 7.8 Open MPI Alternative
 
 The distributed VectorDB path defaults to MPICH-style launch syntax:
 
@@ -1101,9 +1327,7 @@ Example:
   --results-dir /shared/vdb_results
 ```
 
-Additional MPI arguments can be passed with `--mpi-params`.
-
-Example:
+Additional MPI arguments can be passed with `--mpi-params`:
 
 ```bash
 ./mlpstorage vectordb run \
@@ -1128,7 +1352,343 @@ Example:
 
 ---
 
-## Testing the Distributed Implementation
+## 8. End-to-End Examples
+
+### Single-Node Example
+
+```bash
+# 1. Estimate storage.
+./mlpstorage vectordb datasize \
+  --file \
+  --open \
+  --dimension 1536 \
+  --num-vectors 1000000 \
+  --index-type DISKANN
+
+# 2. Load vectors.
+./mlpstorage vectordb datagen \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config default \
+  --collection mlps_single_1m \
+  --force \
+  --results-dir ~/vdb_results
+
+# 3. Run simple benchmark.
+./mlpstorage vectordb run \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config default \
+  --collection mlps_single_1m \
+  --mode timed \
+  --num-query-processes 2 \
+  --runtime 60 \
+  --batch-size 10 \
+  --results-dir ~/vdb_results
+
+# 4. Run enhanced benchmark.
+./mlpstorage vectordb run \
+  --file \
+  --open \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --config default \
+  --collection mlps_single_1m \
+  --mode sweep \
+  --queries 10000 \
+  --num-query-processes 2 \
+  --results-dir ~/vdb_results
+
+# 5. View history.
+./mlpstorage history show
+```
+
+### Distributed MPICH Example
+
+```bash
+# 1. Verify MPI.
+mpiexec -n 2 -hosts node01,node02 hostname
+
+# 2. Load vectors across two benchmark client hosts.
+./mlpstorage vectordb datagen \
+  --file \
+  --open \
+  --distributed \
+  --mpi-impl mpich \
+  --mpi-bin mpiexec \
+  --hosts node01 node02 \
+  --npernode 1 \
+  --host 10.0.0.10 \
+  --port 19530 \
+  --config default \
+  --collection mlps_dist_1m \
+  --num-vectors 1000000 \
+  --dimension 1536 \
+  --num-shards 4 \
+  --force \
+  --results-dir /shared/vdb_results
+
+# 3. Run distributed simple benchmark.
+./mlpstorage vectordb run \
+  --file \
+  --open \
+  --distributed \
+  --mpi-impl mpich \
+  --mpi-bin mpiexec \
+  --hosts node01 node02 \
+  --npernode 1 \
+  --host 10.0.0.10 \
+  --port 19530 \
+  --config default \
+  --collection mlps_dist_1m \
+  --mode timed \
+  --runtime 120 \
+  --num-query-processes 2 \
+  --batch-size 10 \
+  --results-dir /shared/vdb_results
+
+# 4. Run distributed enhanced benchmark.
+./mlpstorage vectordb run \
+  --file \
+  --open \
+  --distributed \
+  --mpi-impl mpich \
+  --mpi-bin mpiexec \
+  --hosts node01 node02 \
+  --npernode 1 \
+  --host 10.0.0.10 \
+  --port 19530 \
+  --config default \
+  --collection mlps_dist_1m \
+  --mode sweep \
+  --queries 10000 \
+  --num-query-processes 2 \
+  --results-dir /shared/vdb_results
+```
+
+---
+
+## 9. Enhanced Benchmark Full Reference
+
+`enhanced_bench.py` merges the operational features of `simple_bench.py` with
+advanced features for parameter sweeps, warm/cold cache regimes, budget mode,
+YAML config, and memory estimation.
+
+### Two Execution Paths
+
+The script automatically selects the path based on the flags provided.
+
+| Path | Trigger | Best for |
+|------|---------|----------|
+| Runtime / query-count | `--runtime` or `--batch-size` present | Sustained load, CI gating, storage testing |
+| Sweep / cache | Neither `--runtime` nor `--batch-size` present, or explicit `--sweep` | Parameter tuning, recall target sweep, warm/cold analysis |
+
+### Path A — Runtime / Query-Count Mode
+
+This path mimics `simple_bench.py`. It runs workers for a fixed duration or query
+count, writes per-process CSV files, and aggregates latency and recall stats.
+
+Create the FLAT ground-truth collection (first run only):
+
+```bash
+python vdbbench/enhanced_bench.py \
+  --host 127.0.0.1 \
+  --collection mlps_10m_10shards_1536dim_uniform_diskann \
+  --auto-create-flat \
+  --runtime 1 \
+  --batch-size 1 \
+  --processes 1
+```
+
+Runtime-based run:
+
+```bash
+python vdbbench/enhanced_bench.py \
+  --host 127.0.0.1 \
+  --collection mlps_10m_10shards_1536dim_uniform_diskann \
+  --runtime 120 \
+  --batch-size 10 \
+  --processes 4 \
+  --search-limit 10 \
+  --search-ef 200
+```
+
+Query-count-based run:
+
+```bash
+python vdbbench/enhanced_bench.py \
+  --host 127.0.0.1 \
+  --collection mlps_10m_10shards_1536dim_uniform_diskann \
+  --queries 50000 \
+  --batch-size 10 \
+  --processes 4
+```
+
+With explicit FLAT GT collection:
+
+```bash
+python vdbbench/enhanced_bench.py \
+  --host 127.0.0.1 \
+  --collection mlps_10m_10shards_1536dim_uniform_diskann \
+  --gt-collection mlps_10m_10shards_1536dim_uniform_diskann_flat_gt \
+  --runtime 120 \
+  --batch-size 10 \
+  --processes 4
+```
+
+### Path B — Sweep / Cache / Budget Mode
+
+Single-thread, both warm and cold cache, recall sweep targeting 0.95:
+
+```bash
+python vdbbench/enhanced_bench.py \
+  --host 127.0.0.1 \
+  --collection mlps_10m_10shards_1536dim_uniform_diskann \
+  --gt-collection mlps_10m_10shards_1536dim_uniform_diskann_flat_gt \
+  --mode single \
+  --sweep \
+  --target-recall 0.95 \
+  --cache-state both \
+  --queries 1000 \
+  --k 10
+```
+
+Multi-process default parameters:
+
+```bash
+python vdbbench/enhanced_bench.py \
+  --host 127.0.0.1 \
+  --collection mlps_10m_10shards_1536dim_uniform_diskann \
+  --gt-collection mlps_10m_10shards_1536dim_uniform_diskann_flat_gt \
+  --mode mp \
+  --processes 8 \
+  --cache-state warm \
+  --queries 1000 \
+  --k 10
+```
+
+Multiple recall targets, optimized for latency:
+
+```bash
+python vdbbench/enhanced_bench.py \
+  --host 127.0.0.1 \
+  --collection mlps_10m_10shards_1536dim_uniform_diskann \
+  --gt-collection mlps_10m_10shards_1536dim_uniform_diskann_flat_gt \
+  --mode both \
+  --sweep \
+  --recall-targets 0.90 0.95 0.99 \
+  --optimize latency \
+  --cache-state warm
+```
+
+### Key Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--collection` | required | ANN-indexed collection name |
+| `--runtime` | `None` | Benchmark duration in seconds |
+| `--queries` | `1000` | Total query count |
+| `--batch-size` | required for runtime path | Queries per batch |
+| `--processes` | `8` | Worker processes |
+| `--search-limit` | `10` | Top-k results per query |
+| `--search-ef` | `200` | Search parameter override |
+| `--num-query-vectors` | `1000` | Pre-generated query vectors for recall |
+| `--recall-k` | `--search-limit` | k for recall@k |
+| `--gt-collection` | `<collection>_flat_gt` | FLAT GT collection name |
+| `--auto-create-flat` | `False` | Auto-create FLAT GT collection from source |
+| `--no-create-flat` | `False` | Validate and reuse existing FLAT GT collection |
+| `--vector-dim` | `1536` | Vector dimension |
+| `--output-dir` / `--out-dir` | `vdbbench_results/` | Output directory |
+| `--json-output` | `False` | Print summary as JSON |
+| `--report-count` | `10` | Batches between progress logs |
+| `--host` / `--port` | `localhost:19530` | Milvus connection |
+| `--config` | `None` | YAML config file |
+
+### Output Files
+
+#### Runtime path
+
+```text
+config.json
+milvus_benchmark_p0.csv
+milvus_benchmark_p1.csv
+recall_hits_p0.jsonl
+recall_hits_p1.jsonl
+recall_stats.json
+statistics.json
+```
+
+#### Sweep path
+
+```text
+combined_bench_<tag>.json
+combined_bench_<tag>.csv
+combined_bench_<tag>.sweep.csv
+```
+
+---
+
+## 10. Metrics and Measurement
+
+### Recall Measurement
+
+Recall is computed outside the timed benchmark loop so it does not inflate
+latency measurements.
+
+The benchmark uses a FLAT ground-truth collection for exact nearest-neighbor
+results.
+
+Simple benchmark output includes:
+
+```text
+recall_stats.json
+statistics.json
+```
+
+Recall fields include:
+
+```text
+mean_recall
+median_recall
+min_recall
+max_recall
+p5_recall
+p95_recall
+p99_recall
+num_queries_evaluated
+per_query_recall
+recall_by_query
+```
+
+The `per_query_recall` and `recall_by_query` fields are used for exact
+multi-rank aggregation.
+
+### Disk I/O Metrics
+
+Disk I/O is measured by reading `/proc/diskstats` before and after each
+benchmark run.
+
+Fields include:
+
+```text
+bytes_read
+bytes_written
+read_mbps
+write_mbps
+read_iops
+write_iops
+```
+
+In distributed mode, disk I/O is aggregated once per benchmark client host to
+avoid double-counting multiple MPI ranks on the same host.
+
+---
+
+## 11. Testing and Validation
 
 ### 1. MPI launch smoke test
 
@@ -1348,487 +1908,7 @@ Expected files:
 
 ---
 
-## `mlpstorage` Quick Reference
-
-The VDB benchmark is integrated into the MLPerf Storage CLI.
-
-### Available commands
-
-```bash
-./mlpstorage vectordb --help
-./mlpstorage vectordb datasize --help
-./mlpstorage vectordb datagen --help
-./mlpstorage vectordb run --help
-```
-
-### End-to-end single-node example
-
-```bash
-# 1. Estimate storage.
-./mlpstorage vectordb datasize \
-  --file \
-  --open \
-  --dimension 1536 \
-  --num-vectors 1000000 \
-  --index-type DISKANN
-
-# 2. Load vectors.
-./mlpstorage vectordb datagen \
-  --file \
-  --open \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --config default \
-  --collection mlps_single_1m \
-  --force \
-  --results-dir ~/vdb_results
-
-# 3. Run simple benchmark.
-./mlpstorage vectordb run \
-  --file \
-  --open \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --config default \
-  --collection mlps_single_1m \
-  --mode timed \
-  --num-query-processes 2 \
-  --runtime 60 \
-  --batch-size 10 \
-  --results-dir ~/vdb_results
-
-# 4. Run enhanced benchmark.
-./mlpstorage vectordb run \
-  --file \
-  --open \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --config default \
-  --collection mlps_single_1m \
-  --mode sweep \
-  --queries 10000 \
-  --num-query-processes 2 \
-  --results-dir ~/vdb_results
-
-# 5. View history.
-./mlpstorage history show
-```
-
-### End-to-end distributed MPICH example
-
-```bash
-# 1. Verify MPI.
-mpiexec -n 2 -hosts node01,node02 hostname
-
-# 2. Load vectors across two benchmark client hosts.
-./mlpstorage vectordb datagen \
-  --file \
-  --open \
-  --distributed \
-  --mpi-impl mpich \
-  --mpi-bin mpiexec \
-  --hosts node01 node02 \
-  --npernode 1 \
-  --host 10.0.0.10 \
-  --port 19530 \
-  --config default \
-  --collection mlps_dist_1m \
-  --num-vectors 1000000 \
-  --dimension 1536 \
-  --num-shards 4 \
-  --force \
-  --results-dir /shared/vdb_results
-
-# 3. Run distributed simple benchmark.
-./mlpstorage vectordb run \
-  --file \
-  --open \
-  --distributed \
-  --mpi-impl mpich \
-  --mpi-bin mpiexec \
-  --hosts node01 node02 \
-  --npernode 1 \
-  --host 10.0.0.10 \
-  --port 19530 \
-  --config default \
-  --collection mlps_dist_1m \
-  --mode timed \
-  --runtime 120 \
-  --num-query-processes 2 \
-  --batch-size 10 \
-  --results-dir /shared/vdb_results
-
-# 4. Run distributed enhanced benchmark.
-./mlpstorage vectordb run \
-  --file \
-  --open \
-  --distributed \
-  --mpi-impl mpich \
-  --mpi-bin mpiexec \
-  --hosts node01 node02 \
-  --npernode 1 \
-  --host 10.0.0.10 \
-  --port 19530 \
-  --config default \
-  --collection mlps_dist_1m \
-  --mode sweep \
-  --queries 10000 \
-  --num-query-processes 2 \
-  --results-dir /shared/vdb_results
-```
-
----
-
-## Config Files
-
-VectorDB `mlpstorage` configs live in:
-
-```text
-configs/vectordbbench/
-```
-
-The `--config` flag takes the filename without `.yaml`.
-
-Example:
-
-```bash
---config default
-```
-
-loads:
-
-```text
-configs/vectordbbench/default.yaml
-```
-
-Typical configs:
-
-| Config | Vectors | Dimension | Shards | Index |
-|--------|---------|-----------|--------|-------|
-| `default` | 1M | 1536 | 1 | DiskANN |
-| `10m` | 10M | 1536 | 10 | DiskANN |
-
-Custom configs can be added to the same directory.
-
----
-
-## `enhanced_bench.py` Full Reference
-
-`enhanced_bench.py` merges the operational features of `simple_bench.py` with
-advanced features for parameter sweeps, warm/cold cache regimes, budget mode,
-YAML config, and memory estimation.
-
-### Two execution paths
-
-The script automatically selects the path based on the flags provided.
-
-| Path | Trigger | Best for |
-|------|---------|----------|
-| Runtime / query-count | `--runtime` or `--batch-size` present | Sustained load, CI gating, storage testing |
-| Sweep / cache | Neither `--runtime` nor `--batch-size` present, or explicit `--sweep` | Parameter tuning, recall target sweep, warm/cold analysis |
-
-### Path A — Runtime / Query-Count Mode
-
-This path mimics `simple_bench.py`. It runs workers for a fixed duration or query
-count, writes per-process CSV files, and aggregates latency and recall stats.
-
-Create the FLAT ground-truth collection first run only:
-
-```bash
-python vdbbench/enhanced_bench.py \
-  --host 127.0.0.1 \
-  --collection mlps_10m_10shards_1536dim_uniform_diskann \
-  --auto-create-flat \
-  --runtime 1 \
-  --batch-size 1 \
-  --processes 1
-```
-
-Runtime-based run:
-
-```bash
-python vdbbench/enhanced_bench.py \
-  --host 127.0.0.1 \
-  --collection mlps_10m_10shards_1536dim_uniform_diskann \
-  --runtime 120 \
-  --batch-size 10 \
-  --processes 4 \
-  --search-limit 10 \
-  --search-ef 200
-```
-
-Query-count-based run:
-
-```bash
-python vdbbench/enhanced_bench.py \
-  --host 127.0.0.1 \
-  --collection mlps_10m_10shards_1536dim_uniform_diskann \
-  --queries 50000 \
-  --batch-size 10 \
-  --processes 4
-```
-
-With explicit FLAT GT collection:
-
-```bash
-python vdbbench/enhanced_bench.py \
-  --host 127.0.0.1 \
-  --collection mlps_10m_10shards_1536dim_uniform_diskann \
-  --gt-collection mlps_10m_10shards_1536dim_uniform_diskann_flat_gt \
-  --runtime 120 \
-  --batch-size 10 \
-  --processes 4
-```
-
-### Path B — Sweep / Cache / Budget Mode
-
-Single-thread, both warm and cold cache, recall sweep targeting 0.95:
-
-```bash
-python vdbbench/enhanced_bench.py \
-  --host 127.0.0.1 \
-  --collection mlps_10m_10shards_1536dim_uniform_diskann \
-  --gt-collection mlps_10m_10shards_1536dim_uniform_diskann_flat_gt \
-  --mode single \
-  --sweep \
-  --target-recall 0.95 \
-  --cache-state both \
-  --queries 1000 \
-  --k 10
-```
-
-Multi-process default parameters:
-
-```bash
-python vdbbench/enhanced_bench.py \
-  --host 127.0.0.1 \
-  --collection mlps_10m_10shards_1536dim_uniform_diskann \
-  --gt-collection mlps_10m_10shards_1536dim_uniform_diskann_flat_gt \
-  --mode mp \
-  --processes 8 \
-  --cache-state warm \
-  --queries 1000 \
-  --k 10
-```
-
-Multiple recall targets, optimized for latency:
-
-```bash
-python vdbbench/enhanced_bench.py \
-  --host 127.0.0.1 \
-  --collection mlps_10m_10shards_1536dim_uniform_diskann \
-  --gt-collection mlps_10m_10shards_1536dim_uniform_diskann_flat_gt \
-  --mode both \
-  --sweep \
-  --recall-targets 0.90 0.95 0.99 \
-  --optimize latency \
-  --cache-state warm
-```
-
-### Key parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--collection` | required | ANN-indexed collection name |
-| `--runtime` | `None` | Benchmark duration in seconds |
-| `--queries` | `1000` | Total query count |
-| `--batch-size` | required for runtime path | Queries per batch |
-| `--processes` | `8` | Worker processes |
-| `--search-limit` | `10` | Top-k results per query |
-| `--search-ef` | `200` | Search parameter override |
-| `--num-query-vectors` | `1000` | Pre-generated query vectors for recall |
-| `--recall-k` | `--search-limit` | k for recall@k |
-| `--gt-collection` | `<collection>_flat_gt` | FLAT GT collection name |
-| `--auto-create-flat` | `False` | Auto-create FLAT GT collection from source |
-| `--no-create-flat` | `False` | Validate and reuse existing FLAT GT collection |
-| `--vector-dim` | `1536` | Vector dimension |
-| `--output-dir` / `--out-dir` | `vdbbench_results/` | Output directory |
-| `--json-output` | `False` | Print summary as JSON |
-| `--report-count` | `10` | Batches between progress logs |
-| `--host` / `--port` | `localhost:19530` | Milvus connection |
-| `--config` | `None` | YAML config file |
-
-### Runtime path outputs
-
-```text
-config.json
-milvus_benchmark_p0.csv
-milvus_benchmark_p1.csv
-recall_hits_p0.jsonl
-recall_hits_p1.jsonl
-recall_stats.json
-statistics.json
-```
-
-### Sweep path outputs
-
-```text
-combined_bench_<tag>.json
-combined_bench_<tag>.csv
-combined_bench_<tag>.sweep.csv
-```
-
----
-
-## Direct Script Usage
-
-### Load directly
-
-```bash
-uv run load-vdb \
-  --config vdbbench/configs/10m_diskann.yaml
-```
-
-### Simple benchmark directly
-
-```bash
-uv run vdbbench \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --collection-name mlps_1m_1536dim_uniform_diskann \
-  --processes 4 \
-  --batch-size 10 \
-  --runtime 120 \
-  --output-dir /tmp/vdbbench_results
-```
-
-### Enhanced benchmark directly
-
-```bash
-uv run enhanced-bench \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --collection mlps_1m_1536dim_uniform_diskann \
-  --sweep \
-  --queries 10000 \
-  --processes 4 \
-  --out-dir /tmp/vdbbench_results
-```
-
----
-
-## Recall Measurement
-
-Recall is computed outside the timed benchmark loop so it does not inflate
-latency measurements.
-
-The benchmark uses a FLAT ground-truth collection for exact nearest-neighbor
-results.
-
-Simple benchmark output includes:
-
-```text
-recall_stats.json
-statistics.json
-```
-
-Recall fields include:
-
-```text
-mean_recall
-median_recall
-min_recall
-max_recall
-p5_recall
-p95_recall
-p99_recall
-num_queries_evaluated
-per_query_recall
-recall_by_query
-```
-
-The `per_query_recall` and `recall_by_query` fields are used for exact
-multi-rank aggregation.
-
----
-
-## Disk I/O Metrics
-
-Disk I/O is measured by reading `/proc/diskstats` before and after each
-benchmark run.
-
-Fields include:
-
-```text
-bytes_read
-bytes_written
-read_mbps
-write_mbps
-read_iops
-write_iops
-```
-
-In distributed mode, disk I/O is aggregated once per benchmark client host to
-avoid double-counting multiple MPI ranks on the same host.
-
----
-
-## Supported Databases
-
-Currently supported:
-
-* Milvus with DiskANN
-* Milvus with HNSW
-* Milvus with AISAQ
-* Milvus with FLAT
-* Milvus with IVF-style indexes
-
----
-
-## Dependencies
-
-Recommended installation:
-
-```bash
-cd storage
-uv sync --extra vectordb
-uv pip install -e ./vdb_benchmark
-```
-
-Manual installation:
-
-```bash
-pip install pymilvus numpy pyyaml tabulate pandas
-```
-
-Package purposes:
-
-| Package | Purpose |
-|---------|---------|
-| `pymilvus` | Milvus client |
-| `numpy` | Vector generation and recall math |
-| `pyyaml` | YAML config support |
-| `tabulate` | Collection info table display |
-| `pandas` | Latency/statistics aggregation |
-
-The `datasize` command does not require Milvus or `pymilvus`. Load and run
-commands require a running Milvus server.
-
----
-
-## Preview Status
-
-The VectorDB benchmark is currently in preview status.
-
-All runs qualify for OPEN category only. Pass `--open` to acknowledge this:
-
-```bash
-./mlpstorage vectordb run \
-  --file \
-  --open \
-  --host 127.0.0.1 \
-  --port 19530 \
-  --config default \
-  --collection mlps_1m_1536dim_uniform_diskann \
-  --mode timed \
-  --num-query-processes 4 \
-  --runtime 120 \
-  --results-dir ~/vdb_results
-```
-
----
-
-## Troubleshooting
+## 12. Troubleshooting
 
 ### `vector dimension mismatch`
 
@@ -1918,7 +1998,7 @@ uv run vdb-aggregate --help
 
 ---
 
-## Contributing
+## 13. Contributing
 
 Contributions are welcome. Pull requests that add or modify distributed
 VectorDB behavior should include:

--- a/vdb_benchmark/README.md
+++ b/vdb_benchmark/README.md
@@ -6,10 +6,16 @@ supports Milvus with DiskANN, HNSW, AISAQ, FLAT, and IVF-style indexes.
 > **Preview Status:** The VectorDB benchmark is in preview. All runs qualify for
 > OPEN category only. Pass `--open` to acknowledge this.
 
-> **Modular Runner (Preview):** A backend-agnostic runner is available as a
-> standalone preview via `python -m vdbbench.benchmark`. The `./mlpstorage vectordb`
-> command continues to use the Milvus-oriented scripts until the modular runner is
-> integrated.
+The benchmark can be run in two ways:
+
+1. Directly with the scripts in `vdb_benchmark/vdbbench/`
+2. Through the MLPerf Storage CLI with `./mlpstorage vectordb`
+
+The `mlpstorage` path is recommended for standard benchmark workflows.
+
+> The modular backend-agnostic runner is currently a standalone preview.
+> It is invoked with `python -m vdbbench.benchmark`.
+> The existing `./mlpstorage vectordb` command continues to use the Milvus-oriented scripts until the modular runner is integrated.
 
 ---
 
@@ -61,21 +67,22 @@ supports Milvus with DiskANN, HNSW, AISAQ, FLAT, and IVF-style indexes.
 
 | Requirement | Version | Notes |
 |-------------|---------|-------|
-| Python | 3.12+ | Required |
-| Docker & Docker Compose | Latest | For running Milvus |
+| Python | ≥ 3.12 | Required |
+| Docker Engine | ≥ 20.10 | For running Milvus containers |
+| Docker Compose | v2+ | `docker compose` (v2 CLI plugin) preferred |
 | Git | Any | To clone the repository |
-| `uv` | Latest | Recommended package manager |
-| MPI (MPICH or OpenMPI) | Any | Only for distributed/multi-node runs |
+| `uv` | Latest | Recommended package manager ([install](https://docs.astral.sh/uv/getting-started/installation/)) |
+| MPI (MPICH or OpenMPI) | Any | Only for distributed/multi-node runs; requires `mpi4py ≥ 4.0.0` |
 
 ### Python Dependencies
 
-| Package | Purpose |
-|---------|---------|
-| `pymilvus` | Milvus client |
-| `numpy` | Vector generation and recall math |
-| `pyyaml` | YAML config support |
-| `tabulate` | Collection info table display |
-| `pandas` | Latency/statistics aggregation |
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `pymilvus` | ≥ 2.4.0 | Milvus client |
+| `numpy` | ≥ 1.24.3 | Vector generation and recall math |
+| `pandas` | ≥ 2.0.3 | Latency/statistics aggregation |
+| `pyyaml` | ≥ 6.0 | YAML config support |
+| `tabulate` | ≥ 0.9.0 | Collection info table display |
 
 The `datasize` command does not require Milvus or `pymilvus`. Load and run
 commands require a running Milvus server.
@@ -95,10 +102,10 @@ A running Milvus instance is required for all load (`datagen`) and benchmark
 (`run`) commands. This section applies to both the mlpstorage CLI and direct
 script paths.
 
-Standalone Milvus stacks are available in the `stacks` directory:
+Standalone Milvus stacks are available in the `vdb_benchmark/stacks` directory:
 
 ```text
-stacks/
+vdb_benchmark/stacks/
 └── milvus/
     ├── cluster/
     └── standalone/
@@ -116,8 +123,8 @@ the values as needed.
 ### Option A: Local Storage with MinIO
 
 ```bash
-cp stacks/milvus/standalone/minio/.env.example \
-   stacks/milvus/standalone/minio/.env
+cp vdb_benchmark/stacks/milvus/standalone/minio/.env.example \
+   vdb_benchmark/stacks/milvus/standalone/minio/.env
 ```
 
 The compose file uses `/mnt/vdb` as the root directory for Docker volumes. Set
@@ -133,13 +140,13 @@ The stack creates three containers:
 Start:
 
 ```bash
-docker compose -f stacks/milvus/standalone/minio/docker-compose.yml up -d
+docker compose -f vdb_benchmark/stacks/milvus/standalone/minio/docker-compose.yml up -d
 ```
 
 or:
 
 ```bash
-docker-compose -f stacks/milvus/standalone/minio/docker-compose.yml up -d
+docker-compose -f vdb_benchmark/stacks/milvus/standalone/minio/docker-compose.yml up -d
 ```
 
 ### Option B: S3 Storage
@@ -147,20 +154,20 @@ docker-compose -f stacks/milvus/standalone/minio/docker-compose.yml up -d
 Copy and configure environment (fill in your S3 credentials):
 
 ```bash
-cp stacks/milvus/standalone/s3/.env.example \
-   stacks/milvus/standalone/s3/.env
+cp vdb_benchmark/stacks/milvus/standalone/s3/.env.example \
+   vdb_benchmark/stacks/milvus/standalone/s3/.env
 ```
 
 Start:
 
 ```bash
-docker compose -f stacks/milvus/standalone/s3/docker-compose-s3.yml up -d
+docker compose -f vdb_benchmark/stacks/milvus/standalone/s3/docker-compose-s3.yml up -d
 ```
 
 or:
 
 ```bash
-docker-compose -f stacks/milvus/standalone/s3/docker-compose-s3.yml up -d
+docker-compose -f vdb_benchmark/stacks/milvus/standalone/s3/docker-compose-s3.yml up -d
 ```
 
 ### Verify Milvus is Healthy
@@ -178,17 +185,12 @@ The default Milvus endpoint is:
 127.0.0.1:19530
 ```
 
-> **Note:** All `stacks/` paths above are relative to the `vdb_benchmark/`
-> directory. If running from the repository root (`storage/`), prefix with
-> `vdb_benchmark/` (e.g., `vdb_benchmark/stacks/milvus/standalone/minio/...`).
-
 ---
 
-## 3. Quick Start — First Benchmark in 10 Minutes
+## 3. Quick Start 
 
-This section gets you from zero to a working benchmark result on a single machine.
-Every command is copy-paste ready. Assumes you have already deployed Milvus
-([Section 2](#2-deploy-milvus)).
+This section gets you from zero to a working benchmark result on a standalone-system.
+Assumes Milvus is set up as per section #2 instructions. 
 
 ### Step 1 — Install
 
@@ -538,6 +540,10 @@ in [Section 2](#2-deploy-milvus).
 
 ### 5.2 Load Vectors
 
+> **Working directory:** All `python vdbbench/...` commands in this section
+> assume you are in `storage/vdb_benchmark/`. Console scripts (`uv run load-vdb`,
+> etc.) work from any directory.
+
 #### Load using a YAML config
 
 ```bash
@@ -574,10 +580,10 @@ python vdbbench/load_vdb.py \
 
 #### Config file location
 
-Direct script configs live in:
+Direct script configs live in `vdbbench/configs/` (relative to `storage/vdb_benchmark/`):
 
 ```text
-vdb_benchmark/vdbbench/configs/
+vdbbench/configs/
 ├── 10m_diskann.yaml       (10M vectors, 10 shards, 1536 dim)
 ├── 10m_hnsw.yaml
 ├── 1m_diskann.yaml        (1M vectors, 1 shard, 1536 dim)
@@ -1473,6 +1479,9 @@ mpiexec -n 2 -hosts node01,node02 hostname
 ---
 
 ## 9. Enhanced Benchmark Full Reference
+
+> **Working directory:** All commands below assume you are in
+> `storage/vdb_benchmark/`.
 
 `enhanced_bench.py` merges the operational features of `simple_bench.py` with
 advanced features for parameter sweeps, warm/cold cache regimes, budget mode,


### PR DESCRIPTION
Followed README.md instructions on a new system, felt better grouping of steps is needed.

- Added separate Quick-Start and Pre-requisites sections 
- Grouped mlpstorage (recommended) and manual commands in separate sections.
- Aligned file paths with current directory 
- Cleaned up repeated instructions.
- Fixed config tree listing to match command paths
- Consolidated distributed execution documentation, all multi-node content grouped under Section 7