### PR TITLE
fix(kvcache): datasize whatif/open crash on missing args.loops

### DIFF
--- a/mlpstorage_py/cli/kvcache_args.py
+++ b/mlpstorage_py/cli/kvcache_args.py
@@ -187,6 +187,10 @@ def _add_kvcache_cache_arguments(parser, mode):
             params='',
         )
     else:
+        # `--loops` is registered only on the run subparser (via
+        # _add_kvcache_open_args), so the datasize subparser would have no
+        # `loops` attr on its namespace. main.py reads it for every command.
+        cache_group.set_defaults(loops=1)
         cache_group.add_argument(
             '--gpu-mem-gb',
             type=float,

--- a/mlpstorage_py/main.py
+++ b/mlpstorage_py/main.py
@@ -323,7 +323,7 @@ def _main_impl():
         print_run_summary(args)
 
     # For other commands, run the benchmark
-    for i in range(args.loops):
+    for i in range(getattr(args, 'loops', 1)):
         if signal_received:
             logger.warning('Caught signal, exiting...')
             return EXIT_CODE.INTERRUPTED

--- a/tests/unit/test_parser_modes.py
+++ b/tests/unit/test_parser_modes.py
@@ -182,6 +182,47 @@ class TestOpenGatedArgExclusion:
         assert args.loops == 2
 
     # ------------------------------------------------------------------
+    # Regression: every subcommand must expose `args.loops` on its namespace.
+    # main.py:326 does `for i in range(getattr(args, 'loops', 1))` after the
+    # fix for #444, but the parsers should still guarantee the attribute so
+    # the run_summary output and any future caller doesn't see None. Issue
+    # #444 was caused by kvcache datasize in open/whatif lacking this.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize('mode, benchmark, sub_argv', [
+        # kvcache — the direct repro for #444
+        ('closed',  'kvcache',       ['datasize']),
+        ('open',    'kvcache',       ['datasize']),
+        ('whatif',  'kvcache',       ['datasize']),
+        # training — non-run subcommands have no --loops flag
+        ('closed',  'training',      ['unet3d', 'datasize', '-cm', '64', '-at', 'b200', '-ma', '4']),
+        ('open',    'training',      ['unet3d', 'datasize', '-cm', '64', '-at', 'b200', '-ma', '4']),
+        ('whatif',  'training',      ['unet3d', 'datasize', '-cm', '64', '-at', 'h100', '-ma', '4']),
+        ('closed',  'training',      ['unet3d', 'datagen', '-np', '4', 'file']),
+        # checkpointing — datasize / configview
+        ('closed',  'checkpointing', ['datasize', '-cm', '64', '-m', 'llama3-8b', '-np', '2']),
+        ('open',    'checkpointing', ['datasize', '-cm', '64', '-m', 'llama3-8b', '-np', '2']),
+        # vectordb — datasize / datagen
+        ('closed',  'vectordb',      ['datasize']),
+        ('open',    'vectordb',      ['datasize']),
+        ('whatif',  'vectordb',      ['datasize']),
+    ])
+    def test_non_run_subcommands_expose_loops_attr(self, mode, benchmark, sub_argv):
+        """Every benchmark subcommand must populate args.loops so main.py can drive the run loop.
+
+        Regression for #444: `mlpstorage whatif kvcache datasize` crashed with
+        AttributeError because the run loop in main.py reads args.loops, but
+        --loops was only registered on the run subparser.
+        """
+        argv = ['mlpstorage', mode, benchmark] + sub_argv
+        with patch('sys.argv', argv):
+            args = parse_arguments()
+        assert hasattr(args, 'loops'), (
+            f"{mode} {benchmark} {sub_argv[0]} did not set args.loops on the namespace"
+        )
+        assert args.loops == 1
+
+    # ------------------------------------------------------------------
     # Help-text hiding test (MEDIUM concern from 04-REVIEWS.md)
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Resolves #444.

`mlpstorage whatif kvcache datasize` (and `open kvcache datasize`) crashed with `'Namespace' object has no attribute 'loops'` before the benchmark started. Root cause: the kvcache `datasize` subparser only got a `loops=1` default in **closed** mode (via `set_defaults` in `_add_kvcache_cache_arguments`). In open/whatif, `--loops` was registered only on the `run` subparser via `_add_kvcache_open_args`, so the `datasize` namespace had no `loops` attribute, and `main.py`'s `for i in range(args.loops)` raised `AttributeError`.

Fix is two small changes plus a regression test:

- **`mlpstorage_py/cli/kvcache_args.py`** — add `set_defaults(loops=1)` in the open/whatif branch of `_add_kvcache_cache_arguments` so the `datasize` namespace gets the same default that closed mode already provided. The `run` subparser's `--loops` argument continues to override this default in open/whatif.
- **`mlpstorage_py/main.py`** — change `for i in range(args.loops):` to `for i in range(getattr(args, 'loops', 1)):`. This mirrors the pattern already used in `run_summary.py:73` and defends against the same class of bug in any future subcommand.
- **`tests/unit/test_parser_modes.py`** — new `test_non_run_subcommands_expose_loops_attr` parametrized over 12 mode×benchmark×subcommand combinations that don't accept `--loops` as a flag. Includes the direct #444 repros (`closed/open/whatif` × `kvcache datasize`) plus regression coverage for `training`, `checkpointing`, and `vectordb`.

## Wider sweep

Audited training/checkpointing/vectordb parsers for the same issue: all three already use `set_defaults(loops=1)` in a per-subcommand core-args function, so every subcommand's namespace has `loops`. The bug is genuinely isolated to kvcache. Also scanned `main.py`, `cli_parser.update_args`, and `run_summary.py` for other unconditional `args.X` reads — line 326 was the only unguarded one; everything else uses `hasattr`/`getattr`.

## Test plan

- [x] Repro the exact command from #444 — `mlpstorage whatif kvcache datasize --results-dir /tmp/mlps-results --gpu-mem-gb 16 --cpu-mem-gb 32` — now parses cleanly with `args.loops == 1`.
- [x] New regression test covers all 12 mode×benchmark×non-run-subcommand combinations.
- [x] Full unit suite: `pytest tests/unit` — 1232 passed, 4 skipped, 0 regressions. (Three modules with missing optional deps `pyarrow`/`numpy` and one environmental `importlib.metadata` test were pre-existing failures unrelated to this change.)