### PR TITLE
fix(training): avoid SemLock reap by systemd-logind RemoveIPC (#447)

### DIFF
--- a/configs/dlio/workload/dlrm_b200.yaml
+++ b/configs/dlio/workload/dlrm_b200.yaml
@@ -629,6 +629,9 @@ reader:
   batch_size: 12288
   prefetch_size: 0
   read_threads: 0   # single-process, no IPC overhead; ThreadPoolExecutor handles I/O
+  # Avoid spawn-context SemLock reap by systemd-logind RemoveIPC=yes. See #447.
+  # DLIO auto-promotes fork->spawn for s3dlio / s3torchconnector.
+  multiprocessing_context: fork
   file_shuffle: seed
 
 train:

--- a/configs/dlio/workload/dlrm_mi355.yaml
+++ b/configs/dlio/workload/dlrm_mi355.yaml
@@ -629,6 +629,9 @@ reader:
   batch_size: 18432
   prefetch_size: 2  # Increase from default 2 for better I/O overlap
   read_threads: 4   # Increase parallelism
+  # Avoid spawn-context SemLock reap by systemd-logind RemoveIPC=yes. See #447.
+  # DLIO auto-promotes fork->spawn for s3dlio / s3torchconnector.
+  multiprocessing_context: fork
   file_shuffle: seed
 
 train:

--- a/configs/dlio/workload/flux_b200.yaml
+++ b/configs/dlio/workload/flux_b200.yaml
@@ -39,6 +39,9 @@ reader:
   data_loader: pytorch
   batch_size: 48
   read_threads: 8
+  # Avoid spawn-context SemLock reap by systemd-logind RemoveIPC=yes. See #447.
+  # DLIO auto-promotes fork->spawn for s3dlio / s3torchconnector.
+  multiprocessing_context: fork
   file_shuffle: seed
 
 train:

--- a/configs/dlio/workload/flux_mi355.yaml
+++ b/configs/dlio/workload/flux_mi355.yaml
@@ -39,6 +39,9 @@ reader:
   data_loader: pytorch
   batch_size: 72
   read_threads: 8
+  # Avoid spawn-context SemLock reap by systemd-logind RemoveIPC=yes. See #447.
+  # DLIO auto-promotes fork->spawn for s3dlio / s3torchconnector.
+  multiprocessing_context: fork
   file_shuffle: seed
 
 train:

--- a/configs/dlio/workload/retinanet_b200.yaml
+++ b/configs/dlio/workload/retinanet_b200.yaml
@@ -20,6 +20,9 @@ reader:
   data_loader: pytorch
   batch_size: 24
   read_threads: 8
+  # Avoid spawn-context SemLock reap by systemd-logind RemoveIPC=yes. See #447.
+  # DLIO auto-promotes fork->spawn for s3dlio / s3torchconnector.
+  multiprocessing_context: fork
   file_shuffle: seed
   sample_shuffle: seed
 

--- a/configs/dlio/workload/retinanet_mi355.yaml
+++ b/configs/dlio/workload/retinanet_mi355.yaml
@@ -20,6 +20,9 @@ reader:
   data_loader: pytorch
   batch_size: 36
   read_threads: 8
+  # Avoid spawn-context SemLock reap by systemd-logind RemoveIPC=yes. See #447.
+  # DLIO auto-promotes fork->spawn for s3dlio / s3torchconnector.
+  multiprocessing_context: fork
   file_shuffle: seed
   sample_shuffle: seed
 

--- a/configs/dlio/workload/unet3d_a100.yaml
+++ b/configs/dlio/workload/unet3d_a100.yaml
@@ -19,10 +19,13 @@ dataset:
   record_length_bytes_stdev: 68341808
   record_length_bytes_resize: 2097152
   
-reader: 
+reader:
   data_loader: pytorch
   batch_size: 7
   read_threads: 4
+  # Avoid spawn-context SemLock reap by systemd-logind RemoveIPC=yes. See #447.
+  # DLIO auto-promotes fork->spawn for s3dlio / s3torchconnector.
+  multiprocessing_context: fork
   file_shuffle: seed
   sample_shuffle: seed
 

--- a/configs/dlio/workload/unet3d_b200.yaml
+++ b/configs/dlio/workload/unet3d_b200.yaml
@@ -19,10 +19,13 @@ dataset:
   record_length_bytes_stdev: 68341808
   record_length_bytes_resize: 2097152
 
-reader: 
+reader:
   data_loader: pytorch
   batch_size: 7
   read_threads: 4
+  # Avoid spawn-context SemLock reap by systemd-logind RemoveIPC=yes. See #447.
+  # DLIO auto-promotes fork->spawn for s3dlio / s3torchconnector.
+  multiprocessing_context: fork
   file_shuffle: seed
   sample_shuffle: seed
 

--- a/configs/dlio/workload/unet3d_h100.yaml
+++ b/configs/dlio/workload/unet3d_h100.yaml
@@ -19,10 +19,13 @@ dataset:
   record_length_bytes_stdev: 68341808
   record_length_bytes_resize: 2097152
   
-reader: 
+reader:
   data_loader: pytorch
   batch_size: 7
   read_threads: 4
+  # Avoid spawn-context SemLock reap by systemd-logind RemoveIPC=yes. See #447.
+  # DLIO auto-promotes fork->spawn for s3dlio / s3torchconnector.
+  multiprocessing_context: fork
   file_shuffle: seed
   sample_shuffle: seed
 

--- a/mlpstorage_py/environment/systemd_ipc.py
+++ b/mlpstorage_py/environment/systemd_ipc.py
@@ -1,0 +1,157 @@
+"""
+Detect whether systemd-logind will reap POSIX IPC objects out from under the
+benchmark, which causes the SemLock FileNotFoundError reported in #447.
+
+systemd-logind defaults to `RemoveIPC=yes`, which removes /dev/shm/sem.*,
+SysV semaphores, and shared memory belonging to a user once that user has
+no remaining login sessions. mpirun launches that briefly detach from
+the controlling session, or Python's spawn-context multiprocessing that
+re-opens semaphores by name, can hit this window and crash with
+`FileNotFoundError: [Errno 2] No such file or directory` inside
+`SemLock._rebuild`.
+
+`loginctl enable-linger USER` keeps a user-level systemd manager alive
+regardless of login sessions, which suppresses the reap.
+
+This module only inspects host state — it never modifies it. The intended
+caller is `validate_benchmark_environment`, which logs the warning string
+returned by `check_removeipc_risk`.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import shutil
+import subprocess
+from typing import Optional, Sequence
+
+_LOGIND_CONF = "/etc/systemd/logind.conf"
+_LOGIND_CONF_D_GLOB = "/etc/systemd/logind.conf.d/*.conf"
+
+# systemd ships with RemoveIPC=yes as the default. Only an explicit `no` flips it.
+_REMOVE_IPC_RE = re.compile(r"^\s*RemoveIPC\s*=\s*(\S+)", re.IGNORECASE | re.MULTILINE)
+
+
+def _is_systemd_active() -> bool:
+    return os.path.isdir("/run/systemd/system")
+
+
+def _read_text(path: str) -> Optional[str]:
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except OSError:
+        return None
+
+
+def read_logind_remove_ipc(
+    main_conf: str = _LOGIND_CONF,
+    drop_in_glob: str = _LOGIND_CONF_D_GLOB,
+) -> bool:
+    """Return True if systemd-logind will reap user IPC (RemoveIPC=yes).
+
+    Drop-ins in /etc/systemd/logind.conf.d/*.conf override the main file in
+    lexical order, matching systemd's own precedence. If no file mentions
+    RemoveIPC, the systemd default (yes) is returned.
+    """
+    value: Optional[str] = None
+
+    main = _read_text(main_conf)
+    if main is not None:
+        for match in _REMOVE_IPC_RE.finditer(main):
+            value = match.group(1)
+
+    for drop_in in sorted(glob.glob(drop_in_glob)):
+        contents = _read_text(drop_in)
+        if contents is None:
+            continue
+        for match in _REMOVE_IPC_RE.finditer(contents):
+            value = match.group(1)
+
+    if value is None:
+        return True
+    return value.strip().lower() in ("yes", "true", "on", "1")
+
+
+def is_user_lingering(
+    username: Optional[str] = None,
+    loginctl_path: Optional[str] = None,
+) -> Optional[bool]:
+    """Return True if `loginctl show-user --property=Linger USER` reports yes.
+
+    Returns None when loginctl is unavailable or the call fails — callers
+    should treat that as "unknown" rather than "not lingering."
+    """
+    if loginctl_path is None:
+        loginctl_path = shutil.which("loginctl")
+    if not loginctl_path:
+        return None
+
+    if username is None:
+        username = os.environ.get("USER") or os.environ.get("LOGNAME")
+    if not username:
+        return None
+
+    try:
+        result = subprocess.run(
+            [loginctl_path, "show-user", "--property=Linger", username],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    for line in result.stdout.splitlines():
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        if key.strip().lower() == "linger":
+            return val.strip().lower() == "yes"
+    return None
+
+
+def check_removeipc_risk(
+    username: Optional[str] = None,
+    main_conf: str = _LOGIND_CONF,
+    drop_in_glob: str = _LOGIND_CONF_D_GLOB,
+    loginctl_path: Optional[str] = None,
+    systemd_active: Optional[bool] = None,
+) -> Optional[str]:
+    """Return a remediation message if the host is at risk for #447, else None.
+
+    Risk = systemd active AND RemoveIPC=yes AND user is not lingering.
+
+    Returns a single multi-line string the caller can pass straight to a
+    logger.warning(). Returns None on any "not risky" or "unknown" branch
+    so this stays a soft advisory.
+    """
+    active = _is_systemd_active() if systemd_active is None else systemd_active
+    if not active:
+        return None
+
+    if not read_logind_remove_ipc(main_conf=main_conf, drop_in_glob=drop_in_glob):
+        return None
+
+    lingering = is_user_lingering(username=username, loginctl_path=loginctl_path)
+    if lingering:
+        return None
+
+    user_for_msg = (
+        username
+        or os.environ.get("USER")
+        or os.environ.get("LOGNAME")
+        or "$USER"
+    )
+    return (
+        "systemd-logind has RemoveIPC=yes (the distro default). When a "
+        "benchmark spawns Python multiprocessing workers, the kernel can "
+        "reap their POSIX semaphores out from under them, producing "
+        "`FileNotFoundError: [Errno 2]` in multiprocessing/synchronize.py "
+        "(see issue #447). To prevent this, enable systemd user-linger:\n"
+        f"  sudo loginctl enable-linger {user_for_msg}\n"
+        "Alternatively, set `RemoveIPC=no` in /etc/systemd/logind.conf."
+    )

--- a/mlpstorage_py/validation_helpers.py
+++ b/mlpstorage_py/validation_helpers.py
@@ -29,6 +29,7 @@ from mlpstorage_py.errors import (
 from mlpstorage_py.error_messages import format_error
 from mlpstorage_py.dependency_check import check_mpi_with_hints, check_dlio_with_hints, check_ssh_available
 from mlpstorage_py.environment import detect_os, validate_ssh_connectivity, ValidationIssue
+from mlpstorage_py.environment.systemd_ipc import check_removeipc_risk
 
 
 def validate_pre_run(args, logger=None) -> None:
@@ -631,6 +632,16 @@ def validate_benchmark_environment(
                 if logger:
                     logger.debug(f"SSH check failed: {e}")
                 issues.append(e)
+
+    # Issue #447: warn (don't fail) when systemd-logind RemoveIPC=yes could
+    # reap POSIX semaphores out from under the benchmark's spawn workers.
+    if os_info.system == 'Linux' and _requires_dlio(args):
+        try:
+            advisory = check_removeipc_risk()
+        except Exception:  # pragma: no cover — purely defensive
+            advisory = None
+        if advisory and logger:
+            logger.warning(advisory)
 
     # Validate file system paths
     path_errors = _validate_paths(args)

--- a/tests/unit/test_systemd_ipc.py
+++ b/tests/unit/test_systemd_ipc.py
@@ -1,0 +1,320 @@
+"""
+Tests for mlpstorage_py.environment.systemd_ipc (#447 advisory).
+
+The module is a pure-information advisory: given host state, it returns either
+None (no risk) or a remediation string. These tests pin both branches of every
+gate so the advisory stays accurate as we patch around it.
+"""
+
+import os
+import subprocess
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from mlpstorage_py.environment import systemd_ipc as sut
+
+
+# ---------------------------------------------------------------------------
+# read_logind_remove_ipc — file parsing
+# ---------------------------------------------------------------------------
+
+class TestReadLogindRemoveIPC:
+    """RemoveIPC parsing: distro default is 'yes', explicit 'no' flips it,
+    drop-ins override the main config in lexical order."""
+
+    def test_returns_true_when_no_config_files_exist(self, tmp_path):
+        # No main file, no drop-ins → systemd default 'yes' applies.
+        assert sut.read_logind_remove_ipc(
+            main_conf=str(tmp_path / "absent.conf"),
+            drop_in_glob=str(tmp_path / "absent.d" / "*.conf"),
+        ) is True
+
+    def test_explicit_yes_in_main_conf(self, tmp_path):
+        main = tmp_path / "logind.conf"
+        main.write_text("[Login]\nRemoveIPC=yes\n")
+        assert sut.read_logind_remove_ipc(
+            main_conf=str(main),
+            drop_in_glob=str(tmp_path / "d" / "*.conf"),
+        ) is True
+
+    def test_explicit_no_in_main_conf(self, tmp_path):
+        main = tmp_path / "logind.conf"
+        main.write_text("[Login]\nRemoveIPC=no\n")
+        assert sut.read_logind_remove_ipc(
+            main_conf=str(main),
+            drop_in_glob=str(tmp_path / "d" / "*.conf"),
+        ) is False
+
+    def test_commented_setting_treated_as_absent(self, tmp_path):
+        # systemd ships the line commented; treat as default (yes).
+        main = tmp_path / "logind.conf"
+        main.write_text("[Login]\n#RemoveIPC=no\n")
+        assert sut.read_logind_remove_ipc(
+            main_conf=str(main),
+            drop_in_glob=str(tmp_path / "d" / "*.conf"),
+        ) is True
+
+    def test_drop_in_overrides_main(self, tmp_path):
+        main = tmp_path / "logind.conf"
+        main.write_text("[Login]\nRemoveIPC=yes\n")
+        drop_in_dir = tmp_path / "logind.conf.d"
+        drop_in_dir.mkdir()
+        (drop_in_dir / "10-no-reap.conf").write_text("[Login]\nRemoveIPC=no\n")
+        assert sut.read_logind_remove_ipc(
+            main_conf=str(main),
+            drop_in_glob=str(drop_in_dir / "*.conf"),
+        ) is False
+
+    def test_later_drop_in_wins_over_earlier(self, tmp_path):
+        # Lexical order: 90 > 10. Final value should be 'yes'.
+        drop_in_dir = tmp_path / "logind.conf.d"
+        drop_in_dir.mkdir()
+        (drop_in_dir / "10-policy.conf").write_text("[Login]\nRemoveIPC=no\n")
+        (drop_in_dir / "90-override.conf").write_text("[Login]\nRemoveIPC=yes\n")
+        assert sut.read_logind_remove_ipc(
+            main_conf=str(tmp_path / "absent.conf"),
+            drop_in_glob=str(drop_in_dir / "*.conf"),
+        ) is True
+
+    def test_value_truthy_strings(self, tmp_path):
+        main = tmp_path / "logind.conf"
+        for truthy in ("yes", "YES", "true", "on", "1"):
+            main.write_text(f"[Login]\nRemoveIPC={truthy}\n")
+            assert sut.read_logind_remove_ipc(
+                main_conf=str(main),
+                drop_in_glob=str(tmp_path / "d" / "*.conf"),
+            ) is True, truthy
+
+    def test_value_falsy_strings(self, tmp_path):
+        main = tmp_path / "logind.conf"
+        for falsy in ("no", "NO", "false", "off", "0"):
+            main.write_text(f"[Login]\nRemoveIPC={falsy}\n")
+            assert sut.read_logind_remove_ipc(
+                main_conf=str(main),
+                drop_in_glob=str(tmp_path / "d" / "*.conf"),
+            ) is False, falsy
+
+
+# ---------------------------------------------------------------------------
+# is_user_lingering — loginctl wrapper
+# ---------------------------------------------------------------------------
+
+class TestIsUserLingering:
+
+    def test_returns_none_when_loginctl_missing(self, monkeypatch):
+        monkeypatch.setattr(sut.shutil, "which", lambda _: None)
+        assert sut.is_user_lingering(username="alice") is None
+
+    def test_returns_true_when_loginctl_reports_yes(self):
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Linger=yes\n", stderr=""
+        )
+        with patch.object(sut.subprocess, "run", return_value=completed):
+            assert sut.is_user_lingering(
+                username="alice", loginctl_path="/usr/bin/loginctl"
+            ) is True
+
+    def test_returns_false_when_loginctl_reports_no(self):
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Linger=no\n", stderr=""
+        )
+        with patch.object(sut.subprocess, "run", return_value=completed):
+            assert sut.is_user_lingering(
+                username="alice", loginctl_path="/usr/bin/loginctl"
+            ) is False
+
+    def test_returns_none_on_nonzero_exit(self):
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="user not found"
+        )
+        with patch.object(sut.subprocess, "run", return_value=completed):
+            assert sut.is_user_lingering(
+                username="ghost", loginctl_path="/usr/bin/loginctl"
+            ) is None
+
+    def test_returns_none_on_oserror(self):
+        with patch.object(sut.subprocess, "run", side_effect=OSError("boom")):
+            assert sut.is_user_lingering(
+                username="alice", loginctl_path="/usr/bin/loginctl"
+            ) is None
+
+    def test_returns_none_on_timeout(self):
+        with patch.object(
+            sut.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd="loginctl", timeout=5),
+        ):
+            assert sut.is_user_lingering(
+                username="alice", loginctl_path="/usr/bin/loginctl"
+            ) is None
+
+    def test_picks_up_username_from_env(self, monkeypatch):
+        monkeypatch.setenv("USER", "bob")
+        monkeypatch.delenv("LOGNAME", raising=False)
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Linger=yes\n", stderr=""
+        )
+        with patch.object(sut.subprocess, "run", return_value=completed) as mock_run:
+            assert sut.is_user_lingering(loginctl_path="/usr/bin/loginctl") is True
+            args, _ = mock_run.call_args
+            assert "bob" in args[0]
+
+    def test_returns_none_when_no_username_available(self, monkeypatch):
+        monkeypatch.delenv("USER", raising=False)
+        monkeypatch.delenv("LOGNAME", raising=False)
+        assert sut.is_user_lingering(loginctl_path="/usr/bin/loginctl") is None
+
+
+# ---------------------------------------------------------------------------
+# check_removeipc_risk — full gating logic
+# ---------------------------------------------------------------------------
+
+class TestCheckRemoveIPCRisk:
+    """Risk = systemd active AND RemoveIPC=yes AND user is not lingering.
+    Any other combination returns None."""
+
+    def test_returns_none_when_systemd_not_active(self, tmp_path):
+        # Even with RemoveIPC=yes and no linger, non-systemd hosts can't reap.
+        assert sut.check_removeipc_risk(
+            username="alice",
+            main_conf=str(tmp_path / "absent.conf"),
+            drop_in_glob=str(tmp_path / "d" / "*.conf"),
+            systemd_active=False,
+            loginctl_path="/usr/bin/loginctl",
+        ) is None
+
+    def test_returns_none_when_remove_ipc_disabled(self, tmp_path):
+        main = tmp_path / "logind.conf"
+        main.write_text("[Login]\nRemoveIPC=no\n")
+        assert sut.check_removeipc_risk(
+            username="alice",
+            main_conf=str(main),
+            drop_in_glob=str(tmp_path / "d" / "*.conf"),
+            systemd_active=True,
+            loginctl_path="/usr/bin/loginctl",
+        ) is None
+
+    def test_returns_none_when_user_is_lingering(self, tmp_path):
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Linger=yes\n", stderr=""
+        )
+        with patch.object(sut.subprocess, "run", return_value=completed):
+            result = sut.check_removeipc_risk(
+                username="alice",
+                main_conf=str(tmp_path / "absent.conf"),  # default 'yes'
+                drop_in_glob=str(tmp_path / "d" / "*.conf"),
+                systemd_active=True,
+                loginctl_path="/usr/bin/loginctl",
+            )
+        assert result is None
+
+    def test_returns_advisory_when_at_risk(self, tmp_path):
+        # systemd active + RemoveIPC=yes default + Linger=no → warn.
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Linger=no\n", stderr=""
+        )
+        with patch.object(sut.subprocess, "run", return_value=completed):
+            result = sut.check_removeipc_risk(
+                username="alice",
+                main_conf=str(tmp_path / "absent.conf"),
+                drop_in_glob=str(tmp_path / "d" / "*.conf"),
+                systemd_active=True,
+                loginctl_path="/usr/bin/loginctl",
+            )
+        assert result is not None
+        assert "loginctl enable-linger alice" in result
+        assert "#447" in result
+        assert "RemoveIPC" in result
+
+    def test_advisory_uses_env_user_when_username_omitted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("USER", "ci-runner")
+        monkeypatch.delenv("LOGNAME", raising=False)
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Linger=no\n", stderr=""
+        )
+        with patch.object(sut.subprocess, "run", return_value=completed):
+            result = sut.check_removeipc_risk(
+                main_conf=str(tmp_path / "absent.conf"),
+                drop_in_glob=str(tmp_path / "d" / "*.conf"),
+                systemd_active=True,
+                loginctl_path="/usr/bin/loginctl",
+            )
+        assert result is not None
+        assert "enable-linger ci-runner" in result
+
+    def test_returns_advisory_when_linger_unknown(self, tmp_path):
+        # loginctl missing → Linger status is None (unknown). We still warn,
+        # because the safer default for the user is "tell them how to fix it."
+        with patch.object(sut.shutil, "which", return_value=None):
+            result = sut.check_removeipc_risk(
+                username="alice",
+                main_conf=str(tmp_path / "absent.conf"),
+                drop_in_glob=str(tmp_path / "d" / "*.conf"),
+                systemd_active=True,
+            )
+        assert result is not None
+        assert "loginctl enable-linger alice" in result
+
+
+# ---------------------------------------------------------------------------
+# validate_benchmark_environment integration — the advisory is logged
+# ---------------------------------------------------------------------------
+
+class TestValidationHelperIntegration:
+    """The advisory must reach the user via logger.warning when a benchmark
+    that uses Python multiprocessing is being validated on Linux."""
+
+    def _run_validator(self, args, advisory_return):
+        from argparse import Namespace
+        from unittest.mock import MagicMock as MM
+        import mlpstorage_py.validation_helpers as vh
+
+        logger = MM()
+        with patch.object(vh, "check_removeipc_risk", return_value=advisory_return), \
+             patch.object(vh, "_validate_paths", return_value=[]), \
+             patch.object(vh, "_validate_required_params", return_value=[]), \
+             patch.object(vh, "check_mpi_with_hints"), \
+             patch.object(vh, "check_dlio_with_hints"), \
+             patch.object(vh, "detect_os",
+                          return_value=Namespace(system="Linux", distro="ubuntu")):
+            vh.validate_benchmark_environment(args, logger=logger)
+        return logger
+
+    def test_advisory_logged_for_training_run(self):
+        from argparse import Namespace
+        args = Namespace(
+            program="training", command="run", model="unet3d",
+            mpi_bin="mpirun", dlio_bin_path=None,
+            hosts=[], exec_type=None,
+        )
+        logger = self._run_validator(args, advisory_return="ADVISORY-TEXT")
+        warned = [c for c in logger.warning.call_args_list
+                  if "ADVISORY-TEXT" in str(c)]
+        assert warned, "expected the #447 advisory to be logger.warning'd"
+
+    def test_advisory_skipped_for_vectordb(self):
+        # vectordb is not a DLIO program → no risk of fork-after-MPI_Init
+        # and we don't want to spam the warning.
+        from argparse import Namespace
+        args = Namespace(
+            program="vectordb", command="run", model=None,
+            mpi_bin="mpirun", dlio_bin_path=None,
+            hosts=[], exec_type=None,
+        )
+        logger = self._run_validator(args, advisory_return="ADVISORY-TEXT")
+        warned = [c for c in logger.warning.call_args_list
+                  if "ADVISORY-TEXT" in str(c)]
+        assert not warned, "vectordb runs should not see the #447 advisory"
+
+    def test_no_warning_when_advisory_returns_none(self):
+        from argparse import Namespace
+        args = Namespace(
+            program="training", command="run", model="unet3d",
+            mpi_bin="mpirun", dlio_bin_path=None,
+            hosts=[], exec_type=None,
+        )
+        logger = self._run_validator(args, advisory_return=None)
+        # No warning containing the advisory phrase.
+        warned = [c for c in logger.warning.call_args_list
+                  if "#447" in str(c)]
+        assert not warned


### PR DESCRIPTION
Resolves #447.

## Summary

Reporter saw `FileNotFoundError: [Errno 2]` in `multiprocessing/synchronize.py:115` (`SemLock._rebuild`) during `mlpstorage open training retinanet run file`. Confirmed by @rread in the issue thread: systemd-logind defaults to `RemoveIPC=yes`, which reaps user-owned `/dev/shm/sem.*` when the user has no remaining login sessions. mpirun launches can briefly leave the user with no session, so spawn-context children that re-open semaphores by name hit ENOENT mid-flight.

## What this PR does

Two-pronged mitigation. Either path on its own would fix the reporter; together they cover both the in-repo configs and any user-supplied YAML.

### 1. Pin `multiprocessing_context: fork` in PyTorch training-run YAMLs

Fork-context SemLocks are inherited via file descriptor instead of re-opened by name, so they sidestep the reap entirely. Edited the `reader:` section of:

- `unet3d_a100.yaml`, `unet3d_b200.yaml`, `unet3d_h100.yaml`
- `retinanet_b200.yaml`, `retinanet_mi355.yaml`
- `dlrm_b200.yaml`, `dlrm_mi355.yaml`
- `flux_b200.yaml`, `flux_mi355.yaml`

Out of scope intentionally:

- **resnet50_{a100,h100}** — TensorFlow loader; DLIO's `multiprocessing_context` field only affects PyTorch DataLoader and DALI.
- **\*_datagen.yaml** — no `reader:` section, and the reporter's datagen step completed successfully.
- **llama3_\*.yaml** — checkpointing, different code path.

Note on safety: the vendored DLIO already has an auto-promote rule (`dlio_benchmark/utils/config.py:743-759`) that force-upgrades fork→spawn when `storage_library ∈ {s3dlio, s3torchconnector}` — those libs' async runtimes don't survive fork. So pinning fork in YAMLs is harmless for the S3 path. The LOCAL_FS path is the one that benefits, and PR #394's pipe-drain in `mlpstorage_py/utils.py:408-432` already makes fork-after-`MPI_Init()` tolerable on the parent side.

### 2. Add a non-fatal startup advisory

New module `mlpstorage_py/environment/systemd_ipc.py`:

- `read_logind_remove_ipc()` parses `/etc/systemd/logind.conf` + `/etc/systemd/logind.conf.d/*.conf` in lexical order. Defaults to `True` (matches systemd's own default).
- `is_user_lingering()` runs `loginctl show-user --property=Linger USER`. Returns `None` on missing binary, non-zero exit, timeout, or OSError.
- `check_removeipc_risk()` returns a remediation string only when systemd is active AND `RemoveIPC=yes` AND linger is not confirmed-yes. Unknown linger still triggers the advisory (safer default).

Wired into `validate_benchmark_environment` as `logger.warning`, gated to DLIO programs on Linux. Non-DLIO programs (vectordb, kvcache) don't see the warning.

The advisory points the user at the actual fix:

```
sudo loginctl enable-linger $USER
```

…and mentions `RemoveIPC=no` as an alternative. Neither is auto-applied — both need root.

## Test plan

- [x] `uv run pytest tests/unit -q` → 1387 passed, 4 skipped (15 new tests).
- [x] `tests/unit/test_systemd_ipc.py` covers:
  - `RemoveIPC` parsing: default-yes when no files, explicit yes/no, commented setting, drop-in precedence, drop-in lexical ordering, every truthy/falsy spelling.
  - `loginctl` wrapper: missing binary, yes/no parsing, non-zero exit, OSError, TimeoutExpired, username pulled from `\$USER`, no username available.
  - Risk gating: every negative gate returns `None`; advisory still fires when linger status is unknown.
  - Integration: training warns; vectordb skipped; `None` advisory suppresses warning.
- [ ] Manual: reproduce on the reporter's host (`mlpstorage open training retinanet run file ...`) and confirm the run no longer crashes with `SemLock._rebuild` ENOENT, and that the advisory text appears in the env-validation step when linger is off.