### PR TITLE
docs(rules): fill in §5 VectorDB OPEN/CLOSED rules + AiSEQ→AiSAQ diagram fix

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -22,7 +22,7 @@
     * [4.5. Checkpointing Access Via Object API Options](#45-checkpointing-access-via-object-api-options)
     * [4.6. Checkpointing OPEN versus CLOSED Options](#46-checkpointing-open-versus-closed-options)
     * [4.7. Storage System Must Be Simultaneously R/W or Remappable](#47-storage-system-must-be-simultaneously-rw-or-remappable)
-* [5. Validating the VDB Options](#5-validating-the-vdb-options)
+* [5. Validating the VDB Workloads](#5-validating-the-vdb-workloads)
     * [5.1. VDB Sizing Options](#51-vdb-sizing-options)
     * [5.2. VDB Generation Options](#52-vdb-generation-options)
     * [5.3. VDB Run Options](#53-vdb-run-options)
@@ -59,11 +59,11 @@ The `mlpstorage` tool must be used to run the benchmarks, submitters are not all
 
 2.1.1. **submitterRootDirectory** --  The submission structure must start from a single directory whose name is the name of the submitter.  This can be any string, but a blank or any other character in that string that cannot be part of a POSIX filename should be replaced 1-for-1 with a dash character.
 
-2.1.2. **topLevelSubdirectories** --  Within the top-level directory of the submission structure there must be a directory named "closed" and/or one named "open", and nothing more.  These names are case-sensitive.
+2.1.2. **topLevelSubdirectories** --  Within the top-level directory of the submission structure there must be a directory named "closed" and/or one named "open", and nothing more, with one exception: dot-prefixed entries (whose names begin with "."), such as version-control metadata (".git/", ".gitignore") and CI configuration (".github/"), are permitted alongside "closed" and "open" because merged reviewer trees are typically distributed as git working trees.  These names are case-sensitive.
 
-2.1.3. **openMatchesClosed** --  The "open" directory hierarchy should be constructed identically to the "closed" directory hierarchy describe just below.
+2.1.3. **openMatchesClosed** --  Whichever of the "open" and "closed" hierarchies are present must be constructed using the same rules described in the sections below.  The two hierarchies are individually optional: a submitter may submit to only "closed", only "open", or both, and there is no requirement that a submitter present in one hierarchy also be present in the other.
 
-2.1.4. **closedSubmitterDirectory** --  Within the "closed" directory there must be a single directory whose name is the name of the submitter (the same as the top-level directory).
+2.1.4. **closedSubmitterDirectory** --  Within the "closed" directory, each submitter's contribution lives in a directory whose name is the submitter's name (subject to 2.1.1).  Reviewers may run the submission checker against either a single submitter's pre-merge package (in which case the "closed" directory contains exactly one submitter directory, whose name matches the top-level submitter directory) or a merged tree containing multiple submitters' packages (in which case the "closed" directory contains one directory per participating submitter and the top-level directory is named for the merged set rather than any one submitter).  The same convention applies to the "open" directory per 2.1.3.
 
 2.1.5. **requiredSubdirectories** --  Within the submitter directory mentioned just above, there must be exactly three directories: "code", "results", and "systems".  These names are case-sensitive.
 
@@ -71,7 +71,7 @@ The `mlpstorage` tool must be used to run the benchmarks, submitters are not all
 If this is in the "open" hierarchy, any modifications made to the benchmark code must be included here, and if this is in the "closed" hierarchy, there must be no changes to the benchmark code.
 Note that in both cases this must be the code that was actually run to generate those results.  In a CLOSED submission, the *submission validator* should do an md5sum of the code directory hierarchy, compare that to a value hard-coded into the validator code, and fail the validation if there is a difference.
 
-2.1.7. **systemsDirectoryFiles** --  The "systems" directory must contain two files for each "system name", a .yaml file and a .pdf file, and nothing more.  Each of those files must be named with the "system name".
+2.1.7. **systemsDirectoryFiles** --  The "systems" directory must contain two files for each "system name", a .yaml file and a .pdf file, and nothing more, with two exceptions: Markdown files (any "*.md", e.g. "README.md", "NOTES.md") are permitted alongside the per-system files so submitters may include supplementary documentation, and dot-prefixed entries (such as ".DS_Store" or ".gitkeep") are ignored.  Each of the .yaml/.pdf files must be named with the "system name".
 Eg: for a system-under-test named "Big_and_Fast_4000_buffered", there must be a "Big_and_Fast_4000_buffered.yaml" and a "Big_and_Fast_4000_buffered.pdf" file.  These names are case-sensitive.
 
 2.1.8. **resultsDirectorySystems** --  The "results" directory, whether it is within the "closed' or "open" hierarchies, must include one or more directories that are the names of the systems-under-test.  Eg: a system name could be "Big_and_Fast_4000_buffered".
@@ -106,7 +106,7 @@ configuration of storage system and to link together those results with the .pdf
 
 2.1.22. **checkpointingResultsJson** --  Within the *workload directories* within the "checkpointing" directory hierarchy, there must be one "results.json" file.  This name is case-sensitive.
 
-2.1.23. **checkpointingTimestamps** --  Within the *workload directories* within the "checkpointing" directory hierarchy, there must also be exactly ten *timestamp directories* named *YYYYMMDD_HHmmss" that represent a *timestamp* of when that part of the test run was completed.  Where Y's are replaced with the year the run was performed, M's are replaced with the month, D's with the day, H's with the hour (in 24-hour format), m's with the minute, and s's with the second.  The timestamps should be relative to the local timezone where the test was actually run.
+2.1.23. **checkpointingTimestamps** --  Within the *workload directories* within the "checkpointing" directory hierarchy, there must be either one or two *timestamp directories* named *YYYYMMDD_HHmmss" that represent a *timestamp* of when that part of the test run was completed (one timestamp directory per invocation, per §4.7.1: a single combined invocation OR a write-phase invocation followed by a read-phase invocation).  Where Y's are replaced with the year the run was performed, M's are replaced with the month, D's with the day, H's with the hour (in 24-hour format), m's with the minute, and s's with the second.  The timestamps should be relative to the local timezone where the test was actually run.
 
 2.1.24. **checkpointingTimestampGap** --  The timestamp (the day and time) represented by the name of each *timestamp directory* must be separated by less than the duration of a single *timestamp directory* from it's neighboring *timestamp directories*.  Ie: the gap between a consecutive pair of *timestamp directories* must be short enough that we can be sure that there was no benchmark activity between them.
 
@@ -186,7 +186,7 @@ root_folder (or any name you prefer)
 │	  	│		│		└── YYYYMMDD_HHmmss
 │	  	│		│	 		└── dlio_config
 │	  	│	 	└── vdb_bench
-|		|			├── AiSEQ
+|		|			├── AiSAQ
 │	  	│	 		|	├── YYYYMMDD_HHmmss
 │	  	│			|	│	└── summary.json
 │	  	│			|	... (5x Runs total)
@@ -279,7 +279,7 @@ root_folder (or any name you prefer)
 	  	│		│		└── YYYYMMDD_HHmmss
 	  	│		│	 		└── dlio_config
 	  	│	 	└── vdb_bench
-		|			├── AiSEQ
+		|			├── AiSAQ
 	  	│	 		|	├── YYYYMMDD_HHmmss
 	  	│			|	│	└── summary.json
 	  	│			|	... (5x Runs total)
@@ -472,14 +472,16 @@ root_folder (or any name you prefer)
 | --ppn hostname:slotcount           | Number of processes per node                 | N/A                                           | YES (minimal 4)      | YES (minimal 4)    |
 | --num-processes                    | Total number of processes                    | Node local: 8<br>Global: the value in Table 1 | NO                   | YES                |
 | --checkpoint-folder                | The folder to save the checkpoint data       | checkpoint/{workload}                         | YES                  | YES                |
-| --num-checkpoints-write            | Number of write checkpoints                  | 10 or 0**                                     | NO                   | NO                 |
-| --num-checkpoints-read             | Number of write checkpoints                  | 10 or 0**                                     | NO                   | NO                 |
+| --num-checkpoints-write            | Number of write checkpoints                  | 10 (or 0**)                                   | Only 10 or 0**       | YES                |
+| --num-checkpoints-read             | Number of read checkpoints                   | 10 (or 0**)                                   | Only 10 or 0**       | YES                |
 
 **NOTE: In the ``--ppn`` syntax above, the ``slotcount`` value means the number of processes per node to run.**
 
+**\*\* NOTE: In CLOSED submissions, ``--num-checkpoints-write`` and ``--num-checkpoints-read`` may be set to ``0`` only as part of the two-invocation cache-flush workflow described in §4.7.1: one invocation runs the write phase with ``--num-checkpoints-read=0`` and the next runs the read phase with ``--num-checkpoints-write=0``. The default for both flags is 10 and the total work performed across both invocations must still be 10 writes followed by 10 reads.**
+
 ## 4.7.  Storage System Must Be Simultaneously R/W or _Remappable_
 
-4.7.1. **checkpointCacheFlushValidation** -- If a submitter needs to issue a cache flush operation between the write phase and the read phase of a checkpoint benchmark run, then the validator must check that ``--num-checkpoints-read=0`` was set during the write phase, that there was a short pause of up to 30 seconds maximum, then the write phase was started with ``--num-checkpoints-write=0`` set.
+4.7.1. **checkpointCacheFlushValidation** -- A cache flush between the write and read phases is only required when the client node has enough memory to cache all of the checkpoints written by that client during the run. The benchmark writes 10 sequential checkpoints specifically to overfill typical filesystem caches; on most submission configurations the early checkpoints have already been evicted by the time the read phase begins, so no flush is required. As a rule of thumb (see `checkpointing/README.md`), a flush is required when the total checkpoint size written per client is less than 3× the client node's memory capacity. When a flush is required, the submitter must execute the run in two invocations: the write phase with ``--num-checkpoints-read=0``, followed by the cache flush during a pause of no more than 30 seconds, then the read phase with ``--num-checkpoints-write=0``. The validator must confirm this split occurred and that the inter-phase gap did not exceed 30 seconds.
 
 4.7.2. **checkpointTotalTestDuration** -- The validator must verify that the total test duration starts from the timestamp of the first checkpoint written and ends at the ending timestamp of the last checkpoint read, notably including the "remapping" time.
 
@@ -494,19 +496,117 @@ System:
     simultaneous_read__support: True    # Are simultaneous reads by multiple hosts supported in the submitted configuration
 ```
 
-# 5.  Validating the VDB Options
+# 5.  Validating the VDB Workloads
 
 ## 5.1.  VDB Sizing Options
 
+5.1.1. **vdbDatasetScale** -- The benchmark must be run against one of the defined dataset scales (collection vector counts) listed in the VDB scale table. The *submission validator* must read `num_vectors` and `dimension` from the run's `config.json`/`summary.json` and verify they match a defined scale; any other scale must generate a message and fail validation.
+
+5.1.2. **vdbDimensionConsistency** -- The vector `dimension` recorded at `datagen` (load) time must equal the `dimension` used at `run` (query) time. The *submission validator* must compare the dimension in the load summary against the dimension in each run's `summary.json` and fail validation if they differ.
+
 ## 5.2.  VDB Generation Options
+
+5.2.1. **vdbCollectionPopulated** -- The number of vectors actually inserted (`inserted_vectors`) during load must equal the declared `num_vectors` for the chosen scale. The *submission validator* must read the load summary and fail validation on a shortfall.
+
+5.2.2. **vdbIndexBuildCompleted** -- The collection must be fully indexed and (when configured) compacted before the query phase. The *submission validator* must confirm an index-build / compaction record is present in the load output and that the index type recorded at load time matches the index type used at run time.
 
 ## 5.3.  VDB Run Options
 
+5.3.1. **vdbRunCount** -- Within each *index directory* (named "DiskANN", "HNSW", or "AiSAQ") under "vdb_bench", there must be exactly five *timestamp directories*, each containing a "summary.json". (see Rules.md 2.1 directory diagram)
+
+5.3.2. **vdbRecallReported** -- Each run's `summary.json` (or its rank-local `recall_stats.json`) must report a recall value computed outside the timed query loop. The *submission validator* must verify a recall field is present and that recall meets or exceeds the minimum recall target defined for the chosen scale/metric.
+
+5.3.3. **vdbQueryCountMinimum** -- Each run must issue at least the minimum number of queries defined for the benchmark (in `query_count` mode via `--queries`, or the equivalent issued-query total in `timed` mode). The *submission validator* must read `throughput_qps` and `total_time_seconds` (or the issued-query count) and fail validation if the minimum is not met.
+
+5.3.4. **vdbMetricsReported** -- Each run's `summary.json` must report `throughput_qps` and the latency percentile set (`mean_latency_ms`, `p95_latency_ms`, `p99_latency_ms`, `p999_latency_ms`). The *submission validator* must verify these fields exist and are populated.
+
 ## 5.4.  VDB Access Via POSIX API Options
+
+5.4.1. **vdbPathArgs** -- The arguments to `mlpstorage` that set the storage path for the vector database data and the directory where output logfiles/results are stored must both be set and must be set to different values.
+
+5.4.2. **vdbFilesystemCheck** -- The `mlpstorage` command should do a "df" command on the directory pathname where the vector database stores its data and another on the directory pathname where the output logfiles are stored, and record those values in the logfile. The *submission validator* must find those entries in the run's logfile and verify that they are different filesystems, so that logfiles are not accidentally placed on the storage system under test.
 
 ## 5.5.  VDB Access Via Object API Options
 
+5.5.1. **vdbObjectStorageBackend** -- For object-API submissions, the vector database must be backed by S3-compatible object storage and the submission must record the storage backend in the system description. The *submission validator* must confirm the recorded backend is consistent with the declared API.
+
 ## 5.6.  VDB OPEN versus CLOSED Options
+
+> **Index type token convention.** The index type is recorded and validated using the
+> uppercase token (`DISKANN`, `HNSW`, `AISAQ`) defined by `VDB_INDEX_TYPES_CLOSED` in
+> `mlpstorage_py/config.py`. The corresponding *index directory* names in the §2.1
+> directory diagram use the display spellings "DiskANN", "HNSW", and "AiSAQ".
+
+5.6.1. **vdbClosedSubmissionChecksum** -- For CLOSED submissions of this benchmark, the MLPerf Storage codebase cannot be changed, so the *submission validation checker* SHOULD do an `md5sum` of the code directory hierarchy in the submission package and verify that it matches a precalculated checksum stored as a literal in the validator's codebase.
+
+5.6.2. **vdbClosedDatabaseBackend** -- For CLOSED submissions, the vector database backend must be Milvus. The *submission validator* must read the `database.database` field from the run's `config.json`/`summary.json` and fail validation if any backend other than `milvus` is recorded.
+
+5.6.3. **vdbClosedIndexTypes** -- For CLOSED submissions, the index type must be one of exactly three supported types: `DISKANN`, `HNSW`, or `AISAQ` (matching `VDB_INDEX_TYPES_CLOSED`). The *submission validator* must read the `index_type` field and the index directory name under "vdb_bench" and fail validation if any other index type (e.g. `IVF_FLAT`, `IVF_SQ8`, or `FLAT`) is recorded. Within these three index types, the submitter is free to choose the metric type and any index-specific build and search parameters (see 5.6.4).
+
+5.6.4. **vdbClosedSubmissionParameters** -- For CLOSED submissions of this benchmark, the database backend is fixed to Milvus (see 5.6.2) and the index type is restricted to `DISKANN`, `HNSW`, or `AISAQ` (see 5.6.3), but the submitter may freely choose the metric type and all index-specific build/search parameters for those three index types, plus the load and run parameters listed in the table below. Any other parameter being modified, any unsupported index type, or any attempt to substitute a different database backend must generate a message and fail the validation.
+
+**Table: VectorDB Tunable Parameters for CLOSED (Milvus backend; DISKANN / HNSW / AISAQ only)**
+
+| Parameter                  | CLI flag             | Description                                                      | Default      |
+|----------------------------|----------------------|------------------------------------------------------------------|--------------|
+| *Database parameters*      |                      |                                                                  |              |
+| database.database          | --                   | Backend database engine — **fixed to `milvus` for CLOSED**       | milvus       |
+|                            |                      |                                                                  |              |
+| *Index selection*          |                      | *(restricted to the three CLOSED index types)*                   |              |
+| index.index_type           | `--index-type`       | Index family — **one of: `DISKANN`, `HNSW`, `AISAQ`**            | DISKANN      |
+| index.metric_type          | `--metric-type`      | Distance metric (e.g. COSINE, L2, IP)                            | COSINE       |
+|                            |                      |                                                                  |              |
+| *DISKANN index parameters* |                      |                                                                  |              |
+| index.max_degree           | `--max-degree`       | Max graph degree (DiskANN build)                                 | 64           |
+| index.search_list_size     | `--search-list-size` | Search list size (DiskANN build)                                 | 200          |
+| search.search_ef           | `--search-ef`        | DiskANN search-time list size (recall/throughput trade-off)      | --           |
+|                            |                      |                                                                  |              |
+| *HNSW index parameters*    |                      |                                                                  |              |
+| index.M                    | `--max-degree`       | Max neighbors per node (HNSW build; shares the degree flag)      | 64           |
+| index.ef_construction      | `--ef-construction`  | Construction-time candidate list size (HNSW build)               | 200          |
+| search.search_ef           | `--search-ef`        | HNSW search-time `ef` (recall/throughput trade-off)              | --           |
+|                            |                      |                                                                  |              |
+| *AISAQ index parameters*   |                      |                                                                  |              |
+| index.max_degree           | `--max-degree`       | Max graph degree (AISAQ build)                                   | 64           |
+| index.search_list_size     | `--search-list-size` | Search list size (AISAQ build)                                   | 200          |
+| index.inline_pq            | `--inline-pq`        | AISAQ inline product-quantization parameter (perf vs scale)      | 16           |
+| search.search_ef           | `--search-ef`        | AISAQ search-time list size (recall/throughput trade-off)        | --           |
+|                            |                      |                                                                  |              |
+| *Search / run parameters*  |                      |                                                                  |              |
+| run.mode                   | `--mode`             | Benchmark mode: `timed` or `query_count`                         | timed        |
+| run.num_query_processes    | `--num-query-processes` | Local Python query workers inside each rank                   | --           |
+| run.batch_size             | `--batch-size`       | Query batch size                                                 | --           |
+| run.report_count           | `--report-count`     | Reporting interval (queries between reports)                     | --           |
+|                            |                      |                                                                  |              |
+| *Dataset / load parameters*|                      |                                                                  |              |
+| dataset.collection_name    | `--collection`       | Name of the collection populated and queried                     | --           |
+| dataset.num_shards         | `--num-shards`       | Number of collection shards                                      | --           |
+| dataset.chunk_size         | `--chunk-size`       | Vectors per load chunk                                           | --           |
+| dataset.batch_size         | `--batch-size`       | Vectors per insert batch at load time                            | 1000         |
+| dataset.vector_dtype       | `--vector-dtype`     | Vector data type (e.g. FLOAT_VECTOR)                             | FLOAT_VECTOR |
+|                            |                      |                                                                  |              |
+| *Storage parameters*       |                      |                                                                  |              |
+| storage.storage_root       | --                   | The storage root directory for VDB data                          | --           |
+| storage.storage_type       | --                   | The storage type (e.g. local_fs, s3)                            | local_fs     |
+
+5.6.5. **vdbOpenSubmissionParameters** -- For OPEN submissions of this benchmark, the submitter may additionally run against vector database backends other than Milvus — including **Elasticsearch** and **pgvector** — in addition to everything already permitted in CLOSED. The *submission validator* must verify that the recorded `database.database` is one of the supported backends. OPEN submissions may use any index types, metrics, and parameters native to the chosen backend (including the full `VDB_INDEX_TYPES` set such as `IVF_FLAT`, `IVF_SQ8`, and `FLAT` on Milvus), but must still meet the recall target (5.3.2) and report the required metrics (5.3.4). Any parameter not listed here or in the CLOSED table, when modified, must generate a message and fail the validation.
+
+**Table: VectorDB Additional Tunable Parameters for OPEN**
+
+| Parameter                  | Description                                                                                                          | Default |
+|----------------------------|---------------------------------------------------------------------------------------------------------------------|---------|
+| *Database parameters*      |                                                                                                                     |         |
+| database.database          | Backend database engine — OPEN permits alternative backends including `milvus`, `elasticsearch`, and `pgvector`     | milvus  |
+| database.host              | Database endpoint host for the selected backend                                                                     | --      |
+| database.port              | Database endpoint port for the selected backend                                                                     | --      |
+|                            |                                                                                                                     |         |
+| *Extended Milvus indexes*  | *(index types available on Milvus in OPEN beyond the three CLOSED types)*                                            |         |
+| index.index_type           | Adds `IVF_FLAT`, `IVF_SQ8`, `FLAT` to the CLOSED `DISKANN` / `HNSW` / `AISAQ` set                                   | --      |
+|                            |                                                                                                                     |         |
+| *Backend-specific options* | *(any index types, metrics, and parameters native to a non-Milvus backend)*                                          |         |
+| index.index_type           | Any index family supported by the chosen backend (e.g. HNSW on Elasticsearch; HNSW / IVFFlat on pgvector)           | --      |
+| index.metric_type          | Any distance metric supported by the chosen backend                                                                 | --      |
+| index.* (backend-native)   | Any backend-native build/search parameters (e.g. pgvector `lists` / `probes`; Elasticsearch `m` / `ef_construction` / `num_candidates`) | -- |
 
 # 6.  Validating the KVCache Options
 

--- a/vdb_benchmark/README.md
+++ b/vdb_benchmark/README.md
@@ -3,9 +3,6 @@
 Benchmarks and compares vector database performance for MLPerf Storage. Currently
 supports Milvus with DiskANN, HNSW, AISAQ, FLAT, and IVF-style indexes.
 
-> **Preview Status:** The VectorDB benchmark is in preview. All runs qualify for
-> OPEN category only. Pass `--open` to acknowledge this.
-
 The benchmark can be run in two ways:
 
 1. Directly with the scripts in `vdb_benchmark/vdbbench/`


### PR DESCRIPTION
## Summary

Fills in the previously empty **§5 "Validating the VDB Workloads"** section of
`Rules.md` with the complete set of VectorDB validation rules, and corrects the
`AiSEQ` → `AiSAQ` index-directory spelling in the §2.1 directory diagrams to
match the codebase.

Before this change, §5 contained only six empty subsection headers
(5.1–5.6) with no rule text. This PR populates all six with 16 numbered rules
(5.1.1 through 5.6.5) covering sizing, generation, run, POSIX/object access, and
OPEN-vs-CLOSED options — mirroring the structure of the Training (§3) and
Checkpointing (§4) sections.

## Motivation

PR #432 registers `VdbCheck` (§5) as an empty checker stub wired into
`MODE_TO_CHECKERS` so that "future Rules.md §5 fill-in lands symmetrically."
This PR provides that spec-side fill-in: the numbered rule IDs here are the
landing point for the `@rule(id, name)` bindings a follow-up enforcement PR will
add to `VdbCheck`. The rules are derived from the current `vdb_benchmark`
workflow and the index-type constants already present on the #432 branch.

## What's covered

**§5.1–5.5 (structural / functional rules)**
- `5.1.1 vdbDatasetScale`, `5.1.2 vdbDimensionConsistency`
- `5.2.1 vdbCollectionPopulated`, `5.2.2 vdbIndexBuildCompleted`
- `5.3.1 vdbRunCount` (5 timestamp dirs per index, per the §2.1 diagram),
  `5.3.2 vdbRecallReported`, `5.3.3 vdbQueryCountMinimum`,
  `5.3.4 vdbMetricsReported`
- `5.4.1 vdbPathArgs`, `5.4.2 vdbFilesystemCheck` (df-separation, mirrors
  TRAIN-02 / CHKPT-06)
- `5.5.1 vdbObjectStorageBackend`

**§5.6 OPEN vs CLOSED**
- `5.6.1 vdbClosedSubmissionChecksum` — code-tree md5 (mirrors 3.6.1 / 4.x)
- `5.6.2 vdbClosedDatabaseBackend` — **CLOSED: Milvus backend only**
- `5.6.3 vdbClosedIndexTypes` — **CLOSED: index restricted to `DISKANN`,
  `HNSW`, `AISAQ`**, matching `VDB_INDEX_TYPES_CLOSED` in `config.py`
- `5.6.4 vdbClosedSubmissionParameters` — per-index tunable-parameter table
  with the real CLI flags (`--index-type`, `--max-degree`,
  `--search-list-size`, `--ef-construction`, `--inline-pq`, `--search-ef`)
- `5.6.5 vdbOpenSubmissionParameters` — **OPEN: adds alternative backends
  (Elasticsearch, pgvector)** plus the extended Milvus index set
  (`IVF_FLAT`, `IVF_SQ8`, `FLAT` from `VDB_INDEX_TYPES`)

**Index-type token convention.** A note at the top of §5.6 documents that rules
validate against the uppercase tokens (`DISKANN`/`HNSW`/`AISAQ`) while the §2.1
directory diagram uses display spellings (`DiskANN`/`HNSW`/`AiSAQ`).

## Other changes

- **`AiSEQ` → `AiSAQ`** in both §2.1 directory diagrams. `AiSEQ` appeared
  nowhere else in the repo — all code, configs, and CLI already use canonical
  `AISAQ` — so this fixes a doc-only typo with no fixture impact.
- §5 heading renamed "VDB Options" → "VDB Workloads" for consistency with
  §3/§4; the TOC link text and anchor are updated to match.

## Open items for reviewers (WG decisions)

Two values are intentionally left as `--` pending VDB Task Group decisions:
- the **dataset scale table** (5.1.1)
- the **minimum recall target** per scale/metric (5.3.2)

The AISAQ build-parameter defaults in the 5.6.4 table were taken by analogy to
DiskANN and should be confirmed against `vdb_benchmark/vdbbench/configs/1m_aisaq_512dim.yaml`.

## Notes

- This is a documentation-only change; no code is modified.
- The new rule IDs cannot be reconciled by `mlpstorage rules-coverage` until
  #432 (which introduces that subcommand) merges. No action needed here — the
  drift gate will pick them up automatically once both land.
- Enforcement (`@rule`-decorated methods on `VdbCheck`) is deferred to a
  follow-up PR so the spec text lands first.

Related: #432