### PR TITLE
chore(deps): track DLIO main @ PR #24 merge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,13 +126,12 @@ environments = ["sys_platform == 'linux'"]
 torch = [{ index = "pytorch-cpu" }]
 torchvision = [{ index = "pytorch-cpu" }]
 torchaudio = [{ index = "pytorch-cpu" }]
-# Pinned to FileSystemGuy-combined-391-448 head — carries:
+# Pinned to upstream main @ PR #24 merge — carries:
 #   - DLIO PR #21 fix for storage #391 part 1 (TorchIterableDatasetSimple gating)
 #   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #24 fix for storage #448 (per-node worker-memory budget)
-# Revert to branch = "main" once PRs #23 and #24 merge upstream.
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "814f3ff400c865a294bfc70714a3289efbfa83ac" }
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "1d11f9820b71db1d59b41283bc8c57db0c42cb7f" }
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- Update the `dlio-benchmark` git pin in `pyproject.toml` from `814f3ff4…` (tip of the now-merged `FileSystemGuy-issue448-per-node-memory-budget` PR branch) to `1d11f9820b…` (the PR #24 merge commit on upstream `main`).
- Refresh the surrounding comment block; drop the stale "revert to branch=main once PRs #23/#24 merge" note since both have merged.

## Why
The previous SHA is not reachable from upstream `main` (it's the pre-merge branch HEAD), so installs were effectively tracking a detached branch tip. The new SHA is the canonical merge commit on `main` and contains the same fixes for storage #391, #415, and #448.

## Test plan
- [ ] `pip install -e .` resolves `dlio-benchmark` cleanly from the new rev
- [ ] `pytest tests/unit -v` passes