### PR TITLE
fix(dlio): strip URI scheme from storage.storage_root (#392)

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -3,6 +3,7 @@ import os
 import os.path
 import pprint
 import sys
+from urllib.parse import urlparse
 
 from mlpstorage_py.benchmarks.base import Benchmark
 from mlpstorage_py.config import (CONFIGS_ROOT_DIR, BENCHMARK_TYPES, EXEC_TYPE, MPIRUN, MLPSTORAGE_BIN_NAME,
@@ -216,8 +217,33 @@ class DLIOBenchmark(Benchmark, abc.ABC):
             f'uri_scheme={uri_scheme}, force_path_style={is_http_scheme and bool(endpoint_url)})'
         )
 
+    @staticmethod
+    def _strip_uri_scheme(value):
+        # DLIO obj_store_lib treats storage_root as a bare bucket/prefix and
+        # unconditionally prepends a scheme when constructing object URIs.
+        # Strip any leading <scheme>:// so DLIO doesn't produce s3://s3://...
+        # See issue #392.
+        if '://' not in value:
+            return value
+        parsed = urlparse(value)
+        if not parsed.scheme:
+            return value
+        normalized = (parsed.netloc + parsed.path).rstrip('/')
+        return normalized or parsed.netloc
+
     def process_dlio_params(self, config_file):
         params_dict = dict() if not self.args.params else {k: v for k, v in (item.split("=") for item in self.args.params)}
+
+        storage_root = params_dict.get('storage.storage_root')
+        if storage_root:
+            normalized = DLIOBenchmark._strip_uri_scheme(storage_root)
+            if normalized != storage_root:
+                self.logger.debug(
+                    f"Normalized storage.storage_root: {storage_root!r} -> {normalized!r} "
+                    f"(scheme stripped to avoid DLIO double-prefix bug, issue #392)"
+                )
+                params_dict['storage.storage_root'] = normalized
+
         yaml_params = read_config_from_file(os.path.join(self.DLIO_CONFIG_PATH, "workload", config_file))
         combined_params = update_nested_dict(yaml_params, create_nested_dict(params_dict))
 

--- a/tests/unit/test_dlio_object_storage.py
+++ b/tests/unit/test_dlio_object_storage.py
@@ -409,6 +409,42 @@ class TestProcessDlioParams:
         params_dict, _, _ = DLIOBenchmark.process_dlio_params(obj, 'fake.yaml')
         assert params_dict == {}
 
+    # ----- Issue #392: storage_root scheme stripping ------------------------
+
+    @pytest.mark.parametrize('raw,expected', [
+        ('s3://mlperf-data/unet3d', 'mlperf-data/unet3d'),
+        ('s3://mlperf-data/unet3d/', 'mlperf-data/unet3d'),
+        ('s3://mybucket', 'mybucket'),
+        ('s3://mybucket/', 'mybucket'),
+        ('az://container/path', 'container/path'),
+        ('gs://bucket/prefix/deeper', 'bucket/prefix/deeper'),
+        ('mybucket', 'mybucket'),
+        ('mybucket/prefix', 'mybucket/prefix'),
+    ])
+    def test_strip_uri_scheme(self, raw, expected):
+        assert DLIOBenchmark._strip_uri_scheme(raw) == expected
+
+    @patch('mlpstorage_py.benchmarks.dlio.read_config_from_file')
+    def test_storage_root_scheme_stripped_when_passed_full_uri(self, mock_rcf):
+        # Reporter's #392 command: storage.storage_root=s3://mlperf-data/unet3d
+        # must be normalized so DLIO doesn't produce s3://s3://... object URIs.
+        mock_rcf.return_value = _YAML_FIXTURE
+        obj = _make_chain_obj(params=[
+            'storage.storage_library=s3dlio',
+            'storage.storage_type=s3',
+            'storage.storage_root=s3://mlperf-data/unet3d',
+        ])
+        params_dict, _, _ = DLIOBenchmark.process_dlio_params(obj, 'fake.yaml')
+        assert params_dict['storage.storage_root'] == 'mlperf-data/unet3d'
+        assert params_dict['storage.storage_type'] == 's3'
+
+    @patch('mlpstorage_py.benchmarks.dlio.read_config_from_file')
+    def test_storage_root_bare_bucket_passes_through(self, mock_rcf):
+        mock_rcf.return_value = _YAML_FIXTURE
+        obj = _make_chain_obj(params=['storage.storage_root=mybucket'])
+        params_dict, _, _ = DLIOBenchmark.process_dlio_params(obj, 'fake.yaml')
+        assert params_dict['storage.storage_root'] == 'mybucket'
+
 
 class TestProcessDlioParamsFullChain:
     """


### PR DESCRIPTION
Resolves #392.

## Summary

When a user passes `--params storage.storage_root=s3://bucket/path`, every S3 upload fails because DLIO's `obj_store_lib` builds URLs with a doubled scheme — `s3://s3://bucket/path/...`. The reporter saw "nothing in S3 / no bucket created" as a result.

The doubled prefix originates in DLIO's `obj_store_lib.ObjStoreLibStorage`:

- `storage_factory.py:49` passes `args.storage_root` straight in as `namespace`.
- `obj_store_lib.py:159` stores it verbatim.
- `obj_store_lib.py:399-401` unconditionally adds `uri_scheme://` when constructing object URIs:
  ```python
  if '://' in str(id):
      return id
  return f"{self.uri_scheme}://{self.namespace.name}/{id.lstrip('/')}"
  ```

So a `storage_root` like `s3://mlperf-data/unet3d` plus a key like `data/unet3d/train/img_000_of_168.npz` produces `s3://s3://mlperf-data/unet3d/data/unet3d/train/img_000_of_168.npz`. MinIO rejects every put, and Keith's command exits without writing anything.

`--object` mode happens to avoid this because `_apply_object_storage_params` sets `storage_root = $BUCKET` (bare bucket, no scheme). Users who hand-roll `--params storage.storage_root=...` hit it.

## What this PR does

- Adds `DLIOBenchmark._strip_uri_scheme` and normalizes `storage.storage_root` in `process_dlio_params` so any `<scheme>://` prefix is stripped before the override is handed off to DLIO. The bare-bucket form is untouched.
- Adds parametrized tests covering `s3://`, `s3://bucket/`, `az://`, `gs://`, and bare-bucket cases, plus the reporter's exact command shape.

The proper fix still belongs in DLIO's `obj_store_lib` — once the pinned fork is patched and `pyproject.toml:127` is bumped, this normalization becomes a harmless no-op, since the normalized input is also valid input.

## Test plan

- [x] `uv run pytest tests/unit -q` → 1372 passed, 4 skipped.
- [ ] Manual: rerun the reporter's `mlpstorage training datagen --model unet3d --num-processes 1 --params storage.storage_library=s3dlio --params storage.storage_type=s3 --params storage.storage_root=s3://mlperf-data/unet3d` against MinIO and confirm objects land at `s3://mlperf-data/unet3d/data/unet3d/train/img_*.npz` (single `s3://`).