### PR TITLE
fix(cli): clear error when --params token is missing '=' (#469)

### DIFF
--- a/mlpstorage_py/cli_parser.py
+++ b/mlpstorage_py/cli_parser.py
@@ -280,6 +280,22 @@ def update_args(args):
     # Check for list of lists in params and flatten them
     if hasattr(args, 'params') and args.params:
         flattened_params = [item for sublist in args.params for item in sublist]
+        # Each token must be of the form KEY=VALUE. argparse with nargs="+"
+        # silently accepts space-separated pairs (--param KEY VALUE), which
+        # used to surface as "not enough values to unpack" inside the DLIO
+        # param processor (issue #469). Catch it here with a message that
+        # actually names the offending token and the right syntax.
+        bad = [tok for tok in flattened_params if '=' not in tok]
+        if bad:
+            print(
+                "Error: --params expects KEY=VALUE tokens joined with '=' "
+                "(no space).\n"
+                f"  Offending token(s): {bad}\n"
+                "  Wrong: --param dataset.num_files_train 35000\n"
+                "  Right: --param dataset.num_files_train=35000\n"
+                "  Multiple overrides: --params A=1 B=2 C=3"
+            )
+            sys.exit(EXIT_CODE.INVALID_ARGUMENTS)
         setattr(args, 'params', flattened_params)
 
     if hasattr(args, 'mpi_params') and args.mpi_params:

--- a/tests/unit/test_cli_parser.py
+++ b/tests/unit/test_cli_parser.py
@@ -195,6 +195,16 @@ class TestUpdateArgsAndConfig:
         update_args(args)
         assert args.params == ['key=val1', 'key=val2']
 
+    def test_update_args_rejects_space_separated_params(self):
+        """update_args should fail with a clear error when --param uses space instead of '='. (issue #469)"""
+        # Simulates `--param dataset.num_files_train 35000` — argparse with
+        # nargs="+" captures both tokens; without validation the missing '='
+        # surfaces later as "not enough values to unpack".
+        args = argparse.Namespace(params=[['dataset.num_files_train', '35000']])
+        with pytest.raises(SystemExit) as excinfo:
+            update_args(args)
+        assert excinfo.value.code == EXIT_CODE.INVALID_ARGUMENTS
+
     def test_yaml_config_overrides(self):
         """apply_yaml_config_overrides should update namespace attributes safely."""
         mock_yaml_content = """


### PR DESCRIPTION
## Summary

When a user passes `--param KEY VALUE` (space-separated) instead of `--param KEY=VALUE`, mlpstorage used to fail deep in the DLIO param processor with:

```
ValueError: not enough values to unpack (expected 2, got 1)
```

Reported in #469. The error gave no hint that the underlying problem was CLI syntax.

This PR adds a validation step right after `--params` flattening (`mlpstorage_py/cli_parser.py:281-283`) that names the offending token and shows the correct form before exiting with `INVALID_ARGUMENTS`.

## Why

`argparse` with `nargs="+"` silently accepts space-separated pairs for `--params`. `update_args` then flattens the list, and `mlpstorage_py/benchmarks/dlio.py:235` calls `split("=")` on each token. A token without `=` produces a single-element list, which fails the `k, v = ...` unpack.

## Behavior change

Before:

```
$ mlpstorage closed training unet3d run file ... --param dataset.num_files_train 35000
ERROR:main:424: Unexpected error: not enough values to unpack (expected 2, got 1)
ERROR:main:425: An internal error occurred: ...
This is likely a bug in MLPerf Storage.
Please report this issue at: https://github.com/mlcommons/storage/issues
```

After:

```
$ mlpstorage closed training unet3d run file ... --param dataset.num_files_train 35000
Error: --params expects KEY=VALUE tokens joined with '=' (no space).
  Offending token(s): ['dataset.num_files_train', '35000']
  Wrong: --param dataset.num_files_train 35000
  Right: --param dataset.num_files_train=35000
  Multiple overrides: --params A=1 B=2 C=3
```

## Test plan

- [x] `pytest tests/unit/test_cli_parser.py -q` — 34 pass (33 existing + 1 new regression test pinning that `update_args` exits `INVALID_ARGUMENTS` on space-separated params).
- [ ] Run the reproducer from #469 (`--param dataset.num_files_train 35000`) and confirm the new error message appears in place of the unpack error.
- [ ] Run a valid command (`--param dataset.num_files_train=35000`) and confirm it still parses.

Closes #469.