### PR TITLE
feat(system_description): add drive media_type and performance block

### DIFF
--- a/mlpstorage_py/system_description/example_NFS.yaml
+++ b/mlpstorage_py/system_description/example_NFS.yaml
@@ -42,13 +42,29 @@ system_under_test:
               - vendor_name: Micron
                 model_name: X9000 TLC
                 interface: nvme
+                media_type: TLC
                 capacity_in_GB: 8000
                 unit_count: 8
+                performance:
+                    seq_read_MBps: 14000
+                    seq_write_MBps: 10000
+                    random_read_IOPS: 2700000
+                    random_write_IOPS: 400000
+                    form_factor: U.2
+                    interface_speed: PCIe Gen5 x4
               - vendor_name: Micron
                 model_name: X1650 QLC
                 interface: nvme
+                media_type: QLC
                 capacity_in_GB: 24000
                 unit_count: 8
+                performance:
+                    seq_read_MBps: 7000
+                    seq_write_MBps: 2000
+                    random_read_IOPS: 1000000
+                    random_write_IOPS: 200000
+                    form_factor: E1.S
+                    interface_speed: PCIe Gen4 x4
           operating_system:
              name: Rocky Linux
              version: "9.5"

--- a/mlpstorage_py/system_description/example_PFS.yaml
+++ b/mlpstorage_py/system_description/example_PFS.yaml
@@ -76,13 +76,29 @@ system_under_test:
               - vendor_name: Micron
                 model_name: X9000 TLC
                 interface: nvme
+                media_type: TLC
                 capacity_in_GB: 8000
                 unit_count: 8
+                performance:
+                    seq_read_MBps: 14000
+                    seq_write_MBps: 10000
+                    random_read_IOPS: 2700000
+                    random_write_IOPS: 400000
+                    form_factor: U.2
+                    interface_speed: PCIe Gen5 x4
               - vendor_name: Micron
                 model_name: X1650 QLC
                 interface: nvme
+                media_type: QLC
                 capacity_in_GB: 24000
                 unit_count: 8
+                performance:
+                    seq_read_MBps: 7000
+                    seq_write_MBps: 2000
+                    random_read_IOPS: 1000000
+                    random_write_IOPS: 200000
+                    form_factor: E1.S
+                    interface_speed: PCIe Gen4 x4
           operating_system:
              name: Rocky Linux
              version: "9.5"

--- a/mlpstorage_py/system_description/example_drive.yaml
+++ b/mlpstorage_py/system_description/example_drive.yaml
@@ -30,6 +30,20 @@ system_under_test:
                     - power_capacity_watts: 1800
                       efficiency: Platinum
                       unit_count: 2
+          drives:
+              - vendor_name: Micron
+                model_name: X9000 TLC
+                interface: nvme
+                media_type: TLC
+                capacity_in_GB: 8000
+                unit_count: 1
+                performance:
+                    seq_read_MBps: 14000
+                    seq_write_MBps: 10000
+                    random_read_IOPS: 2700000
+                    random_write_IOPS: 400000
+                    form_factor: U.2
+                    interface_speed: PCIe Gen5 x4
           operating_system:
              name: Rocky Linux
              version: "9.5"

--- a/mlpstorage_py/system_description/example_remote_block.yaml
+++ b/mlpstorage_py/system_description/example_remote_block.yaml
@@ -40,11 +40,20 @@ system_under_test:
               - vendor_name: Micron
                 model_name: X9000 TLC
                 interface: nvme
+                media_type: TLC
                 capacity_in_GB: 8000
                 unit_count: 8
+                performance:
+                    seq_read_MBps: 14000
+                    seq_write_MBps: 10000
+                    random_read_IOPS: 2700000
+                    random_write_IOPS: 400000
+                    form_factor: U.2
+                    interface_speed: PCIe Gen5 x4
               - vendor_name: Micron
                 model_name: X1650 QLC
                 interface: nvme
+                media_type: QLC
                 capacity_in_GB: 24000
                 unit_count: 8
           operating_system:

--- a/mlpstorage_py/system_description/schema.yaml
+++ b/mlpstorage_py/system_description/schema.yaml
@@ -98,7 +98,23 @@ drive_instance:
     vendor_name:                str( min=1 )        # The name of the vendor who supplies this drive
     model_name:                 str( min=1 )        # The vendor's model name for this drive
     interface:                  enum( 'nvme', 'SAS', 'SATA', 'other' )
+    media_type:                 enum( 'HDD', 'TLC', 'QLC', 'other' )    # Spinning disk or NAND cell type
     capacity_in_GB:             int( min=1 )        # in base 10 GB, not in GiB
+    performance:                include( 'drive_performance', required=False )
+
+---
+#
+# Vendor-published (spec-sheet) performance numbers for a drive.  This whole block is
+# optional; if you include it, the four throughput/IOPS values are required.  These
+# describe nameplate capability of an individual drive, not measured benchmark results.
+#
+drive_performance:
+    seq_read_MBps:              int( min=1 )        # Sequential read throughput, MB/s (base 10)
+    seq_write_MBps:             int( min=1 )        # Sequential write throughput, MB/s (base 10)
+    random_read_IOPS:           int( min=1 )        # 4KB random read IOPS
+    random_write_IOPS:          int( min=1 )        # 4KB random write IOPS
+    form_factor:                enum( 'U.2', 'U.3', 'M.2', 'E1.S', 'E1.L', 'E3.S', 'E3.L', '2.5in', '3.5in', 'AIC', 'other', required=False )
+    interface_speed:            str( min=1, required=False )    # Negotiated link, eg "PCIe Gen5 x4", "SAS-4 24G", "SATA 6G"
 
 ---
 #

--- a/mlpstorage_py/system_description/schema_validator.py
+++ b/mlpstorage_py/system_description/schema_validator.py
@@ -78,6 +78,27 @@ class DriveInterface(str, Enum):
     other = 'other'
 
 
+class DriveMediaType(str, Enum):
+    HDD   = 'HDD'
+    TLC   = 'TLC'
+    QLC   = 'QLC'
+    other = 'other'
+
+
+class DriveFormFactor(str, Enum):
+    U_2     = 'U.2'
+    U_3     = 'U.3'
+    M_2     = 'M.2'
+    E1_S    = 'E1.S'
+    E1_L    = 'E1.L'
+    E3_S    = 'E3.S'
+    E3_L    = 'E3.L'
+    in_2_5  = '2.5in'
+    in_3_5  = '3.5in'
+    AIC     = 'AIC'
+    other   = 'other'
+
+
 class PowerEfficiency(str, Enum):
     Standard = 'Standard'
     Bronze   = 'Bronze'
@@ -131,13 +152,29 @@ class NetworkPort(BaseModel):
     traffic:     List[TrafficType] = Field(min_length=1)
 
 
+class DrivePerformance(BaseModel):
+    """Vendor-published spec-sheet performance for a drive.
+
+    Whole block is optional on DriveInstance; if present, the four throughput/IOPS
+    fields are required.  form_factor and interface_speed remain optional.
+    """
+    seq_read_MBps:      int                        = Field(ge=1)   # base-10 MB/s
+    seq_write_MBps:     int                        = Field(ge=1)   # base-10 MB/s
+    random_read_IOPS:   int                        = Field(ge=1)   # 4KB random
+    random_write_IOPS:  int                        = Field(ge=1)   # 4KB random
+    form_factor:        Optional[DriveFormFactor]  = None
+    interface_speed:    Optional[str]              = Field(default=None, min_length=1)
+
+
 class DriveInstance(BaseModel):
     """One homogeneous group of storage drives sharing the same model and configuration."""
-    unit_count:      int            = Field(ge=1)
-    vendor_name:     str            = Field(min_length=1)
-    model_name:      str            = Field(min_length=1)
+    unit_count:      int                          = Field(ge=1)
+    vendor_name:     str                          = Field(min_length=1)
+    model_name:      str                          = Field(min_length=1)
     interface:       DriveInterface
-    capacity_in_GB:  int            = Field(ge=1)  # base-10 GB
+    media_type:      DriveMediaType                              # HDD vs flash cell type
+    capacity_in_GB:  int                          = Field(ge=1)  # base-10 GB
+    performance:     Optional[DrivePerformance]   = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -121,6 +121,32 @@ def _switch(rack_units=2, unit_count=1) -> dict:
     }
 
 
+def _drive_performance() -> dict:
+    return {
+        "seq_read_MBps": 14000,
+        "seq_write_MBps": 10000,
+        "random_read_IOPS": 2700000,
+        "random_write_IOPS": 400000,
+        "form_factor": "U.2",
+        "interface_speed": "PCIe Gen5 x4",
+    }
+
+
+def _drive(with_performance=False, **overrides) -> dict:
+    d = {
+        "unit_count": 8,
+        "vendor_name": "Micron",
+        "model_name": "X9000 TLC",
+        "interface": "nvme",
+        "media_type": "TLC",
+        "capacity_in_GB": 8000,
+    }
+    if with_performance:
+        d["performance"] = _drive_performance()
+    d.update(overrides)
+    return d
+
+
 def _capabilities(sw=True, sr=True, remap=0) -> dict:
     return {
         "multi_host": True,
@@ -388,7 +414,7 @@ class TestBaseSchemaValidation:
         doc = _onprem_doc()
         doc["system_under_test"]["product_nodes"][0]["drives"] = [{
             "unit_count": 1, "vendor_name": "Micron", "model_name": "9400",
-            "interface": "fibrechannel", "capacity_in_GB": 8000,
+            "interface": "fibrechannel", "media_type": "TLC", "capacity_in_GB": 8000,
         }]
         fail(doc)
 
@@ -839,3 +865,102 @@ class TestNetworkingRequirements:
         doc = _cloud_doc()
         del doc["system_under_test"]["clients"][0]["networking"]
         fail(doc, "clients[0].networking")
+
+
+# ---------------------------------------------------------------------------
+# DriveInstance: media_type required; performance block optional but, if
+# present, its four throughput/IOPS fields are required.
+# ---------------------------------------------------------------------------
+
+class TestDriveInstance:
+    def _doc_with_drives(self, *drives) -> dict:
+        doc = _onprem_doc()
+        doc["system_under_test"]["product_nodes"][0]["drives"] = list(drives)
+        return doc
+
+    # ----- media_type (required) -----
+
+    def test_drive_without_performance_passes(self):
+        ok(self._doc_with_drives(_drive()))
+
+    def test_drive_missing_media_type_fails(self):
+        d = _drive()
+        del d["media_type"]
+        fail(self._doc_with_drives(d), "media_type")
+
+    def test_drive_invalid_media_type_fails(self):
+        fail(self._doc_with_drives(_drive(media_type="SLC")), "media_type")
+
+    def test_drive_media_type_HDD_passes(self):
+        ok(self._doc_with_drives(_drive(media_type="HDD")))
+
+    def test_drive_media_type_QLC_passes(self):
+        ok(self._doc_with_drives(_drive(media_type="QLC")))
+
+    def test_drive_media_type_other_passes(self):
+        ok(self._doc_with_drives(_drive(media_type="other")))
+
+    # ----- performance block (optional) -----
+
+    def test_drive_with_full_performance_passes(self):
+        ok(self._doc_with_drives(_drive(with_performance=True)))
+
+    def test_drive_performance_without_optional_fields_passes(self):
+        d = _drive(with_performance=True)
+        del d["performance"]["form_factor"]
+        del d["performance"]["interface_speed"]
+        ok(self._doc_with_drives(d))
+
+    def test_drive_performance_missing_seq_read_fails(self):
+        d = _drive(with_performance=True)
+        del d["performance"]["seq_read_MBps"]
+        fail(self._doc_with_drives(d), "seq_read_MBps")
+
+    def test_drive_performance_missing_seq_write_fails(self):
+        d = _drive(with_performance=True)
+        del d["performance"]["seq_write_MBps"]
+        fail(self._doc_with_drives(d), "seq_write_MBps")
+
+    def test_drive_performance_missing_random_read_fails(self):
+        d = _drive(with_performance=True)
+        del d["performance"]["random_read_IOPS"]
+        fail(self._doc_with_drives(d), "random_read_IOPS")
+
+    def test_drive_performance_missing_random_write_fails(self):
+        d = _drive(with_performance=True)
+        del d["performance"]["random_write_IOPS"]
+        fail(self._doc_with_drives(d), "random_write_IOPS")
+
+    def test_drive_performance_zero_seq_read_fails(self):
+        d = _drive(with_performance=True)
+        d["performance"]["seq_read_MBps"] = 0
+        fail(self._doc_with_drives(d), "seq_read_MBps")
+
+    def test_drive_performance_negative_iops_fails(self):
+        d = _drive(with_performance=True)
+        d["performance"]["random_write_IOPS"] = -1
+        fail(self._doc_with_drives(d), "random_write_IOPS")
+
+    def test_drive_performance_invalid_form_factor_fails(self):
+        d = _drive(with_performance=True)
+        d["performance"]["form_factor"] = "PCIe"
+        fail(self._doc_with_drives(d), "form_factor")
+
+    def test_drive_performance_valid_form_factors(self):
+        for ff in ["U.2", "U.3", "M.2", "E1.S", "E1.L", "E3.S", "E3.L",
+                   "2.5in", "3.5in", "AIC", "other"]:
+            d = _drive(with_performance=True)
+            d["performance"]["form_factor"] = ff
+            ok(self._doc_with_drives(d))
+
+    def test_drive_performance_empty_interface_speed_fails(self):
+        d = _drive(with_performance=True)
+        d["performance"]["interface_speed"] = ""
+        fail(self._doc_with_drives(d), "interface_speed")
+
+    def test_mixed_drive_groups(self):
+        """Drives list can mix entries with and without the performance block."""
+        ok(self._doc_with_drives(
+            _drive(with_performance=True),
+            _drive(model_name="X1650 QLC", media_type="QLC", capacity_in_GB=24000),
+        ))


### PR DESCRIPTION
Add a required `media_type` enum (HDD, TLC, QLC, other) to drive_instance so every submission discloses whether storage is spinning disk or flash, and which NAND cell type for flash.

Add an optional `performance` sub-block carrying vendor-published spec-sheet numbers for an individual drive. The whole block is optional, but if present seq_read_MBps, seq_write_MBps, random_read_IOPS, and random_write_IOPS are all required. form_factor and interface_speed are optional within the block.

Updates schema.yaml, the pydantic validator, all example YAMLs that contain drive entries, and the schema_validator unit tests (16 new tests covering media_type enforcement and the performance-block optionality contract).