### PR TITLE
chore(deps): track DLIO main @ PR #25 merge (fixes #455)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.12"
+version = "3.0.13"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -131,7 +131,8 @@ torchaudio = [{ index = "pytorch-cpu" }]
 #   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #24 fix for storage #448 (per-node worker-memory budget)
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "1d11f9820b71db1d59b41283bc8c57db0c42cb7f" }
+#   - DLIO PR #25 fix for storage #455 (sampler floor division — equal per-rank shards)
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "cbe200103b05fb65f04110157a7d0dd6d6d88ead" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=814f3ff400c865a294bfc70714a3289efbfa83ac#814f3ff400c865a294bfc70714a3289efbfa83ac" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=cbe200103b05fb65f04110157a7d0dd6d6d88ead#cbe200103b05fb65f04110157a7d0dd6d6d88ead" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.12"
+version = "3.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=814f3ff400c865a294bfc70714a3289efbfa83ac" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=814f3ff400c865a294bfc70714a3289efbfa83ac" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=cbe200103b05fb65f04110157a7d0dd6d6d88ead" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=cbe200103b05fb65f04110157a7d0dd6d6d88ead" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary

Bumps the `dlio-benchmark` git pin to pick up [DLIO PR #25](https://github.com/mlcommons/DLIO_local_changes/pull/25) (`cbe20010`), which fixes the inter-epoch sampler deadlock reported in #455.

- Pin: `1d11f982` → `cbe20010`
- Storage version: `3.0.12` → `3.0.13`
- `uv.lock` regenerated.

## Why

`dlio_sampler` was using `math.ceil(num_samples / comm_size)` with a clamp on the last rank. When `num_samples % comm_size != 0` the last rank produced fewer batches per epoch and the per-step / end-of-epoch `MPI_Barrier`s in `main._train()` matched across iterations — a silent CPU-spinning deadlock at the next epoch boundary with no diagnostic.

PR #25 replaces `ceil + clamp` with floor division at three call sites (`torch_data_loader.dlio_sampler`, `config.build_sample_map_iter`, `config.get_global_map_index`), emits a rank-0 warning when the floor drops samples, and fixes a pre-existing `Sampler.__len__` contract violation (caught by @idevasena during review) so `len(sampler) == len(list(iter(sampler)))`. Includes three regression tests.

Closes #455.

## Test plan

- [ ] `mlpstorage --version` reports `3.0.13`.
- [ ] `pip install -e .` resolves DLIO at `cbe20010`.
- [ ] Multi-rank run with `num_samples % comm_size != 0` (e.g. `unet3d` configured so `num_files_train` is not a multiple of `num-accelerators`) completes past epoch 1 without hanging.
- [ ] DLIO emits the "dropping N sample(s)" warning on rank 0 when N is uneven.