### PR TITLE
accumulation: lock down current behavior and harden discovery/reservation

### DIFF
--- a/mlpstorage_py/benchmarks/base.py
+++ b/mlpstorage_py/benchmarks/base.py
@@ -48,6 +48,10 @@ from functools import wraps
 from pyarrow.ipc import open_stream
 
 from mlpstorage_py.config import PARAM_VALIDATION, DATETIME_STR, MLPS_DEBUG, EXEC_TYPE
+from mlpstorage_py.run_directory import (
+    DEFAULT_COLLISION_BUMP_BUDGET,
+    reserve_run_directory,
+)
 from mlpstorage_py.debug import debug_tryer_wrapper
 from mlpstorage_py.interfaces import BenchmarkInterface, BenchmarkConfig, BenchmarkCommand
 from mlpstorage_py.mlps_logging import setup_logging, apply_logging_options
@@ -134,8 +138,7 @@ class Benchmark(BenchmarkInterface, abc.ABC):
         self.cmd_executor = CommandExecutor(logger=self.logger, debug=args.debug)
 
         self.command_output_files = list()
-        self.run_result_output = self.generate_output_location()
-        os.makedirs(self.run_result_output, exist_ok=True)
+        self.run_result_output = self._reserve_run_directory()
 
         self.metadata_filename = f"{self.BENCHMARK_TYPE.value}_{self.run_datetime}_metadata.json"
         self.metadata_file_path = os.path.join(self.run_result_output, self.metadata_filename)
@@ -801,6 +804,23 @@ class Benchmark(BenchmarkInterface, abc.ABC):
         if not self.BENCHMARK_TYPE:
             raise ValueError('No benchmark specified. Unable to generate output location')
         return generate_output_location(self, self.run_datetime)
+
+    _COLLISION_BUMP_BUDGET = DEFAULT_COLLISION_BUMP_BUDGET
+
+    def _reserve_run_directory(self) -> str:
+        """Atomically reserve a unique run directory, updating run_datetime
+        if a collision pushes the timestamp forward. See
+        mlpstorage_py.benchmarks.run_directory.reserve_run_directory.
+        """
+        def _path_for(dt: str) -> str:
+            self.run_datetime = dt
+            return self.generate_output_location()
+
+        reserved, final_dt = reserve_run_directory(
+            self.run_datetime, _path_for, budget=self._COLLISION_BUMP_BUDGET
+        )
+        self.run_datetime = final_dt
+        return reserved
 
     def verify_benchmark(self) -> bool:
         """Verify benchmark parameters meet OPEN or CLOSED requirements.

--- a/mlpstorage_py/benchmarks/base.py
+++ b/mlpstorage_py/benchmarks/base.py
@@ -45,8 +45,6 @@ from typing import Tuple, Dict, Any, List, Optional, Callable, Set, TYPE_CHECKIN
 
 from functools import wraps
 
-from pyarrow.ipc import open_stream
-
 from mlpstorage_py.config import PARAM_VALIDATION, DATETIME_STR, MLPS_DEBUG, EXEC_TYPE
 from mlpstorage_py.run_directory import (
     DEFAULT_COLLISION_BUMP_BUDGET,

--- a/mlpstorage_py/rules/models.py
+++ b/mlpstorage_py/rules/models.py
@@ -732,6 +732,12 @@ class DLIOResultParser:
             benchmark_type = BENCHMARK_TYPES.checkpointing
             command = "run"
 
+        if benchmark_type is None:
+            raise ValueError(
+                f"Could not determine benchmark type for {result_dir}: "
+                "summary.json lacks workflow signal and no Hydra configs found"
+            )
+
         model = hydra_workload_config.get('model', {}).get("name")
         if model:
             model = model.replace("llama_", "llama3-")

--- a/mlpstorage_py/rules/submission_checkers/base.py
+++ b/mlpstorage_py/rules/submission_checkers/base.py
@@ -92,3 +92,26 @@ class MultiRunRulesChecker(RulesChecker):
                 actual=list(models)
             )
         return None
+
+    def check_benchmark_type_consistency(self) -> Optional[Issue]:
+        """
+        Verify all runs share the same benchmark_type.
+
+        BenchmarkVerifier already rejects mixed-type inputs in its dispatch
+        (verifier.py:_create_rules_checker), but a caller that constructs a
+        MultiRunRulesChecker directly bypasses that guard. Enforcing it here
+        defends against silent grouping bugs when a model name happens to
+        coincide across benchmark types.
+        """
+        types = {run.benchmark_type for run in self.benchmark_runs}
+        if len(types) > 1:
+            return Issue(
+                validation=PARAM_VALIDATION.INVALID,
+                message="Inconsistent benchmark types across runs in submission",
+                parameter="benchmark_type",
+                expected="Single benchmark_type",
+                actual=sorted(
+                    t.name if t is not None else "None" for t in types
+                ),
+            )
+        return None

--- a/mlpstorage_py/rules/utils.py
+++ b/mlpstorage_py/rules/utils.py
@@ -206,8 +206,11 @@ def get_runs_files(results_dir: str, logger=None) -> List:
             logger.warning(f"Results directory not found: {results_dir}")
         return runs
 
-    # Walk the directory tree looking for run directories
-    for root, dirs, files in os.walk(results_dir):
+    # Walk the directory tree looking for run directories. followlinks=True
+    # lets users symlink previously-completed run directories into a fresh
+    # results-dir to accumulate them — a common workflow when stitching
+    # together results from multiple machines or earlier runs.
+    for root, dirs, files in os.walk(results_dir, followlinks=True):
         # Check if this directory contains a summary.json (DLIO run) or metadata file
         has_summary = 'summary.json' in files
         metadata_files = [f for f in files if f.endswith('_metadata.json')]

--- a/mlpstorage_py/run_directory.py
+++ b/mlpstorage_py/run_directory.py
@@ -1,0 +1,75 @@
+"""
+Atomic reservation of per-run result directories.
+
+Run directories are stamped with second-resolution timestamps. Two runs
+started within the same wall-clock second would otherwise collide and
+clobber each other's metadata. The helpers here use exclusive create
+(O_EXCL via os.mkdir) and on collision bump the timestamp one second
+forward, retrying up to a bounded budget.
+
+Kept dependency-free so tests can exercise the logic without pulling in
+the rest of the Benchmark class (which imports pyarrow and MPI).
+"""
+
+from __future__ import annotations
+
+import datetime as _datetime
+import os
+from typing import Callable
+
+RUN_DATETIME_FORMAT = "%Y%m%d_%H%M%S"
+DEFAULT_COLLISION_BUMP_BUDGET = 10
+
+
+def bump_datetime_one_second(run_datetime: str) -> str:
+    """Return ``run_datetime`` advanced by one second, preserving format."""
+    parsed = _datetime.datetime.strptime(run_datetime, RUN_DATETIME_FORMAT)
+    return (parsed + _datetime.timedelta(seconds=1)).strftime(RUN_DATETIME_FORMAT)
+
+
+def reserve_run_directory(
+    initial_run_datetime: str,
+    path_for_datetime: Callable[[str], str],
+    budget: int = DEFAULT_COLLISION_BUMP_BUDGET,
+) -> tuple[str, str]:
+    """Atomically reserve a unique run directory.
+
+    Args:
+        initial_run_datetime: Starting timestamp string (YYYYMMDD_HHMMSS).
+        path_for_datetime: Callable that returns the full result-dir path for
+            a given timestamp string. Lets the caller plug in their own layout
+            (training/<model>/<command>/<datetime>/, etc.) without this helper
+            having to know it.
+        budget: Max number of one-second forward bumps before giving up.
+
+    Returns:
+        (reserved_path, final_run_datetime) — the caller should store
+        ``final_run_datetime`` because metadata/timeseries filenames derive
+        from it and must match the reserved directory.
+
+    Raises:
+        RuntimeError: If the budget is exhausted without finding a free slot.
+    """
+    run_datetime = initial_run_datetime
+    last_parent = ""
+    for _ in range(budget):
+        candidate = path_for_datetime(run_datetime)
+        last_parent = os.path.dirname(candidate)
+        if last_parent:
+            os.makedirs(last_parent, exist_ok=True)
+        try:
+            os.mkdir(candidate)
+        except FileExistsError:
+            run_datetime = bump_datetime_one_second(run_datetime)
+            continue
+        return candidate, run_datetime
+
+    # Use the parent captured during the loop instead of calling
+    # path_for_datetime again — callers may use a side-effecting closure
+    # (e.g. Benchmark._reserve_run_directory mutates self.run_datetime),
+    # and re-invoking would clobber that state.
+    raise RuntimeError(
+        f"Could not reserve a unique run directory after {budget} attempts "
+        f"starting from {initial_run_datetime}; clean stale entries under "
+        f"{last_parent} and retry."
+    )

--- a/tests/integration/test_benchmark_flow.py
+++ b/tests/integration/test_benchmark_flow.py
@@ -592,7 +592,6 @@ class TestKVCacheRunIntegration:
             closed=False, open=False,
         )
         output_dir = str(tmp_path / 'run_output')
-        os.makedirs(output_dir, exist_ok=True)
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen, \
              patch('mlpstorage_py.benchmarks.kvcache.KVCacheBenchmark._collect_cluster_information',
                    return_value=None):

--- a/tests/unit/test_accumulation.py
+++ b/tests/unit/test_accumulation.py
@@ -1,0 +1,518 @@
+"""
+Tests for results-directory accumulation: discovery, grouping, and submission gating.
+
+These tests drive the REAL get_runs_files() walk against synthetic on-disk
+results trees (no mocking of discovery). They lock down current behavior so
+follow-up PRs can fix bugs without regressing the rest of the accumulation
+surface. Scenarios intentionally not covered today are documented as xfail or
+left for follow-up PRs (sub-second collisions, vectordb/kvcache path containing
+engine/model — both addressed in subsequent PRs of this effort).
+
+Existing tests at tests/unit/test_reporting.py:425-531 cover ReportGenerator
+grouping with get_runs_files mocked. tests/unit/test_rules_calculations.py
+covers single-run discovery. This file covers the multi-run accumulation gap.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from mlpstorage_py.config import BENCHMARK_TYPES, PARAM_VALIDATION
+from mlpstorage_py.rules import BenchmarkRun, get_runs_files
+from mlpstorage_py.rules.submission_checkers.training import (
+    TrainingSubmissionRulesChecker,
+)
+from mlpstorage_py.rules.submission_checkers.base import MultiRunRulesChecker
+
+
+# ---------------------------------------------------------------------------
+# Builders — synthesize on-disk runs matching the layouts in
+# mlpstorage_py/rules/utils.py:generate_output_location()
+# ---------------------------------------------------------------------------
+
+_DEFAULT_TRAINING_PARAMETERS = {
+    "model": {"name": "unet3d"},
+    "dataset": {"num_files_train": 400, "data_folder": "/data/unet3d", "format": "npz"},
+    "reader": {"read_threads": 8, "computation_threads": 1, "prefetch_size": 2},
+    "workflow": {"generate_data": False, "train": True, "checkpoint": True},
+}
+
+_DEFAULT_CHECKPOINTING_PARAMETERS = {
+    "model": {"name": "llama3_8b"},
+    "checkpoint": {"checkpoint_folder": "/data/checkpoints"},
+    "workflow": {"generate_data": False, "train": False, "checkpoint": True},
+}
+
+
+def _write_run(
+    run_dir: Path,
+    *,
+    benchmark_type: str,
+    run_datetime: str,
+    model: Optional[str],
+    accelerator: Optional[str],
+    command: str,
+    parameters: dict,
+    include_summary: bool = True,
+    metadata_overrides: Optional[dict] = None,
+) -> Path:
+    """Create one run directory: metadata JSON + optional summary.json."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    metadata = {
+        "benchmark_type": benchmark_type,
+        "model": model,
+        "command": command,
+        "run_datetime": run_datetime,
+        "num_processes": 8,
+        "accelerator": accelerator,
+        "parameters": parameters,
+        "override_parameters": {},
+        "result_dir": str(run_dir),
+    }
+    if metadata_overrides:
+        metadata.update(metadata_overrides)
+
+    metadata_filename = f"{benchmark_type}_{run_datetime}_metadata.json"
+    (run_dir / metadata_filename).write_text(json.dumps(metadata))
+
+    if include_summary:
+        # Minimal DLIO summary — only fields ResultsDirectoryValidator and
+        # DLIOResultParser look at. ResultFilesExtractor uses metadata first
+        # when complete, so summary content is rarely read in these tests.
+        summary = {
+            "start": run_datetime,
+            "num_accelerators": 8,
+            "num_hosts": 1,
+            "host_memory_GB": [256],
+            "host_cpu_count": [64],
+            "metric": {},
+        }
+        (run_dir / "summary.json").write_text(json.dumps(summary))
+
+    return run_dir
+
+
+def make_training_run(
+    results_dir: Path,
+    *,
+    model: str = "unet3d",
+    accelerator: str = "h100",
+    run_datetime: str = "20250111_143022",
+    command: str = "run",
+    parameters: Optional[dict] = None,
+    include_summary: bool = True,
+    metadata_overrides: Optional[dict] = None,
+) -> Path:
+    """Create one training run under results_dir/training/<model>/<command>/<datetime>/."""
+    run_dir = results_dir / "training" / model / command / run_datetime
+    return _write_run(
+        run_dir,
+        benchmark_type="training",
+        run_datetime=run_datetime,
+        model=model,
+        accelerator=accelerator,
+        command=command,
+        parameters=parameters or _DEFAULT_TRAINING_PARAMETERS,
+        include_summary=include_summary,
+        metadata_overrides=metadata_overrides,
+    )
+
+
+def make_checkpointing_run(
+    results_dir: Path,
+    *,
+    model: str = "llama3-8b",
+    run_datetime: str = "20250111_150000",
+    command: str = "run",
+    parameters: Optional[dict] = None,
+    include_summary: bool = True,
+) -> Path:
+    """Create one checkpointing run under results_dir/checkpointing/<model>/<datetime>/."""
+    run_dir = results_dir / "checkpointing" / model / run_datetime
+    return _write_run(
+        run_dir,
+        benchmark_type="checkpointing",
+        run_datetime=run_datetime,
+        model=model,
+        accelerator=None,
+        command=command,
+        parameters=parameters or _DEFAULT_CHECKPOINTING_PARAMETERS,
+        include_summary=include_summary,
+    )
+
+
+def make_vectordb_run(
+    results_dir: Path,
+    *,
+    run_datetime: str = "20250111_160000",
+    command: str = "run",
+    include_summary: bool = True,
+) -> Path:
+    """Create one vectordb run at results_dir/vector_database/<command>/<datetime>/.
+
+    The current path layout has no engine/backend component — this is what
+    PR 3 will add. Builder mirrors current production behavior so tests
+    document the limitation.
+    """
+    run_dir = results_dir / "vector_database" / command / run_datetime
+    return _write_run(
+        run_dir,
+        benchmark_type="vector_database",
+        run_datetime=run_datetime,
+        model=None,
+        accelerator=None,
+        command=command,
+        parameters={"workload": "vdb"},
+        include_summary=include_summary,
+    )
+
+
+def make_kvcache_run(
+    results_dir: Path,
+    *,
+    run_datetime: str = "20250111_170000",
+    command: str = "run",
+    include_summary: bool = True,
+) -> Path:
+    """Create one kvcache run at results_dir/kv_cache/<command>/<datetime>/.
+
+    Current layout has no model component — PR 4 will add it.
+    """
+    run_dir = results_dir / "kv_cache" / command / run_datetime
+    return _write_run(
+        run_dir,
+        benchmark_type="kv_cache",
+        run_datetime=run_datetime,
+        model=None,
+        accelerator=None,
+        command=command,
+        parameters={"workload": "kv"},
+        include_summary=include_summary,
+    )
+
+
+def _stamps(n: int, start_hour: int = 14) -> list[str]:
+    """Generate N distinct run_datetime strings — one per minute from a base hour."""
+    return [f"20250111_{start_hour:02d}{m:02d}00" for m in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Discovery: get_runs_files walks the tree and finds runs by metadata file
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryAcrossBenchmarkTypes:
+    """get_runs_files() should discover runs of every benchmark type."""
+
+    def test_discovers_five_training_runs(self, tmp_path, mock_logger):
+        results_dir = tmp_path / "results"
+        for ts in _stamps(5):
+            make_training_run(results_dir, run_datetime=ts)
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+
+        assert len(runs) == 5
+        assert all(isinstance(r, BenchmarkRun) for r in runs)
+        assert all(r.benchmark_type == BENCHMARK_TYPES.training for r in runs)
+
+    def test_discovers_heterogeneous_tree(self, tmp_path, mock_logger):
+        """Training + checkpointing in the same results-dir are both discovered."""
+        results_dir = tmp_path / "results"
+        for ts in _stamps(3):
+            make_training_run(results_dir, run_datetime=ts)
+        for ts in _stamps(2, start_hour=15):
+            make_checkpointing_run(results_dir, run_datetime=ts)
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+
+        types = {r.benchmark_type for r in runs}
+        assert types == {BENCHMARK_TYPES.training, BENCHMARK_TYPES.checkpointing}
+        assert sum(1 for r in runs if r.benchmark_type == BENCHMARK_TYPES.training) == 3
+        assert sum(1 for r in runs if r.benchmark_type == BENCHMARK_TYPES.checkpointing) == 2
+
+    def test_discovers_vectordb_and_kvcache(self, tmp_path, mock_logger):
+        """Preview benchmarks coexist with training in one results-dir."""
+        results_dir = tmp_path / "results"
+        make_training_run(results_dir, run_datetime="20250111_140000")
+        make_vectordb_run(results_dir, run_datetime="20250111_160000")
+        make_kvcache_run(results_dir, run_datetime="20250111_170000")
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+
+        types = {r.benchmark_type for r in runs}
+        assert types == {
+            BENCHMARK_TYPES.training,
+            BENCHMARK_TYPES.vector_database,
+            BENCHMARK_TYPES.kv_cache,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Training submission gate: N=5 runs required for CLOSED
+# (mlpstorage_py/rules/submission_checkers/training.py:18)
+# ---------------------------------------------------------------------------
+
+
+class TestTrainingRequiredRunsGate:
+    """TrainingSubmissionRulesChecker requires exactly REQUIRED_RUNS=5."""
+
+    def _build_runs(self, tmp_path: Path, n: int, mock_logger) -> list[BenchmarkRun]:
+        results_dir = tmp_path / "results"
+        for ts in _stamps(n):
+            make_training_run(results_dir, run_datetime=ts)
+        return get_runs_files(str(results_dir), logger=mock_logger)
+
+    def test_n4_marks_invalid_for_num_runs(self, tmp_path, mock_logger):
+        runs = self._build_runs(tmp_path, 4, mock_logger)
+        assert len(runs) == 4
+
+        checker = TrainingSubmissionRulesChecker(runs, logger=mock_logger)
+        issue = checker.check_num_runs()
+
+        assert issue is not None
+        assert issue.validation == PARAM_VALIDATION.INVALID
+        assert issue.parameter == "num_runs"
+        assert issue.expected == 5
+        assert issue.actual == 4
+
+    def test_n5_marks_closed_for_num_runs(self, tmp_path, mock_logger):
+        runs = self._build_runs(tmp_path, 5, mock_logger)
+        assert len(runs) == 5
+
+        checker = TrainingSubmissionRulesChecker(runs, logger=mock_logger)
+        issue = checker.check_num_runs()
+
+        assert issue is not None
+        assert issue.validation == PARAM_VALIDATION.CLOSED
+        assert issue.actual == 5
+
+    def test_n6_still_passes_num_runs(self, tmp_path, mock_logger):
+        """The gate is >= REQUIRED_RUNS, not == — extra runs should still pass."""
+        runs = self._build_runs(tmp_path, 6, mock_logger)
+
+        checker = TrainingSubmissionRulesChecker(runs, logger=mock_logger)
+        issue = checker.check_num_runs()
+
+        assert issue.validation == PARAM_VALIDATION.CLOSED
+
+
+# ---------------------------------------------------------------------------
+# Multi-workload separation: 5x unet3d + 5x resnet50 in one tree
+# ---------------------------------------------------------------------------
+
+
+class TestWorkloadSeparation:
+    """Discovery surfaces runs; downstream grouping by (model, accelerator) lives
+    in ReportGenerator._process_workload_groups. These tests verify that the
+    raw discovery preserves enough information to distinguish workloads."""
+
+    def test_two_models_same_accelerator_distinguishable_by_metadata(
+        self, tmp_path, mock_logger
+    ):
+        results_dir = tmp_path / "results"
+        for ts in _stamps(5, start_hour=14):
+            make_training_run(results_dir, model="unet3d", run_datetime=ts)
+        for ts in _stamps(5, start_hour=15):
+            make_training_run(results_dir, model="resnet50", run_datetime=ts)
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+
+        assert len(runs) == 10
+        by_model: dict[str, list[BenchmarkRun]] = {}
+        for r in runs:
+            by_model.setdefault(r.model, []).append(r)
+        assert set(by_model) == {"unet3d", "resnet50"}
+        assert len(by_model["unet3d"]) == 5
+        assert len(by_model["resnet50"]) == 5
+
+    def test_checker_run_consistency_catches_mixed_models(self, tmp_path, mock_logger):
+        """If a caller incorrectly hands a mixed-model list to the checker,
+        check_run_consistency flags it as INVALID."""
+        results_dir = tmp_path / "results"
+        make_training_run(results_dir, model="unet3d", run_datetime="20250111_140000")
+        make_training_run(results_dir, model="resnet50", run_datetime="20250111_150000")
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+        assert len(runs) == 2
+
+        checker = MultiRunRulesChecker(runs, logger=mock_logger)
+        issue = checker.check_run_consistency()
+
+        assert issue is not None
+        assert issue.validation == PARAM_VALIDATION.INVALID
+        assert issue.parameter == "model"
+
+    def test_multi_run_checker_accepts_mixed_benchmark_types(
+        self, tmp_path, mock_logger
+    ):
+        """Documents a defensive-coding gap: MultiRunRulesChecker does NOT
+        verify that all runs share a benchmark_type — that enforcement lives
+        only in BenchmarkVerifier._create_rules_checker (verifier.py:106-108).
+        A caller bypassing the verifier can hand it a heterogeneous list
+        without an error. If model also happens to match across types,
+        check_run_consistency will return None too. PR 2 candidate fix.
+        """
+        results_dir = tmp_path / "results"
+        # Same model name across types — manufactured to bypass the model check
+        make_training_run(results_dir, model="shared-model", run_datetime="20250111_140000")
+        make_checkpointing_run(results_dir, model="shared-model", run_datetime="20250111_150000")
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+        assert len(runs) == 2
+        assert {r.benchmark_type for r in runs} == {
+            BENCHMARK_TYPES.training,
+            BENCHMARK_TYPES.checkpointing,
+        }
+
+        checker = MultiRunRulesChecker(runs, logger=mock_logger)
+        assert checker.check_run_consistency() is None, (
+            "Current behavior: model-only consistency check misses type drift. "
+            "PR 2 should also enforce benchmark_type consistency here."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Documented limitation: vectordb/kvcache lack model/engine in path AND metadata,
+# so two distinct workloads of the same type cannot be told apart today.
+# (Resolved in PR 3 for vectordb and PR 4 for kvcache.)
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewBenchmarkAccumulationLimitation:
+    """Locks down the current (buggy) behavior so PR 3/4 changes are visible."""
+
+    def test_vectordb_runs_have_no_model(self, tmp_path, mock_logger):
+        """Two vectordb runs are discovered, but both have model=None — there is
+        no way today to distinguish e.g. milvus from elasticsearch results.
+        PR 3 will add an engine component to both the path and the metadata."""
+        results_dir = tmp_path / "results"
+        make_vectordb_run(results_dir, run_datetime="20250111_160000")
+        make_vectordb_run(results_dir, run_datetime="20250111_160100")
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+
+        assert len(runs) == 2
+        assert all(r.model is None for r in runs), (
+            "Current behavior: vectordb runs lack model — fix in PR 3."
+        )
+
+    def test_kvcache_runs_have_no_model(self, tmp_path, mock_logger):
+        """Same shape as the vectordb limitation. PR 4 adds model to kvcache."""
+        results_dir = tmp_path / "results"
+        make_kvcache_run(results_dir, run_datetime="20250111_170000")
+        make_kvcache_run(results_dir, run_datetime="20250111_170100")
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+
+        assert len(runs) == 2
+        assert all(r.model is None for r in runs), (
+            "Current behavior: kvcache runs lack model — fix in PR 4."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Negative cases: corrupt / partial run directories
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryNegativeCases:
+    """get_runs_files should isolate failures, not abort the whole walk."""
+
+    def test_corrupt_metadata_skipped_and_warned(self, tmp_path, mock_logger):
+        results_dir = tmp_path / "results"
+
+        # Good run
+        make_training_run(results_dir, run_datetime="20250111_140000")
+
+        # Corrupt run — valid path, garbage JSON
+        bad_dir = results_dir / "training" / "unet3d" / "run" / "20250111_150000"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "training_20250111_150000_metadata.json").write_text("{not json")
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+
+        assert len(runs) == 1, "Good run should still be discovered"
+        assert runs[0].run_datetime == "20250111_140000"
+        mock_logger.warning.assert_called()
+
+    def test_directory_with_no_metadata_or_summary_ignored(self, tmp_path, mock_logger):
+        results_dir = tmp_path / "results"
+        # An orphan timestamp directory the user dropped in — no manifest files
+        orphan = results_dir / "training" / "unet3d" / "run" / "20250111_140000"
+        orphan.mkdir(parents=True)
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+        assert runs == []
+
+    def test_multiple_metadata_files_in_one_dir_skipped(self, tmp_path, mock_logger):
+        """get_runs_files (utils.py:216-219) explicitly skips dirs with >1 metadata
+        file — defensively guards against ambiguous accumulation state."""
+        results_dir = tmp_path / "results"
+        make_training_run(results_dir, run_datetime="20250111_140000")
+
+        # Now drop a second metadata file alongside the good one
+        bad_dir = results_dir / "training" / "unet3d" / "run" / "20250111_140000"
+        (bad_dir / "training_20250111_999999_metadata.json").write_text("{}")
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+        assert runs == []
+        mock_logger.warning.assert_called()
+
+    def test_summary_only_no_metadata_produces_typeless_run(
+        self, tmp_path, mock_logger
+    ):
+        """summary.json without metadata triggers the DLIOResultParser fallback.
+
+        Today, a summary.json with no Hydra configs and no workflow signal
+        produces a BenchmarkRun with benchmark_type=None — the parser does not
+        raise, and discovery accepts the run. Downstream the BenchmarkVerifier
+        will reject it ('Unsupported benchmark type'), but the run still appears
+        in get_runs_files output. PR 2 should reject these earlier rather than
+        leaking typeless runs into accumulation.
+        """
+        results_dir = tmp_path / "results"
+        run_dir = results_dir / "training" / "unet3d" / "run" / "20250111_140000"
+        run_dir.mkdir(parents=True)
+        (run_dir / "summary.json").write_text(json.dumps({"start": "x", "metric": {}}))
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+
+        assert len(runs) == 1, (
+            "Current behavior: typeless run leaks through. PR 2 should reject."
+        )
+        assert runs[0].benchmark_type is None
+
+    def test_nonexistent_results_dir_returns_empty(self, tmp_path, mock_logger):
+        runs = get_runs_files(str(tmp_path / "does-not-exist"), logger=mock_logger)
+        assert runs == []
+        mock_logger.warning.assert_called()
+
+    def test_symlinked_run_directory_is_not_followed(self, tmp_path, mock_logger):
+        """os.walk in get_runs_files (utils.py:210) uses the default
+        followlinks=False. A user who symlinks a previously-completed run into
+        the results tree to 'accumulate' it will see it silently skipped.
+        Documents current behavior — PR 2 may want to either follow symlinks
+        or warn explicitly that symlinks are unsupported.
+        """
+        results_dir = tmp_path / "results"
+        # Real run lives outside the results tree
+        external = tmp_path / "external"
+        make_training_run(external, run_datetime="20250111_140000")
+        external_run_path = external / "training" / "unet3d" / "run" / "20250111_140000"
+
+        # User symlinks the whole run directory under results_dir
+        symlink_parent = results_dir / "training" / "unet3d" / "run"
+        symlink_parent.mkdir(parents=True)
+        (symlink_parent / "20250111_140000").symlink_to(external_run_path)
+
+        runs = get_runs_files(str(results_dir), logger=mock_logger)
+
+        assert runs == [], (
+            "Current behavior: symlinked runs are silently skipped. "
+            "PR 2 should decide: follow or warn."
+        )

--- a/tests/unit/test_accumulation.py
+++ b/tests/unit/test_accumulation.py
@@ -21,6 +21,11 @@ from typing import Optional
 
 import pytest
 
+from mlpstorage_py.run_directory import (
+    DEFAULT_COLLISION_BUMP_BUDGET,
+    bump_datetime_one_second,
+    reserve_run_directory,
+)
 from mlpstorage_py.config import BENCHMARK_TYPES, PARAM_VALIDATION
 from mlpstorage_py.rules import BenchmarkRun, get_runs_files
 from mlpstorage_py.rules.submission_checkers.training import (
@@ -347,16 +352,13 @@ class TestWorkloadSeparation:
         assert issue.validation == PARAM_VALIDATION.INVALID
         assert issue.parameter == "model"
 
-    def test_multi_run_checker_accepts_mixed_benchmark_types(
+    def test_multi_run_checker_rejects_mixed_benchmark_types(
         self, tmp_path, mock_logger
     ):
-        """Documents a defensive-coding gap: MultiRunRulesChecker does NOT
-        verify that all runs share a benchmark_type — that enforcement lives
-        only in BenchmarkVerifier._create_rules_checker (verifier.py:106-108).
-        A caller bypassing the verifier can hand it a heterogeneous list
-        without an error. If model also happens to match across types,
-        check_run_consistency will return None too. PR 2 candidate fix.
-        """
+        """MultiRunRulesChecker.check_benchmark_type_consistency flags INVALID
+        when runs span more than one benchmark_type, even if model names
+        coincide. This defends against silent grouping bugs when a caller
+        bypasses BenchmarkVerifier's dispatch-time type guard."""
         results_dir = tmp_path / "results"
         # Same model name across types — manufactured to bypass the model check
         make_training_run(results_dir, model="shared-model", run_datetime="20250111_140000")
@@ -370,10 +372,13 @@ class TestWorkloadSeparation:
         }
 
         checker = MultiRunRulesChecker(runs, logger=mock_logger)
-        assert checker.check_run_consistency() is None, (
-            "Current behavior: model-only consistency check misses type drift. "
-            "PR 2 should also enforce benchmark_type consistency here."
-        )
+        # Model check still passes (names coincide)
+        assert checker.check_run_consistency() is None
+        # But type check fires
+        type_issue = checker.check_benchmark_type_consistency()
+        assert type_issue is not None
+        assert type_issue.validation == PARAM_VALIDATION.INVALID
+        assert type_issue.parameter == "benchmark_type"
 
 
 # ---------------------------------------------------------------------------
@@ -463,17 +468,11 @@ class TestDiscoveryNegativeCases:
         assert runs == []
         mock_logger.warning.assert_called()
 
-    def test_summary_only_no_metadata_produces_typeless_run(
-        self, tmp_path, mock_logger
-    ):
-        """summary.json without metadata triggers the DLIOResultParser fallback.
-
-        Today, a summary.json with no Hydra configs and no workflow signal
-        produces a BenchmarkRun with benchmark_type=None — the parser does not
-        raise, and discovery accepts the run. Downstream the BenchmarkVerifier
-        will reject it ('Unsupported benchmark type'), but the run still appears
-        in get_runs_files output. PR 2 should reject these earlier rather than
-        leaking typeless runs into accumulation.
+    def test_summary_only_no_metadata_is_rejected(self, tmp_path, mock_logger):
+        """A summary.json with no workflow signal and no Hydra configs cannot
+        be classified as a benchmark type. DLIOResultParser raises and
+        get_runs_files swallows the exception with a warning — the bogus run
+        does NOT leak into accumulation.
         """
         results_dir = tmp_path / "results"
         run_dir = results_dir / "training" / "unet3d" / "run" / "20250111_140000"
@@ -482,23 +481,19 @@ class TestDiscoveryNegativeCases:
 
         runs = get_runs_files(str(results_dir), logger=mock_logger)
 
-        assert len(runs) == 1, (
-            "Current behavior: typeless run leaks through. PR 2 should reject."
-        )
-        assert runs[0].benchmark_type is None
+        assert runs == []
+        mock_logger.warning.assert_called()
 
     def test_nonexistent_results_dir_returns_empty(self, tmp_path, mock_logger):
         runs = get_runs_files(str(tmp_path / "does-not-exist"), logger=mock_logger)
         assert runs == []
         mock_logger.warning.assert_called()
 
-    def test_symlinked_run_directory_is_not_followed(self, tmp_path, mock_logger):
-        """os.walk in get_runs_files (utils.py:210) uses the default
-        followlinks=False. A user who symlinks a previously-completed run into
-        the results tree to 'accumulate' it will see it silently skipped.
-        Documents current behavior — PR 2 may want to either follow symlinks
-        or warn explicitly that symlinks are unsupported.
-        """
+    def test_symlinked_run_directory_is_followed(self, tmp_path, mock_logger):
+        """A user can symlink a previously-completed run directory into a
+        results-dir to accumulate it. get_runs_files follows symlinks so the
+        run is discovered. Stitching together results from multiple machines
+        or earlier batches is a real workflow."""
         results_dir = tmp_path / "results"
         # Real run lives outside the results tree
         external = tmp_path / "external"
@@ -512,7 +507,86 @@ class TestDiscoveryNegativeCases:
 
         runs = get_runs_files(str(results_dir), logger=mock_logger)
 
-        assert runs == [], (
-            "Current behavior: symlinked runs are silently skipped. "
-            "PR 2 should decide: follow or warn."
+        assert len(runs) == 1
+        assert runs[0].benchmark_type == BENCHMARK_TYPES.training
+        assert runs[0].model == "unet3d"
+
+
+# ---------------------------------------------------------------------------
+# Sub-second collision handling for run directory creation
+# (mlpstorage_py/benchmarks/run_directory.py)
+# ---------------------------------------------------------------------------
+
+
+def _flat_path_for(base: Path):
+    return lambda dt: str(base / dt)
+
+
+class TestBumpDatetimeOneSecond:
+    def test_bumps_one_second_forward(self):
+        assert bump_datetime_one_second("20250111_140000") == "20250111_140001"
+
+    def test_rolls_over_minute(self):
+        assert bump_datetime_one_second("20250111_140059") == "20250111_140100"
+
+    def test_rolls_over_day(self):
+        assert bump_datetime_one_second("20250111_235959") == "20250112_000000"
+
+
+class TestReserveRunDirectory:
+    def test_creates_dir_when_no_collision(self, tmp_path):
+        reserved, final_dt = reserve_run_directory(
+            "20250111_140000", _flat_path_for(tmp_path)
         )
+        assert reserved == str(tmp_path / "20250111_140000")
+        assert Path(reserved).is_dir()
+        assert final_dt == "20250111_140000"
+
+    def test_bumps_past_existing_directory(self, tmp_path):
+        (tmp_path / "20250111_140000").mkdir()
+        (tmp_path / "20250111_140001").mkdir()
+
+        reserved, final_dt = reserve_run_directory(
+            "20250111_140000", _flat_path_for(tmp_path)
+        )
+
+        assert reserved == str(tmp_path / "20250111_140002")
+        assert final_dt == "20250111_140002", (
+            "Caller must observe the bumped datetime so metadata filenames match."
+        )
+
+    def test_raises_when_budget_exhausted(self, tmp_path):
+        start = "20250111_140000"
+        cur = start
+        for _ in range(DEFAULT_COLLISION_BUMP_BUDGET):
+            (tmp_path / cur).mkdir()
+            cur = bump_datetime_one_second(cur)
+
+        with pytest.raises(RuntimeError, match="Could not reserve a unique"):
+            reserve_run_directory(start, _flat_path_for(tmp_path))
+
+    def test_creates_parent_dirs(self, tmp_path):
+        nested = tmp_path / "results" / "training" / "unet3d" / "run"
+        # Don't pre-create the parent — reserve_run_directory should
+        reserved, _ = reserve_run_directory(
+            "20250111_140000", _flat_path_for(nested)
+        )
+        assert Path(reserved).is_dir()
+        assert Path(reserved).parent == nested
+
+    def test_small_budget(self, tmp_path):
+        """Custom budget overrides DEFAULT_COLLISION_BUMP_BUDGET."""
+        (tmp_path / "20250111_140000").mkdir()
+        (tmp_path / "20250111_140001").mkdir()
+
+        # budget=2 means it tries 14:00:00 (taken) and 14:00:01 (taken) then gives up
+        with pytest.raises(RuntimeError):
+            reserve_run_directory(
+                "20250111_140000", _flat_path_for(tmp_path), budget=2
+            )
+
+        # budget=3 succeeds at 14:00:02
+        reserved, final_dt = reserve_run_directory(
+            "20250111_140000", _flat_path_for(tmp_path), budget=3
+        )
+        assert final_dt == "20250111_140002"

--- a/tests/unit/test_benchmarks_base.py
+++ b/tests/unit/test_benchmarks_base.py
@@ -196,7 +196,6 @@ class TestBenchmarkWriteMetadata:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             return ConcreteBenchmark(args, run_datetime="20250115_120000")
 
     def test_writes_metadata_file(self, benchmark):
@@ -235,7 +234,6 @@ class TestBenchmarkExecuteCommand:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             return ConcreteBenchmark(args, run_datetime="20250115_120000")
 
     def test_what_if_mode_skips_execution(self, benchmark):
@@ -306,7 +304,6 @@ class TestBenchmarkVerifyBenchmark:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             return ConcreteBenchmark(args, run_datetime="20250115_120000")
 
     def test_returns_true_for_closed_verification(self, benchmark):
@@ -395,7 +392,6 @@ class TestBenchmarkVerifyBenchmark:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = ConcreteBenchmark(args, run_datetime="20250115_120000")
 
         with patch('mlpstorage_py.benchmarks.base.BenchmarkVerifier') as mock_verifier_class:
@@ -429,7 +425,6 @@ class TestBenchmarkRun:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             return ConcreteBenchmark(args, run_datetime="20250115_120000")
 
     def test_calls_run_method(self, benchmark):
@@ -504,7 +499,6 @@ class TestBenchmarkGenerateOutputLocation:
         # Create a valid benchmark first
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = ConcreteBenchmark(args)
 
         # Then set BENCHMARK_TYPE to None on the instance
@@ -620,7 +614,6 @@ class TestBenchmarkValidation:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = TrackingBenchmark(basic_args)
 
         benchmark.run()
@@ -643,7 +636,6 @@ class TestBenchmarkValidation:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = CustomValidationBenchmark(basic_args)
 
         benchmark.run()
@@ -669,7 +661,6 @@ class TestBenchmarkValidation:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = FailingValidationBenchmark(basic_args)
 
         with pytest.raises(DependencyError):
@@ -683,7 +674,6 @@ class TestBenchmarkValidation:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = ConcreteBenchmark(basic_args)
 
         # Should not raise any exception
@@ -706,7 +696,6 @@ class TestBenchmarkValidation:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = ConfigErrorBenchmark(basic_args)
 
         with pytest.raises(ConfigurationError):
@@ -746,7 +735,6 @@ class TestBenchmarkCollectionSelection:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = ConcreteBenchmark(args, logger=mock_logger, run_datetime='20260124_120000')
 
         return benchmark
@@ -879,7 +867,6 @@ class TestBenchmarkClusterSnapshots:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             with patch.object(ClusterInformation, 'from_mpi_collection') as mock_from_mpi:
                 mock_cluster_info = MagicMock()
                 mock_cluster_info.num_hosts = 1
@@ -927,7 +914,6 @@ class TestBenchmarkClusterSnapshots:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             with patch.object(ClusterInformation, 'from_mpi_collection') as mock_from_mpi:
                 mock_cluster_info = MagicMock()
                 mock_cluster_info.num_hosts = 1
@@ -977,7 +963,6 @@ class TestBenchmarkClusterSnapshots:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = TrackingBenchmark(args, logger=mock_logger, run_datetime='20260124_120000')
 
         benchmark.run()
@@ -1002,7 +987,6 @@ class TestBenchmarkClusterSnapshots:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = ConcreteBenchmark(args, logger=mock_logger, run_datetime='20260124_120000')
 
         # Mock ClusterSnapshots
@@ -1031,7 +1015,6 @@ class TestBenchmarkClusterSnapshots:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = ConcreteBenchmark(args, logger=mock_logger, run_datetime='20260124_120000')
 
         # Call end collection without start collection
@@ -1080,7 +1063,6 @@ class TestTimeSeriesCollectionIntegration:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = ConcreteBenchmark(args, logger=mock_logger, run_datetime='20260124_120000')
 
         return benchmark
@@ -1414,7 +1396,6 @@ class TestBenchmarkProgress:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = ConcreteBenchmark(args, logger=mock_logger, run_datetime='20260125_120000')
 
         return benchmark
@@ -1567,7 +1548,6 @@ class TestBenchmarkProgress:
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
             mock_gen.return_value = str(tmp_path / "output")
-            os.makedirs(tmp_path / "output", exist_ok=True)
             benchmark = ExceptionRaisingBenchmark(args, logger=mock_logger, run_datetime='20260125_120000')
 
         with pytest.raises(RuntimeError, match="Test exception"):

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -71,7 +71,6 @@ class TestKVCacheClusterCollection:
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
             mock_cluster.return_value = MagicMock()
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
             benchmark = KVCacheBenchmark(basic_args, run_datetime="20250115_120000")
@@ -87,7 +86,6 @@ class TestKVCacheClusterCollection:
              patch('mlpstorage_py.benchmarks.kvcache.KVCacheBenchmark._collect_cluster_information') as mock_cluster:
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
             benchmark = KVCacheBenchmark(basic_args, run_datetime="20250115_120000")
@@ -139,7 +137,6 @@ class TestKVCacheNumProcessesStorage:
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
             mock_cluster.return_value = None
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
             benchmark = KVCacheBenchmark(basic_args, run_datetime="20250115_120000")
@@ -155,7 +152,6 @@ class TestKVCacheNumProcessesStorage:
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
             mock_cluster.return_value = None
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
             benchmark = KVCacheBenchmark(basic_args, run_datetime="20250115_120000")
@@ -218,7 +214,6 @@ class TestKVCacheMetadata:
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
             mock_cluster.return_value = None
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
             bm = KVCacheBenchmark(base_args, logger=mock_logger, run_datetime="20250124_120000")
@@ -238,7 +233,6 @@ class TestKVCacheMetadata:
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
             mock_cluster.return_value = None
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
             bm = KVCacheBenchmark(base_args, logger=mock_logger, run_datetime="20250124_120000")
@@ -263,7 +257,6 @@ class TestKVCacheMetadata:
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
             mock_cluster.return_value = None
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
             bm = KVCacheBenchmark(base_args, logger=mock_logger, run_datetime="20250124_120000")
@@ -284,7 +277,6 @@ class TestKVCacheMetadata:
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
             mock_cluster.return_value = None
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
             bm = KVCacheBenchmark(base_args, logger=mock_logger, run_datetime="20250124_120000")
@@ -302,7 +294,6 @@ class TestKVCacheMetadata:
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
             mock_cluster.return_value = None
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
             bm = KVCacheBenchmark(base_args, logger=mock_logger, run_datetime="20250124_120000")
@@ -355,7 +346,6 @@ def _make_run_benchmark(tmp_path, what_if=False):
         open=False,
     )
     output_dir = str(tmp_path / 'run_output')
-    os.makedirs(output_dir, exist_ok=True)
     with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen, \
          patch('mlpstorage_py.benchmarks.kvcache.KVCacheBenchmark._collect_cluster_information',
                return_value=None):

--- a/tests/unit/test_benchmarks_vectordb.py
+++ b/tests/unit/test_benchmarks_vectordb.py
@@ -46,7 +46,6 @@ class TestVectorDBCommandMap:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(basic_args)
@@ -62,7 +61,6 @@ class TestVectorDBCommandMap:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(basic_args)
@@ -77,7 +75,6 @@ class TestVectorDBCommandMap:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(basic_args)
@@ -144,7 +141,6 @@ class TestVectorDBMetadata:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(run_args)
@@ -165,7 +161,6 @@ class TestVectorDBMetadata:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(run_args)
@@ -186,7 +181,6 @@ class TestVectorDBMetadata:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(run_args)
@@ -203,7 +197,6 @@ class TestVectorDBMetadata:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(run_args)
@@ -224,7 +217,6 @@ class TestVectorDBMetadata:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(datagen_args)
@@ -252,7 +244,6 @@ class TestVectorDBMetadata:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(run_args)
@@ -269,7 +260,6 @@ class TestVectorDBMetadata:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(run_args)
@@ -290,7 +280,6 @@ class TestVectorDBMetadata:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(datagen_args)
@@ -339,7 +328,6 @@ class TestVectorDBBenchmarkType:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark.verify_benchmark'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             from mlpstorage_py.config import BENCHMARK_TYPES
@@ -354,7 +342,6 @@ class TestVectorDBBenchmarkType:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(basic_args)
@@ -398,7 +385,6 @@ class TestVectorDBConfigHandling:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(basic_args)
@@ -415,7 +401,6 @@ class TestVectorDBConfigHandling:
              patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
             output_dir = str(tmp_path / "output")
             mock_gen.return_value = output_dir
-            os.makedirs(output_dir, exist_ok=True)
 
             from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
             bm = VectorDBBenchmark(basic_args)


### PR DESCRIPTION
## Summary

Foundation work for incremental results accumulation, in two atomic commits:

- **PR 1 (test scaffolding)** — `tests/unit/test_accumulation.py` synthesizes per-benchmark results trees under `tmp_path` and drives the **real** `get_runs_files()` walk (no mocking of discovery). Covers 17 scenarios the existing mocked tests in `test_reporting.py` couldn't: heterogeneous trees (training + checkpointing), the N=5 gate in `TrainingSubmissionRulesChecker`, multi-workload separation (5x unet3d + 5x resnet50), and negative cases (corrupt JSON, missing manifests, multiple metadata files, nonexistent dirs, symlinks).

- **PR 2 (fixes for what PR 1 surfaced)** —
  - `DLIOResultParser.parse()` now raises instead of silently producing `benchmark_type=None`.
  - `MultiRunRulesChecker.check_benchmark_type_consistency` defends against callers bypassing `BenchmarkVerifier`'s dispatch-time type guard.
  - `get_runs_files` uses `followlinks=True` so symlinked runs accumulate cleanly.
  - New `mlpstorage_py/run_directory.py` provides exclusive-create + bounded one-second forward bumps on sub-second timestamp collisions, replacing the prior `os.makedirs(exist_ok=True)` in `Benchmark.__init__`. Tests in `test_benchmarks_kvcache.py` / `test_benchmarks_vectordb.py` that pre-created the output dir under the old semantics are updated.

The bug-surfacing tests from PR 1 are flipped to assert the fixed contracts in PR 2.

This PR is the prerequisite for two follow-up PRs (each code-owner-scoped) targeting this branch:
- `feat(vectordb): add --vdb-engine and include engine in results-dir path` (VDB)
- `feat(kvcache): include model in results-dir path` (KVCache)

## Test plan

- [ ] `pytest tests/unit -q` — full suite passes (1249 pass / 4 skip / 1 pre-existing failure unrelated to this work)
- [ ] `pytest tests/unit/test_accumulation.py -v` — all 25 accumulation tests green
- [ ] No production code change requires manual smoke; behavior verified through tests