### PR TITLE
Change max-concurrent-allocs to 16 to fix memory issue

### DIFF
--- a/kv_cache_benchmark/mlperf_wrapper.py
+++ b/kv_cache_benchmark/mlperf_wrapper.py
@@ -36,7 +36,7 @@ OPTION_PARAMS = {
         'duration': 300,
         'gpu-mem-gb': 0,
         'cpu-mem-gb': 4,
-        'max-concurrent-allocs': 0,
+        'max-concurrent-allocs': 16,
         'generation-mode': 'none',
     },
     3: {


### PR DESCRIPTION
The second test was observed to consume large amounts of memory (>200 GB). To prevent this situation, the max-concurrent-allocs for this test was altered from 0 (unbounded memory allocation) to 16. This will fix issue #405