### PR TITLE
vectordb: add --vdb-engine and include engine in results-dir path

### DIFF
--- a/mlpstorage_py/benchmarks/vectordbbench.py
+++ b/mlpstorage_py/benchmarks/vectordbbench.py
@@ -50,6 +50,14 @@ class VectorDBBenchmark(Benchmark):
     SUMMARY_PREFIX = "VDB_MULTI_NODE_SUMMARY_JSON="
 
     def __init__(self, args, **kwargs):
+        # Mirror the engine into args.model so the existing
+        # metadata extractor (BenchmarkInstanceExtractor) and workload
+        # grouping (ReportGenerator._process_workload_groups, keyed on
+        # (model, accelerator)) treat distinct engines as distinct
+        # workloads — accumulated runs from milvus vs a future engine
+        # stay correctly separated.
+        if hasattr(args, "vdb_engine") and getattr(args, "model", None) is None:
+            args.model = args.vdb_engine
         super().__init__(args, **kwargs)
 
         self.command_method_map = {
@@ -974,7 +982,11 @@ class VectorDBBenchmark(Benchmark):
             {
                 "vectordb_config": self.config_name,
                 "vectordb_config_file": self.config_file,
-                "model": self.config_name,
+                # NB: do NOT set "model" here — the base class records the
+                # engine (via args.model = args.vdb_engine in __init__) and
+                # downstream workload grouping in ReportGenerator keys on it.
+                # Overwriting with config_name would merge distinct engines
+                # that happen to share a config file into one workload.
                 "host": getattr(self.args, "host", "127.0.0.1"),
                 "port": getattr(self.args, "port", 19530),
                 "collection": getattr(self.args, "collection", None),

--- a/mlpstorage_py/cli/vectordb_args.py
+++ b/mlpstorage_py/cli/vectordb_args.py
@@ -26,6 +26,8 @@ from mlpstorage_py.config import (
     VECTOR_DTYPES,
     VECTORDB_DEFAULT_RUNTIME,
     VDB_BENCHMARK_MODES,
+    VDB_ENGINE_DEFAULT,
+    VDB_ENGINES,
     VDB_INDEX_TYPES,
     VDB_INDEX_TYPES_CLOSED,
 )
@@ -205,6 +207,20 @@ def _add_vectordb_core_args(parser, command, index_choices):
     """
     # Set defaults for open-gated attrs so they always exist in the namespace.
     parser.set_defaults(loops=1, params='', allow_invalid_params=False)
+
+    # The engine identifies which vector database implementation is being
+    # benchmarked (milvus today). It is recorded in the results-dir path
+    # and metadata so accumulated runs from different engines coexist.
+    parser.add_argument(
+        '--vdb-engine',
+        choices=VDB_ENGINES,
+        default=VDB_ENGINE_DEFAULT,
+        help=(
+            "Vector database engine being benchmarked. "
+            "Recorded in the result path so multiple engines can accumulate "
+            "in one --results-dir without collision."
+        ),
+    )
 
     # ---- Common args for datagen and run ----
     if command in ("datagen", "run"):

--- a/mlpstorage_py/config.py
+++ b/mlpstorage_py/config.py
@@ -120,6 +120,11 @@ VDB_INDEX_TYPES = ["DISKANN", "HNSW", "AISAQ", "IVF_FLAT", "IVF_SQ8", "FLAT"]
 VDB_INDEX_TYPES_CLOSED = ["DISKANN", "HNSW", "AISAQ"]
 VDB_ORCHESTRATION_MODES = ["ssh", "mpi"]
 VDB_BENCHMARK_MODES = ["timed", "query_count", "sweep"]
+# Vector-database engines. Only milvus is wired up today; the slot exists so
+# accumulated results from multiple engines can coexist in one results-dir
+# (path: vector_database/<engine>/<command>/<datetime>/).
+VDB_ENGINES = ["milvus"]
+VDB_ENGINE_DEFAULT = "milvus"
 
 MPIRUN = "mpirun"
 MPIEXEC = "mpiexec"

--- a/mlpstorage_py/reporting/directory_validator.py
+++ b/mlpstorage_py/reporting/directory_validator.py
@@ -246,6 +246,12 @@ Expected results directory structure:
             checkpointing_llama3-8b_metadata.json
             summary.json
 
+    vector_database/
+      milvus/                          # VDB engine (--vdb-engine)
+        run/
+          20250115_160000/
+            vector_database_20250115_160000_metadata.json
+
     kv_cache/
       llama3.1-8b/
         run/

--- a/mlpstorage_py/rules/utils.py
+++ b/mlpstorage_py/rules/utils.py
@@ -162,7 +162,14 @@ def generate_output_location(benchmark, datetime_str=None, **kwargs) -> str:
         output_location = os.path.join(output_location, datetime_str)
 
     elif benchmark.BENCHMARK_TYPE == BENCHMARK_TYPES.vector_database:
+        engine = getattr(benchmark.args, "vdb_engine", None)
+        if not engine:
+            raise ValueError(
+                "VectorDB engine is required for output location "
+                "(set --vdb-engine on the CLI)."
+            )
         output_location = os.path.join(output_location, benchmark.BENCHMARK_TYPE.name)
+        output_location = os.path.join(output_location, engine)
         output_location = os.path.join(output_location, benchmark.args.command)
         output_location = os.path.join(output_location, datetime_str)
 

--- a/tests/unit/test_accumulation.py
+++ b/tests/unit/test_accumulation.py
@@ -154,22 +154,24 @@ def make_checkpointing_run(
 def make_vectordb_run(
     results_dir: Path,
     *,
+    engine: str = "milvus",
     run_datetime: str = "20250111_160000",
     command: str = "run",
     include_summary: bool = True,
 ) -> Path:
-    """Create one vectordb run at results_dir/vector_database/<command>/<datetime>/.
+    """Create one vectordb run at
+    results_dir/vector_database/<engine>/<command>/<datetime>/.
 
-    The current path layout has no engine/backend component — this is what
-    PR 3 will add. Builder mirrors current production behavior so tests
-    document the limitation.
+    The engine is recorded as model in metadata (matches how
+    VectorDBBenchmark.__init__ mirrors args.vdb_engine into args.model so
+    grouping by (model, accelerator) treats engines as distinct workloads).
     """
-    run_dir = results_dir / "vector_database" / command / run_datetime
+    run_dir = results_dir / "vector_database" / engine / command / run_datetime
     return _write_run(
         run_dir,
         benchmark_type="vector_database",
         run_datetime=run_datetime,
-        model=None,
+        model=engine,
         accelerator=None,
         command=command,
         parameters={"workload": "vdb"},
@@ -388,26 +390,68 @@ class TestWorkloadSeparation:
 # ---------------------------------------------------------------------------
 
 
-class TestPreviewBenchmarkAccumulationLimitation:
-    """Locks down the current (buggy) behavior so PR 3/4 changes are visible."""
+class TestPreviewBenchmarkAccumulation:
+    """Accumulation behavior for preview benchmarks (vectordb, kvcache).
 
-    def test_vectordb_runs_have_no_model(self, tmp_path, mock_logger):
-        """Two vectordb runs are discovered, but both have model=None — there is
-        no way today to distinguish e.g. milvus from elasticsearch results.
-        PR 3 will add an engine component to both the path and the metadata."""
+    VectorDB now (PR 3) records an engine in the path and metadata; kvcache
+    still lacks a model component (PR 4)."""
+
+    def test_vectordb_path_includes_engine(self, tmp_path):
+        """generate_output_location produces vector_database/<engine>/<command>/<datetime>/."""
+        from types import SimpleNamespace
+
+        from mlpstorage_py.config import BENCHMARK_TYPES as _BT
+        from mlpstorage_py.rules.utils import generate_output_location
+
+        fake_benchmark = SimpleNamespace(
+            BENCHMARK_TYPE=_BT.vector_database,
+            args=SimpleNamespace(
+                results_dir=str(tmp_path),
+                command="run",
+                vdb_engine="milvus",
+            ),
+        )
+        location = generate_output_location(fake_benchmark, datetime_str="20250111_160000")
+        assert location == str(
+            tmp_path / "vector_database" / "milvus" / "run" / "20250111_160000"
+        )
+
+    def test_vectordb_path_requires_engine(self, tmp_path):
+        """Without vdb_engine, generate_output_location refuses to build a path."""
+        from types import SimpleNamespace
+
+        from mlpstorage_py.config import BENCHMARK_TYPES as _BT
+        from mlpstorage_py.rules.utils import generate_output_location
+
+        fake_benchmark = SimpleNamespace(
+            BENCHMARK_TYPE=_BT.vector_database,
+            args=SimpleNamespace(
+                results_dir=str(tmp_path),
+                command="run",
+                # no vdb_engine
+            ),
+        )
+        with pytest.raises(ValueError, match="VectorDB engine is required"):
+            generate_output_location(fake_benchmark, datetime_str="20250111_160000")
+
+    def test_vectordb_runs_distinguished_by_engine(self, tmp_path, mock_logger):
+        """Two vectordb engines accumulate in one results-dir without collision.
+        Each run's metadata records the engine in the model slot so workload
+        grouping by (model, accelerator) treats them as distinct workloads."""
         results_dir = tmp_path / "results"
-        make_vectordb_run(results_dir, run_datetime="20250111_160000")
-        make_vectordb_run(results_dir, run_datetime="20250111_160100")
+        make_vectordb_run(results_dir, engine="milvus", run_datetime="20250111_160000")
+        make_vectordb_run(results_dir, engine="milvus", run_datetime="20250111_160100")
+        # A hypothetical future engine in the same tree.
+        make_vectordb_run(results_dir, engine="elasticsearch", run_datetime="20250111_160200")
 
         runs = get_runs_files(str(results_dir), logger=mock_logger)
 
-        assert len(runs) == 2
-        assert all(r.model is None for r in runs), (
-            "Current behavior: vectordb runs lack model — fix in PR 3."
-        )
+        assert len(runs) == 3
+        engines = sorted(r.model for r in runs)
+        assert engines == ["elasticsearch", "milvus", "milvus"]
 
     def test_kvcache_runs_have_no_model(self, tmp_path, mock_logger):
-        """Same shape as the vectordb limitation. PR 4 adds model to kvcache."""
+        """Same shape as the prior vectordb limitation. PR 4 adds model to kvcache."""
         results_dir = tmp_path / "results"
         make_kvcache_run(results_dir, run_datetime="20250111_170000")
         make_kvcache_run(results_dir, run_datetime="20250111_170100")

--- a/tests/unit/test_benchmarks_vectordb.py
+++ b/tests/unit/test_benchmarks_vectordb.py
@@ -97,6 +97,7 @@ class TestVectorDBMetadata:
             results_dir=str(tmp_path),
             command='run',
             config='10m',
+            vdb_engine='milvus',
             host='192.168.1.100',
             port=19531,
             collection='test_collection',
@@ -119,6 +120,7 @@ class TestVectorDBMetadata:
             results_dir=str(tmp_path),
             command='datagen',
             config='default',
+            vdb_engine='milvus',
             host='127.0.0.1',
             port=19530,
             collection='gen_collection',
@@ -148,7 +150,8 @@ class TestVectorDBMetadata:
 
         # Required by history module
         assert 'benchmark_type' in meta
-        assert 'model' in meta  # Uses config_name
+        assert 'model' in meta  # Engine (vdb_engine), recorded so accumulated
+                                # results from multiple engines stay separate.
         assert 'command' in meta
         assert 'run_datetime' in meta
         assert 'result_dir' in meta
@@ -171,9 +174,14 @@ class TestVectorDBMetadata:
         assert 'port' in meta
         assert 'collection' in meta
 
-    def test_metadata_model_uses_config_name(self, run_args, tmp_path):
-        """Verify 'model' field uses config_name for history compatibility."""
+    def test_metadata_model_is_engine_config_preserved_separately(
+        self, run_args, tmp_path
+    ):
+        """'model' records the vdb_engine (so workload grouping treats engines
+        as distinct workloads), while 'vectordb_config' preserves the config
+        name for history/replay."""
         run_args.config = '10m'
+        run_args.vdb_engine = 'milvus'
 
         with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen, \
              patch('mlpstorage_py.benchmarks.vectordbbench.read_config_from_file', return_value={}), \
@@ -186,7 +194,7 @@ class TestVectorDBMetadata:
             bm = VectorDBBenchmark(run_args)
             meta = bm.metadata
 
-        assert meta['model'] == '10m'
+        assert meta['model'] == 'milvus'
         assert meta['vectordb_config'] == '10m'
 
     def test_metadata_run_command_fields(self, run_args, tmp_path):


### PR DESCRIPTION
## Summary

Adds an engine component to the VectorDB results-dir path so multiple engines (today: milvus; future: elasticsearch, etc.) accumulate without collision.

**Path change:** \`<results_dir>/vector_database/<engine>/<command>/<datetime>/\` (was \`vector_database/<command>/<datetime>/\`).

Changes (all VDB-scoped):
- \`config.py\`: \`VDB_ENGINES = [\"milvus\"]\`, \`VDB_ENGINE_DEFAULT = \"milvus\"\`.
- \`cli/vectordb_args.py\`: \`--vdb-engine\` on all subcommands (datasize/datagen/run).
- \`rules/utils.py\`: \`generate_output_location\` for \`vector_database\` inserts the engine; raises if missing.
- \`benchmarks/vectordbbench.py\`:
  - \`__init__\` mirrors \`args.vdb_engine\` into \`args.model\` before \`super().__init__()\`, so the existing metadata extractor and workload grouping (keyed on \`(model, accelerator)\`) treat distinct engines as distinct workloads.
  - **Removes \`\"model\": self.config_name\` from the metadata override.** That line had clobbered the engine and would have merged distinct engines sharing a config file into one workload bucket. \`config_name\` is still preserved as \`vectordb_config\`.
- \`reporting/directory_validator.py\`: documented expected structure updated.
- \`tests/unit/test_accumulation.py\`: \`make_vectordb_run\` takes \`engine\`; positive/negative path tests; converts the \"documents limitation\" test from the foundation PR into \`test_vectordb_runs_distinguished_by_engine\`.
- \`tests/unit/test_benchmarks_vectordb.py\`: fixtures gain \`vdb_engine\`; renames \`test_metadata_model_uses_config_name\` → \`test_metadata_model_is_engine_config_preserved_separately\` to assert the new contract.

**Backwards compatible:** old \`vector_database/<command>/<datetime>/\` trees still discover via \`get_runs_files\` (they appear with \`model=None\` and group separately from new engine-tagged runs in reports).

## Merge order

Targets the foundation branch (#441). Merge that first; then this PR's diff against main will be just the VDB changes.

## Test plan

- [ ] \`pytest tests/unit -q\` — full suite passes
- [ ] \`pytest tests/unit/test_accumulation.py tests/unit/test_benchmarks_vectordb.py -v\` — VDB and accumulation suites green