### PR TITLE
fix: bump DLIO pin for storage #391 (sudo prompt) + #448 (per-node memory budget)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,9 +122,13 @@ environments = ["sys_platform == 'linux'"]
 torch = [{ index = "pytorch-cpu" }]
 torchvision = [{ index = "pytorch-cpu" }]
 torchaudio = [{ index = "pytorch-cpu" }]
-# Pinned to PR #22 head (fix for issue #415: mpi4py auto-init aborts in PyTorch
-# DataLoader spawn-workers). Revert to branch = "main" once the PR merges upstream.
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6" }
+# Pinned to FileSystemGuy-combined-391-448 head — carries:
+#   - DLIO PR #21 fix for storage #391 part 1 (TorchIterableDatasetSimple gating)
+#   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
+#   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
+#   - DLIO PR #24 fix for storage #448 (per-node worker-memory budget)
+# Revert to branch = "main" once PRs #23 and #24 merge upstream.
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "814f3ff400c865a294bfc70714a3289efbfa83ac" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6#60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=814f3ff400c865a294bfc70714a3289efbfa83ac#814f3ff400c865a294bfc70714a3289efbfa83ac" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=60fd3b8e7ae9cc8be644b47df0661366ac2c8bd6" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=814f3ff400c865a294bfc70714a3289efbfa83ac" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=814f3ff400c865a294bfc70714a3289efbfa83ac" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
Resolves #448.
Also resolves the DLIO half of #391 (the silent 30s/epoch stall caused by interactive `sudo` in `drop_caches`).

## Summary

Bumps the DLIO pin from `60fd3b8` to `814f3ff`, which carries two new upstream fixes:

- **mlcommons/DLIO_local_changes#23** — Page-cache flush at the top of each epoch now uses `sudo -n` (non-interactive) and disables itself after the first failure with a single explanatory warning. Fixes the interactive-sudo prompt that the reporter of #391 hit (rich progress bar overwrote the prompt; user couldn't see/respond; 16-hour silent hang).
- **mlcommons/DLIO_local_changes#24** — Worker-memory budget guard scopes to per-node (`read_threads × ranks_per_node()`), uses `psutil.virtual_memory().available` with a 90% safety margin instead of `.total`, and reports hostname + `local_ranks` in the error text. Fixes the false-positive that rejected valid multi-node configs and collapsed `max_threads` to 0 at ~100 nodes (#448).

The intermediate pin point is a combined branch (`FileSystemGuy-combined-391-448`) in DLIO_local_changes so we get both fixes from a single commit while the upstream PRs land. Once they merge, this repo can be re-pinned to `branch = "main"` and the combined branch can be deleted.

## What is NOT in this PR

- The mlpstorage-side workarounds for #391 (e.g. `stdin=DEVNULL` on `CommandExecutor.execute`) are still useful as defense in depth but are not strictly required once the DLIO fix lands. Left for a separate decision.
- Tests for the new DLIO behavior live in the DLIO PRs themselves (well, would — neither PR added a unit test; both behaviors are easier to verify with a real `mpirun` against the changed code).

## Test plan

- [x] `uv lock` resolves the new SHA cleanly.
- [x] `uv sync` installs the bumped DLIO without resolver pain.
- [x] `uv run pytest tests/unit -q` → 1362 passed, 4 skipped. No regression versus the prior pin.
- [ ] Manual: rerun the reporter's #391 command on a host without NOPASSWD sudo and confirm the run no longer pauses at "Starting epoch 1" and the one-line warning appears.
- [ ] Manual: rerun the reporter's #448 4-node × 12-ranks × `read_threads=16` config on 256 GiB nodes and confirm the memory-budget guard no longer falsely rejects.