### PR TITLE
kvcache: include model in results-dir path

### DIFF
--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -26,6 +26,7 @@ from mlpstorage_py.benchmarks.base import Benchmark
 from mlpstorage_py.config import (
     BENCHMARK_TYPES,
     KVCACHE_DEFAULT_DURATION,
+    KVCACHE_MODEL_DEFAULT,
 )
 from mlpstorage_py.interfaces import BenchmarkCommand
 from mlpstorage_py.utils import generate_mpi_prefix_cmd, MLPSJsonEncoder
@@ -77,6 +78,13 @@ class KVCacheBenchmark(Benchmark):
             cluster_collector: Optional cluster collector for DI.
             validator: Optional validator for DI.
         """
+        # Closed-mode kvcache CLI does not expose --model (the model is fixed),
+        # so args.model may be absent. The model is required as a path
+        # component (kv_cache/<model>/<command>/<datetime>/) and as a
+        # workload-grouping key, so guarantee args.model is set with the
+        # closed-mode default before the base class computes the output path.
+        if getattr(args, "model", None) is None:
+            args.model = KVCACHE_MODEL_DEFAULT
         super().__init__(args, logger, run_datetime, run_number,
                          cluster_collector, validator)
 
@@ -93,8 +101,8 @@ class KVCacheBenchmark(Benchmark):
             "datasize": self._execute_datasize,
         }
 
-        # Store key parameters
-        self.model = getattr(args, 'model', 'llama3.1-8b')
+        # Store key parameters. args.model is guaranteed above.
+        self.model = args.model
         self.num_users = getattr(args, 'num_users', 100)
         self.duration = getattr(args, 'duration', KVCACHE_DEFAULT_DURATION)
 

--- a/mlpstorage_py/rules/utils.py
+++ b/mlpstorage_py/rules/utils.py
@@ -167,7 +167,15 @@ def generate_output_location(benchmark, datetime_str=None, **kwargs) -> str:
         output_location = os.path.join(output_location, datetime_str)
 
     elif benchmark.BENCHMARK_TYPE == BENCHMARK_TYPES.kv_cache:
+        model = getattr(benchmark.args, "model", None)
+        if not model:
+            raise ValueError(
+                "Model is required for kv_cache output location: set "
+                "args.model before calling generate_output_location "
+                "(KVCacheBenchmark.__init__ defaults this from KVCACHE_MODEL_DEFAULT)."
+            )
         output_location = os.path.join(output_location, benchmark.BENCHMARK_TYPE.name)
+        output_location = os.path.join(output_location, model)
         output_location = os.path.join(output_location, benchmark.args.command)
         output_location = os.path.join(output_location, datetime_str)
 

--- a/tests/unit/test_accumulation.py
+++ b/tests/unit/test_accumulation.py
@@ -180,20 +180,20 @@ def make_vectordb_run(
 def make_kvcache_run(
     results_dir: Path,
     *,
+    model: str = "llama3.1-8b",
     run_datetime: str = "20250111_170000",
     command: str = "run",
     include_summary: bool = True,
 ) -> Path:
-    """Create one kvcache run at results_dir/kv_cache/<command>/<datetime>/.
-
-    Current layout has no model component — PR 4 will add it.
+    """Create one kvcache run at
+    results_dir/kv_cache/<model>/<command>/<datetime>/.
     """
-    run_dir = results_dir / "kv_cache" / command / run_datetime
+    run_dir = results_dir / "kv_cache" / model / command / run_datetime
     return _write_run(
         run_dir,
         benchmark_type="kv_cache",
         run_datetime=run_datetime,
-        model=None,
+        model=model,
         accelerator=None,
         command=command,
         parameters={"workload": "kv"},
@@ -389,7 +389,8 @@ class TestWorkloadSeparation:
 
 
 class TestPreviewBenchmarkAccumulationLimitation:
-    """Locks down the current (buggy) behavior so PR 3/4 changes are visible."""
+    """VectorDB still lacks an engine component in path/metadata (PR 3 will fix).
+    KVCache now records the model — see TestKVCacheAccumulation below."""
 
     def test_vectordb_runs_have_no_model(self, tmp_path, mock_logger):
         """Two vectordb runs are discovered, but both have model=None — there is
@@ -406,18 +407,62 @@ class TestPreviewBenchmarkAccumulationLimitation:
             "Current behavior: vectordb runs lack model — fix in PR 3."
         )
 
-    def test_kvcache_runs_have_no_model(self, tmp_path, mock_logger):
-        """Same shape as the vectordb limitation. PR 4 adds model to kvcache."""
+
+class TestKVCacheAccumulation:
+    """KVCache now (this PR) records the model in path and metadata."""
+
+    def test_kvcache_path_includes_model(self, tmp_path):
+        """generate_output_location produces kv_cache/<model>/<command>/<datetime>/."""
+        from types import SimpleNamespace
+
+        from mlpstorage_py.config import BENCHMARK_TYPES as _BT
+        from mlpstorage_py.rules.utils import generate_output_location
+
+        fake_benchmark = SimpleNamespace(
+            BENCHMARK_TYPE=_BT.kv_cache,
+            args=SimpleNamespace(
+                results_dir=str(tmp_path),
+                command="run",
+                model="llama3.1-8b",
+            ),
+        )
+        location = generate_output_location(fake_benchmark, datetime_str="20250111_170000")
+        assert location == str(
+            tmp_path / "kv_cache" / "llama3.1-8b" / "run" / "20250111_170000"
+        )
+
+    def test_kvcache_path_requires_model(self, tmp_path):
+        """Without args.model, generate_output_location refuses to build a path."""
+        from types import SimpleNamespace
+
+        from mlpstorage_py.config import BENCHMARK_TYPES as _BT
+        from mlpstorage_py.rules.utils import generate_output_location
+
+        fake_benchmark = SimpleNamespace(
+            BENCHMARK_TYPE=_BT.kv_cache,
+            args=SimpleNamespace(
+                results_dir=str(tmp_path),
+                command="run",
+                # no model
+            ),
+        )
+        with pytest.raises(ValueError, match="Model is required for kv_cache"):
+            generate_output_location(fake_benchmark, datetime_str="20250111_170000")
+
+    def test_kvcache_runs_distinguished_by_model(self, tmp_path, mock_logger):
+        """Two kvcache models accumulate in one results-dir without collision.
+        Each run's metadata records the model so workload grouping by
+        (model, accelerator) treats them as distinct workloads."""
         results_dir = tmp_path / "results"
-        make_kvcache_run(results_dir, run_datetime="20250111_170000")
-        make_kvcache_run(results_dir, run_datetime="20250111_170100")
+        make_kvcache_run(results_dir, model="llama3.1-8b", run_datetime="20250111_170000")
+        make_kvcache_run(results_dir, model="llama3.1-8b", run_datetime="20250111_170100")
+        make_kvcache_run(results_dir, model="llama2-7b", run_datetime="20250111_170200")
 
         runs = get_runs_files(str(results_dir), logger=mock_logger)
 
-        assert len(runs) == 2
-        assert all(r.model is None for r in runs), (
-            "Current behavior: kvcache runs lack model — fix in PR 4."
-        )
+        assert len(runs) == 3
+        models = sorted(r.model for r in runs)
+        assert models == ["llama2-7b", "llama3.1-8b", "llama3.1-8b"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -285,6 +285,31 @@ class TestKVCacheMetadata:
         assert meta['model'] == 'llama3.1-70b-instruct'
         assert meta['kvcache_model'] == 'llama3.1-70b-instruct'
 
+    def test_metadata_closed_mode_defaults_model(self, base_args, mock_logger, tmp_path):
+        """In closed mode the CLI does not expose --model (see
+        _add_kvcache_model_arguments — only added for open/whatif). The
+        benchmark must default args.model from KVCACHE_MODEL_DEFAULT before
+        the base class writes metadata, otherwise the on-disk model field
+        would be None and workload grouping would mis-bucket the run."""
+        from mlpstorage_py.config import KVCACHE_MODEL_DEFAULT
+
+        delattr(base_args, 'model')
+
+        with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen, \
+             patch('mlpstorage_py.benchmarks.kvcache.KVCacheBenchmark._collect_cluster_information') as mock_cluster:
+            output_dir = str(tmp_path / "output")
+            mock_gen.return_value = output_dir
+            mock_cluster.return_value = None
+
+            from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
+            bm = KVCacheBenchmark(base_args, logger=mock_logger, run_datetime="20250124_120000")
+            meta = bm.metadata
+
+        assert meta['model'] == KVCACHE_MODEL_DEFAULT
+        assert meta['kvcache_model'] == KVCACHE_MODEL_DEFAULT
+        # args was mutated to carry the default forward
+        assert base_args.model == KVCACHE_MODEL_DEFAULT
+
     def test_metadata_without_distributed_info(self, base_args, mock_logger, tmp_path):
         """Verify metadata works correctly without distributed execution info."""
         # exec_type, hosts, num_processes are None by default in base_args


### PR DESCRIPTION
## Summary

Adds a model component to the KVCache results-dir path so multiple model variants (llama2-7b, llama3.1-8b, llama3.1-70b-instruct, etc.) accumulate without collision.

**Path change:** \`<results_dir>/kv_cache/<model>/<command>/<datetime>/\` (was \`kv_cache/<command>/<datetime>/\`).

Changes (all kvcache-scoped):
- \`rules/utils.py\`: \`generate_output_location\` for \`kv_cache\` reads \`benchmark.args.model\` and inserts it as a path component; raises if missing.
- \`benchmarks/kvcache.py\`:
  - \`__init__\` defaults \`args.model = KVCACHE_MODEL_DEFAULT\` before \`super().__init__()\`. This is required because the closed-mode CLI does not expose \`--model\` (see \`_add_kvcache_model_arguments\` only being added for open/whatif), and the base class needs \`args.model\` to compute the output path and metadata.
  - Collapses the now-redundant \`getattr(args, 'model', 'llama3.1-8b')\` fallback to a direct \`args.model\` read, and replaces the previously hardcoded string with the constant.
- \`tests/unit/test_accumulation.py\`: \`make_kvcache_run\` takes \`model\`; new path-generation positive/negative tests; \`test_kvcache_runs_distinguished_by_model\`.
- \`tests/unit/test_benchmarks_kvcache.py\`: new \`test_metadata_closed_mode_defaults_model\` exercises the closed-mode default flowing through \`Benchmark.metadata\`.

**Backwards compatible:** existing \`kv_cache/<command>/<datetime>/\` trees still discover via \`get_runs_files\` (they appear with \`model=None\` and group separately from new runs in reports).

## Merge order

Targets the foundation branch (#441). Merge that first; then this PR's diff against main will be just the kvcache changes.

## Test plan

- [ ] \`pytest tests/unit -q\` — full suite passes
- [ ] \`pytest tests/unit/test_accumulation.py tests/unit/test_benchmarks_kvcache.py -v\` — kvcache and accumulation suites green