### PR TITLE
vectordb: add --vdb-index and index-aware VectorDB in results-dir path

### DIFF
--- a/mlpstorage_py/benchmarks/vectordbbench.py
+++ b/mlpstorage_py/benchmarks/vectordbbench.py
@@ -36,7 +36,11 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 from mlpstorage_py.benchmarks.base import Benchmark
-from mlpstorage_py.config import BENCHMARK_TYPES, CONFIGS_ROOT_DIR
+from mlpstorage_py.config import (
+    BENCHMARK_TYPES,
+    CONFIGS_ROOT_DIR,
+    VDB_INDEX_DEFAULT,
+)
 from mlpstorage_py.utils import generate_mpi_prefix_cmd, read_config_from_file
 
 
@@ -49,15 +53,62 @@ class VectorDBBenchmark(Benchmark):
 
     SUMMARY_PREFIX = "VDB_MULTI_NODE_SUMMARY_JSON="
 
+    @staticmethod
+    def _resolve_vdb_index_arguments(args) -> str:
+        """Normalize ``vdb_index`` and the Milvus ``index_type`` argument.
+
+        CLI validation normally performs this resolution. Repeating the small,
+        deterministic normalization here keeps direct benchmark construction
+        (for example, unit tests or API callers) safe and ensures ``vdb_index``
+        exists before ``Benchmark.__init__`` creates the results directory.
+
+        For ``datasize`` and ``datagen``:
+          * neither value supplied -> both use ``VDB_INDEX_DEFAULT``;
+          * only ``vdb_index`` supplied -> ``index_type`` follows it;
+          * only ``index_type`` supplied -> ``vdb_index`` follows it;
+          * conflicting explicit values -> fail rather than mislabel results.
+
+        For ``run``, no index is built, so only ``vdb_index`` is required to
+        identify the index already loaded in the target collection.
+        """
+        command = getattr(args, "command", None)
+        vdb_index = getattr(args, "vdb_index", None)
+
+        if command in ("datasize", "datagen"):
+            index_type = getattr(args, "index_type", None)
+
+            if vdb_index is None and index_type is None:
+                vdb_index = VDB_INDEX_DEFAULT
+                index_type = VDB_INDEX_DEFAULT
+            elif vdb_index is None:
+                vdb_index = index_type
+            elif index_type is None:
+                index_type = vdb_index
+            elif vdb_index != index_type:
+                raise ValueError(
+                    f"--vdb-index ({vdb_index}) and --index-type "
+                    f"({index_type}) must match for the '{command}' command."
+                )
+
+            args.vdb_index = vdb_index
+            args.index_type = index_type
+            return str(vdb_index)
+
+        args.vdb_index = vdb_index or VDB_INDEX_DEFAULT
+        return str(args.vdb_index)
+
     def __init__(self, args, **kwargs):
-        # Mirror the engine into args.model so the existing
-        # metadata extractor (BenchmarkInstanceExtractor) and workload
-        # grouping (ReportGenerator._process_workload_groups, keyed on
-        # (model, accelerator)) treat distinct engines as distinct
-        # workloads — accumulated runs from milvus vs a future engine
-        # stay correctly separated.
-        if hasattr(args, "vdb_engine") and getattr(args, "model", None) is None:
-            args.model = args.vdb_engine
+        # Resolve the index before the base initializer calls
+        # generate_output_location(); the VectorDB path includes vdb_index.
+        vdb_index = self._resolve_vdb_index_arguments(args)
+
+        # Mirror engine + index into args.model so the existing metadata
+        # extractor and workload grouping (keyed on (model, accelerator)) do
+        # not merge, for example, milvus/DISKANN and milvus/HNSW results.
+        vdb_engine = getattr(args, "vdb_engine", None)
+        if vdb_engine and getattr(args, "model", None) is None:
+            args.model = f"{vdb_engine}_{vdb_index}"
+
         super().__init__(args, **kwargs)
 
         self.command_method_map = {
@@ -224,6 +275,32 @@ class VectorDBBenchmark(Benchmark):
             "VectorDB collection name is required. "
             "Pass --collection or set dataset.collection_name in the config."
         )
+
+    def _effective_index_type(self) -> str:
+        """Return the effective index used by datasize/datagen.
+
+        ``vdb_index`` is the benchmark/result identity, while ``index_type``
+        is the concrete Milvus argument. They must describe the same index for
+        commands that estimate or build an index.
+        """
+        vdb_index = getattr(self.args, "vdb_index", None)
+        index_type = getattr(self.args, "index_type", None)
+
+        if vdb_index and index_type and vdb_index != index_type:
+            raise ValueError(
+                f"--vdb-index ({vdb_index}) and --index-type ({index_type}) "
+                f"must match for the '{self.command}' command."
+            )
+
+        effective_index = index_type or vdb_index or VDB_INDEX_DEFAULT
+
+        # Keep both names synchronized for metadata, command generation, and
+        # callers that construct the benchmark without CLI validation.
+        if self.command in ("datasize", "datagen"):
+            self.args.vdb_index = effective_index
+            self.args.index_type = effective_index
+
+        return str(effective_index)
 
     # ------------------------------------------------------------------
     # Shell helpers
@@ -585,7 +662,7 @@ class VectorDBBenchmark(Benchmark):
         dim = self.args.dimension
         num_vectors = self.args.num_vectors
         dtype_bytes = 4
-        index_type = getattr(self.args, "index_type", "DISKANN")
+        index_type = self._effective_index_type()
         num_shards = getattr(self.args, "num_shards", 1)
 
         raw_bytes = num_vectors * dim * dtype_bytes
@@ -623,6 +700,8 @@ class VectorDBBenchmark(Benchmark):
 
     def _execute_datagen_single_node(self) -> int:
         """Execute existing single-node load-vdb path."""
+        index_type = self._effective_index_type()
+
         additional_params = {
             "collection-name": self._collection_name(),
             "dimension": self.args.dimension,
@@ -632,7 +711,7 @@ class VectorDBBenchmark(Benchmark):
             "distribution": self.args.distribution,
             "batch-size": self.args.batch_size,
             "chunk-size": self.args.chunk_size,
-            "index-type": getattr(self.args, "index_type", None),
+            "index-type": index_type,
             "metric-type": getattr(self.args, "metric_type", None),
             "max-degree": getattr(self.args, "max_degree", None),
             "search-list-size": getattr(self.args, "search_list_size", None),
@@ -658,6 +737,7 @@ class VectorDBBenchmark(Benchmark):
 
     def _execute_datagen_distributed(self) -> int:
         """Execute distributed VectorDB load through MPI wrapper."""
+        index_type = self._effective_index_type()
         base_output_dir = self._base_output_dir("load")
         world_size = self._mpi_world_size()
         os.makedirs(base_output_dir, exist_ok=True)
@@ -687,7 +767,7 @@ class VectorDBBenchmark(Benchmark):
             "distribution": self.args.distribution,
             "batch-size": self.args.batch_size,
             "chunk-size": self.args.chunk_size,
-            "index-type": getattr(self.args, "index_type", None),
+            "index-type": index_type,
             "metric-type": getattr(self.args, "metric_type", None),
             "max-degree": getattr(self.args, "max_degree", None),
             "search-list-size": getattr(self.args, "search_list_size", None),
@@ -982,11 +1062,16 @@ class VectorDBBenchmark(Benchmark):
             {
                 "vectordb_config": self.config_name,
                 "vectordb_config_file": self.config_file,
+                "vdb_engine": getattr(self.args, "vdb_engine", None),
+                "vdb_index": (
+                    getattr(self.args, "vdb_index", None)
+                    or VDB_INDEX_DEFAULT
+                ),
                 # NB: do NOT set "model" here — the base class records the
-                # engine (via args.model = args.vdb_engine in __init__) and
+                # composite engine/index identity prepared in __init__, and
                 # downstream workload grouping in ReportGenerator keys on it.
-                # Overwriting with config_name would merge distinct engines
-                # that happen to share a config file into one workload.
+                # Overwriting model with config_name would merge distinct VDB
+                # engines or index families that share a config file.
                 "host": getattr(self.args, "host", "127.0.0.1"),
                 "port": getattr(self.args, "port", 19530),
                 "collection": getattr(self.args, "collection", None),
@@ -1006,7 +1091,7 @@ class VectorDBBenchmark(Benchmark):
                 {
                     "dimension": getattr(self.args, "dimension", None),
                     "num_vectors": getattr(self.args, "num_vectors", None),
-                    "index_type": getattr(self.args, "index_type", None),
+                    "index_type": self._effective_index_type(),
                     "num_shards": getattr(self.args, "num_shards", None),
                 }
             )
@@ -1021,7 +1106,7 @@ class VectorDBBenchmark(Benchmark):
                     "distribution": getattr(self.args, "distribution", None),
                     "batch_size": getattr(self.args, "batch_size", None),
                     "chunk_size": getattr(self.args, "chunk_size", None),
-                    "index_type": getattr(self.args, "index_type", None),
+                    "index_type": self._effective_index_type(),
                     "metric_type": getattr(self.args, "metric_type", None),
                     "seed": getattr(self.args, "seed", None),
                 }
@@ -1045,6 +1130,5 @@ class VectorDBBenchmark(Benchmark):
                     "recall_k": getattr(self.args, "recall_k", None),
                 }
             )
-
 
         return base_metadata

--- a/mlpstorage_py/cli/vectordb_args.py
+++ b/mlpstorage_py/cli/vectordb_args.py
@@ -20,14 +20,18 @@ Distributed VectorDB terminology:
       written under --rank-output-dir on each node.
 """
 
+import sys
+
 from mlpstorage_py.config import (
     DISTRIBUTIONS,
+    EXIT_CODE,
     SEARCH_METRICS,
     VECTOR_DTYPES,
     VECTORDB_DEFAULT_RUNTIME,
     VDB_BENCHMARK_MODES,
     VDB_ENGINE_DEFAULT,
     VDB_ENGINES,
+    VDB_INDEX_DEFAULT,
     VDB_INDEX_TYPES,
     VDB_INDEX_TYPES_CLOSED,
 )
@@ -222,6 +226,24 @@ def _add_vectordb_core_args(parser, command, index_choices):
         ),
     )
 
+    # Keep the parser-level default as None so post-parse validation can tell
+    # whether --vdb-index was omitted. This preserves compatibility with the
+    # existing --index-type flag: for datasize/datagen, either flag can supply
+    # the index and the other is derived from it. After validation, vdb_index
+    # is always populated for every VectorDB command.
+    parser.add_argument(
+        '--vdb-index',
+        choices=index_choices,
+        default=None,
+        help=(
+            "Vector index family used to identify the measured workload and "
+            "partition results as vector_database/<vdb-engine>/<vdb-index>/"
+            "<command>/<datetime>. For datasize/datagen, --index-type defaults "
+            "to this value. For run, this identifies the index already loaded "
+            f"in the target collection. Defaults to {VDB_INDEX_DEFAULT}."
+        ),
+    )
+
     # ---- Common args for datagen and run ----
     if command in ("datagen", "run"):
         parser.add_argument(
@@ -263,8 +285,11 @@ def _add_vectordb_core_args(parser, command, index_choices):
         parser.add_argument(
             '--index-type',
             choices=index_choices,
-            default="DISKANN",
-            help="Index type for storage estimation",
+            default=None,
+            help=(
+                "Milvus index type used for storage estimation. "
+                "Defaults to --vdb-index when omitted."
+            ),
         )
         parser.add_argument(
             '--num-shards',
@@ -326,8 +351,11 @@ def _add_vectordb_core_args(parser, command, index_choices):
         parser.add_argument(
             '--index-type',
             choices=index_choices,
-            default="DISKANN",
-            help="Vector index type to create during load.",
+            default=None,
+            help=(
+                "Milvus index type to create during load. "
+                "Defaults to --vdb-index when omitted."
+            ),
         )
         parser.add_argument(
             '--force',
@@ -516,9 +544,92 @@ def _add_vectordb_open_args(parser, command):
         )
 
 
+def _resolve_vdb_index_arguments(args):
+    """Resolve --vdb-index and --index-type into a consistent namespace.
+
+    ``--vdb-index`` is the benchmark identity used by result paths, metadata,
+    and reporting. ``--index-type`` is the Milvus implementation argument used
+    by datasize/datagen. Keeping the parser defaults as ``None`` lets this
+    function preserve existing commands that only pass ``--index-type`` while
+    still making ``--vdb-index`` available to every VectorDB command.
+
+    Args:
+        args (argparse.Namespace): Parsed VectorDB arguments.
+
+    Raises:
+        ValueError: If datasize/datagen explicitly specify conflicting values.
+    """
+    command = getattr(args, 'command', None)
+    vdb_index = getattr(args, 'vdb_index', None)
+
+    if command in ('datasize', 'datagen'):
+        index_type = getattr(args, 'index_type', None)
+
+        if vdb_index is None and index_type is None:
+            vdb_index = VDB_INDEX_DEFAULT
+            index_type = VDB_INDEX_DEFAULT
+        elif vdb_index is None:
+            # Backward compatibility for existing invocations that only use
+            # --index-type. The result-path identity follows the actual index.
+            vdb_index = index_type
+        elif index_type is None:
+            # Preferred new behavior: --vdb-index is the source of truth and
+            # supplies the Milvus implementation argument.
+            index_type = vdb_index
+        elif vdb_index != index_type:
+            raise ValueError(
+                f"--vdb-index ({vdb_index}) and --index-type ({index_type}) "
+                f"must match for the '{command}' command."
+            )
+
+        args.vdb_index = vdb_index
+        args.index_type = index_type
+        return
+
+    # The run command does not build an index, but the value is required to
+    # identify the loaded collection/index in result paths and metadata.
+    args.vdb_index = vdb_index or VDB_INDEX_DEFAULT
+
+
 def validate_vectordb_arguments(args):
-    """Validate the whole set of args given that we're doing a vectordb benchmark.
+    """Validate and normalize arguments for the VectorDB benchmark.
 
     Args:
         args (argparse.Namespace): The parsed command-line arguments.
     """
+    error_messages = []
+
+    try:
+        _resolve_vdb_index_arguments(args)
+    except ValueError as exc:
+        error_messages.append(str(exc))
+
+    allowed_indexes = (
+        VDB_INDEX_TYPES_CLOSED
+        if getattr(args, 'mode', None) == 'closed'
+        else VDB_INDEX_TYPES
+    )
+
+    vdb_index = getattr(args, 'vdb_index', None)
+    if vdb_index not in allowed_indexes:
+        error_messages.append(
+            "Invalid VectorDB index '{}'. Supported indexes are: {}".format(
+                vdb_index,
+                ", ".join(allowed_indexes),
+            )
+        )
+
+    if getattr(args, 'command', None) in ('datasize', 'datagen'):
+        index_type = getattr(args, 'index_type', None)
+        if index_type not in allowed_indexes:
+            error_messages.append(
+                "Invalid Milvus index type '{}'. Supported indexes are: {}".format(
+                    index_type,
+                    ", ".join(allowed_indexes),
+                )
+            )
+
+    if error_messages:
+        for message in error_messages:
+            print(message, file=sys.stderr)
+        sys.exit(EXIT_CODE.INVALID_ARGUMENTS)

--- a/mlpstorage_py/cli_parser.py
+++ b/mlpstorage_py/cli_parser.py
@@ -322,8 +322,8 @@ def update_args(args):
             sys.exit(EXIT_CODE.INVALID_ARGUMENTS)
         args.hosts = normalized
 
-    if hasattr(args, 'hosts') and getattr(args, 'num_client_hosts', None) is None:
-        setattr(args, "num_client_hosts", len(args.hosts))
+        if getattr(args, 'num_client_hosts', None) is None:
+            setattr(args, "num_client_hosts", len(args.hosts))
 
 
 if __name__ == "__main__":

--- a/mlpstorage_py/config.py
+++ b/mlpstorage_py/config.py
@@ -122,9 +122,10 @@ VDB_ORCHESTRATION_MODES = ["ssh", "mpi"]
 VDB_BENCHMARK_MODES = ["timed", "query_count", "sweep"]
 # Vector-database engines. Only milvus is wired up today; the slot exists so
 # accumulated results from multiple engines can coexist in one results-dir
-# (path: vector_database/<engine>/<command>/<datetime>/).
+# (path: vector_database/<engine>/<index>/<command>/<datetime>/).
 VDB_ENGINES = ["milvus"]
 VDB_ENGINE_DEFAULT = "milvus"
+VDB_INDEX_DEFAULT = "DISKANN"
 
 MPIRUN = "mpirun"
 MPIEXEC = "mpiexec"

--- a/mlpstorage_py/reporting/directory_validator.py
+++ b/mlpstorage_py/reporting/directory_validator.py
@@ -39,7 +39,7 @@ class ResultsDirectoryValidator:
     results_dir/
         <benchmark_type>/           # training, checkpointing, vector_database, kv_cache
             <model>/                # unet3d, retinanet, llama3-8b, etc.
-                <command>/          # run, datagen (for training)
+                <command>/          # run, datagen, datasize
                     <datetime>/     # YYYYMMDD_HHMMSS format
                         *_metadata.json
                         summary.json (for DLIO runs)
@@ -51,6 +51,29 @@ class ResultsDirectoryValidator:
                 <datetime>/
                     *_metadata.json
                     summary.json
+
+    VectorDB structures accepted for backward compatibility:
+    results_dir/
+        vector_database/
+            <command>/
+                <datetime>/
+                    *_metadata.json
+
+    results_dir/
+        vector_database/
+            <engine>/
+                <command>/
+                    <datetime>/
+                        *_metadata.json
+
+    Preferred VectorDB structure:
+    results_dir/
+        vector_database/
+            <engine>/
+                <index>/
+                    <command>/
+                        <datetime>/
+                            *_metadata.json
     """
 
     EXPECTED_BENCHMARK_TYPES = ['training', 'checkpointing', 'vector_database', 'kv_cache']
@@ -129,6 +152,13 @@ class ResultsDirectoryValidator:
     def _validate_benchmark_type_dir(self, benchmark_dir: Path) -> None:
         """Validate a benchmark type directory (e.g., training/)."""
         benchmark_type = benchmark_dir.name
+
+        # VectorDB has engine and index identity levels that do not exist in
+        # the generic <benchmark>/<model>/<command>/<datetime> hierarchy.
+        if benchmark_type == 'vector_database':
+            self._validate_vectordb_dir(benchmark_dir)
+            return
+
         has_valid_content = False
 
         for model_dir in benchmark_dir.iterdir():
@@ -139,6 +169,107 @@ class ResultsDirectoryValidator:
         if not has_valid_content:
             self.result.warnings.append(
                 f"Benchmark type directory '{benchmark_type}/' is empty"
+            )
+
+    def _validate_vectordb_dir(self, benchmark_dir: Path) -> None:
+        """Validate supported VectorDB results-directory layouts.
+
+        Accepted layouts:
+            vector_database/<command>/<datetime>/
+            vector_database/<engine>/<command>/<datetime>/
+            vector_database/<engine>/<index>/<command>/<datetime>/
+
+        The first two forms are retained for backward compatibility. Engine
+        and index directory names are not checked against static allowlists so
+        the validator continues to work as new implementations are added.
+        """
+        benchmark_type = benchmark_dir.name
+        visible_dirs = [
+            entry for entry in benchmark_dir.iterdir()
+            if entry.is_dir() and not entry.name.startswith('.')
+        ]
+
+        if not visible_dirs:
+            self.result.warnings.append(
+                f"Benchmark type directory '{benchmark_type}/' is empty"
+            )
+            return
+
+        has_valid_runs = False
+
+        for first_level in visible_dirs:
+            # Legacy layout, before --vdb-engine:
+            # vector_database/<command>/<datetime>/
+            if first_level.name in self.EXPECTED_COMMANDS:
+                if self._validate_command_dir(first_level, benchmark_type):
+                    has_valid_runs = True
+                continue
+
+            # Engine-aware layouts:
+            # vector_database/<engine>/<command>/<datetime>/
+            # vector_database/<engine>/<index>/<command>/<datetime>/
+            engine_dir = first_level
+            engine_has_valid_runs = False
+            engine_children = [
+                entry for entry in engine_dir.iterdir()
+                if entry.is_dir() and not entry.name.startswith('.')
+            ]
+
+            if not engine_children:
+                self.result.warnings.append(
+                    f"VectorDB engine directory '{engine_dir}' is empty"
+                )
+                continue
+
+            for second_level in engine_children:
+                # PR #442 layout, before --vdb-index.
+                if second_level.name in self.EXPECTED_COMMANDS:
+                    if self._validate_command_dir(second_level, benchmark_type):
+                        engine_has_valid_runs = True
+                        has_valid_runs = True
+                    continue
+
+                # Index-aware layout. The index directory must contain one or
+                # more command directories.
+                index_dir = second_level
+                index_has_valid_runs = False
+                index_children = [
+                    entry for entry in index_dir.iterdir()
+                    if entry.is_dir() and not entry.name.startswith('.')
+                ]
+
+                if not index_children:
+                    self.result.warnings.append(
+                        f"VectorDB index directory '{index_dir}' is empty"
+                    )
+                    continue
+
+                for command_dir in index_children:
+                    if command_dir.name in self.EXPECTED_COMMANDS:
+                        if self._validate_command_dir(command_dir, benchmark_type):
+                            index_has_valid_runs = True
+                            engine_has_valid_runs = True
+                            has_valid_runs = True
+                    else:
+                        self.result.warnings.append(
+                            "Unexpected directory in VectorDB index directory "
+                            f"'{index_dir}': {command_dir.name}. Expected a "
+                            f"command directory: {self.EXPECTED_COMMANDS}"
+                        )
+
+                if not index_has_valid_runs:
+                    self.result.warnings.append(
+                        f"No valid run directories found in {index_dir}"
+                    )
+
+            if not engine_has_valid_runs:
+                self.result.warnings.append(
+                    f"No valid run directories found in {engine_dir}"
+                )
+
+        if not has_valid_runs:
+            self.result.warnings.append(
+                f"No valid VectorDB run directories found in {benchmark_dir}"
             )
 
     def _validate_model_dir(self, model_dir: Path, benchmark_type: str) -> None:
@@ -153,20 +284,44 @@ class ResultsDirectoryValidator:
                     has_valid_runs = True
                 # Check if this is a command subdirectory
                 elif entry.name in self.EXPECTED_COMMANDS:
-                    for datetime_dir in entry.iterdir():
-                        if datetime_dir.is_dir():
-                            if self._is_datetime_dir(datetime_dir.name):
-                                self._validate_run_dir(datetime_dir, benchmark_type)
-                                has_valid_runs = True
-                            else:
-                                self.result.warnings.append(
-                                    f"Unexpected directory format in {entry}: {datetime_dir.name}"
-                                )
+                    if self._validate_command_dir(entry, benchmark_type):
+                        has_valid_runs = True
 
         if not has_valid_runs:
             self.result.warnings.append(
                 f"No valid run directories found in {model_dir}"
             )
+
+    def _validate_command_dir(
+        self, command_dir: Path, benchmark_type: str
+    ) -> bool:
+        """Validate datetime run directories below a command directory.
+
+        Args:
+            command_dir: A run, datagen, or datasize directory.
+            benchmark_type: Benchmark type passed to run-level validation.
+
+        Returns:
+            True when at least one datetime-formatted run directory is found.
+            A matching directory can still contain a run-level error such as
+            a missing metadata file.
+        """
+        has_valid_runs = False
+
+        for datetime_dir in command_dir.iterdir():
+            if not datetime_dir.is_dir() or datetime_dir.name.startswith('.'):
+                continue
+
+            if self._is_datetime_dir(datetime_dir.name):
+                self._validate_run_dir(datetime_dir, benchmark_type)
+                has_valid_runs = True
+            else:
+                self.result.warnings.append(
+                    f"Unexpected directory format in {command_dir}: "
+                    f"{datetime_dir.name}"
+                )
+
+        return has_valid_runs
 
     def _validate_run_dir(self, run_dir: Path, benchmark_type: str) -> None:
         """Validate a single run directory."""
@@ -248,15 +403,20 @@ Expected results directory structure:
 
     vector_database/
       milvus/                          # VDB engine (--vdb-engine)
-        run/
-          20250115_160000/
-            vector_database_20250115_160000_metadata.json
+        DISKANN/                       # VDB index (--vdb-index)
+          run/
+            20250115_160000/
+              vector_database_20250115_160000_metadata.json
 
     kv_cache/
       llama3.1-8b/
         run/
           20250115_160000/
             kvcache_llama3.1-8b_metadata.json
+
+Backward-compatible VectorDB layouts also accepted:
+  vector_database/<command>/<datetime>/
+  vector_database/<engine>/<command>/<datetime>/
 
 Key files:
   - *_metadata.json: Contains benchmark configuration and parameters

--- a/mlpstorage_py/rules/utils.py
+++ b/mlpstorage_py/rules/utils.py
@@ -168,8 +168,19 @@ def generate_output_location(benchmark, datetime_str=None, **kwargs) -> str:
                 "VectorDB engine is required for output location "
                 "(set --vdb-engine on the CLI)."
             )
+        vdb_index = (
+            getattr(benchmark.args, "vdb_index", None)
+            or getattr(benchmark.args, "index_type", None)
+        )
+        if not vdb_index:
+            raise ValueError(
+                "VectorDB index is required for output location "
+                "(set --vdb-index on the CLI)."
+            )
+        
         output_location = os.path.join(output_location, benchmark.BENCHMARK_TYPE.name)
         output_location = os.path.join(output_location, engine)
+        output_location = os.path.join(output_location, vdb_index)
         output_location = os.path.join(output_location, benchmark.args.command)
         output_location = os.path.join(output_location, datetime_str)
 

--- a/tests/unit/test_accumulation.py
+++ b/tests/unit/test_accumulation.py
@@ -5,8 +5,8 @@ These tests drive the REAL get_runs_files() walk against synthetic on-disk
 results trees (no mocking of discovery). They lock down current behavior so
 follow-up PRs can fix bugs without regressing the rest of the accumulation
 surface. Scenarios intentionally not covered today are documented as xfail or
-left for follow-up PRs (sub-second collisions, vectordb/kvcache path containing
-engine/model — both addressed in subsequent PRs of this effort).
+left for follow-up PRs (for example, sub-second collisions). VectorDB and
+KV-cache path identity are covered here, including VectorDB engine/index.
 
 Existing tests at tests/unit/test_reporting.py:425-531 cover ReportGenerator
 grouping with get_runs_files mocked. tests/unit/test_rules_calculations.py
@@ -155,27 +155,40 @@ def make_vectordb_run(
     results_dir: Path,
     *,
     engine: str = "milvus",
+    index: str = "DISKANN",
     run_datetime: str = "20250111_160000",
     command: str = "run",
     include_summary: bool = True,
 ) -> Path:
-    """Create one vectordb run at
-    results_dir/vector_database/<engine>/<command>/<datetime>/.
+    """Create one VectorDB run under the engine/index-aware layout.
 
-    The engine is recorded as model in metadata (matches how
-    VectorDBBenchmark.__init__ mirrors args.vdb_engine into args.model so
-    grouping by (model, accelerator) treats engines as distinct workloads).
+    The composite engine/index identity is recorded in ``model`` because the
+    current reporting layer groups workloads by ``(model, accelerator)``.
+    Explicit ``vdb_engine`` and ``vdb_index`` metadata remain available to
+    downstream consumers.
     """
-    run_dir = results_dir / "vector_database" / engine / command / run_datetime
+    model = f"{engine}_{index}"
+    run_dir = (
+        results_dir
+        / "vector_database"
+        / engine
+        / index
+        / command
+        / run_datetime
+    )
     return _write_run(
         run_dir,
         benchmark_type="vector_database",
         run_datetime=run_datetime,
-        model=engine,
+        model=model,
         accelerator=None,
         command=command,
         parameters={"workload": "vdb"},
         include_summary=include_summary,
+        metadata_overrides={
+            "vdb_engine": engine,
+            "vdb_index": index,
+        },
     )
 
 
@@ -384,20 +397,70 @@ class TestWorkloadSeparation:
 
 
 # ---------------------------------------------------------------------------
-# Documented limitation: vectordb/kvcache lack model/engine in path AND metadata,
-# so two distinct workloads of the same type cannot be told apart today.
-# (Resolved in PR 3 for vectordb and PR 4 for kvcache.)
+# Preview benchmark path identity and accumulation.
 # ---------------------------------------------------------------------------
 
 
 class TestPreviewBenchmarkAccumulation:
     """Accumulation behavior for preview benchmarks (vectordb, kvcache).
 
-    VectorDB (PR 3) records an engine and KVCache (PR 4) records the model
+    VectorDB records engine/index identity and KVCache records the model
     as the distinguishing component in path and metadata."""
 
-    def test_vectordb_path_includes_engine(self, tmp_path):
-        """generate_output_location produces vector_database/<engine>/<command>/<datetime>/."""
+    def test_vectordb_path_includes_engine_and_index(self, tmp_path):
+        """Path is vector_database/<engine>/<index>/<command>/<datetime>."""
+        from types import SimpleNamespace
+
+        from mlpstorage_py.config import BENCHMARK_TYPES as _BT
+        from mlpstorage_py.rules.utils import generate_output_location
+
+        fake_benchmark = SimpleNamespace(
+            BENCHMARK_TYPE=_BT.vector_database,
+            args=SimpleNamespace(
+                results_dir=str(tmp_path),
+                command="run",
+                vdb_engine="milvus",
+                vdb_index="DISKANN",
+            ),
+        )
+        location = generate_output_location(
+            fake_benchmark,
+            datetime_str="20250111_160000",
+        )
+
+        assert location == str(
+            tmp_path
+            / "vector_database"
+            / "milvus"
+            / "DISKANN"
+            / "run"
+            / "20250111_160000"
+        )
+
+    def test_vectordb_path_requires_engine(self, tmp_path):
+        """Without vdb_engine, output-location generation fails clearly."""
+        from types import SimpleNamespace
+
+        from mlpstorage_py.config import BENCHMARK_TYPES as _BT
+        from mlpstorage_py.rules.utils import generate_output_location
+
+        fake_benchmark = SimpleNamespace(
+            BENCHMARK_TYPE=_BT.vector_database,
+            args=SimpleNamespace(
+                results_dir=str(tmp_path),
+                command="run",
+                vdb_index="DISKANN",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="VectorDB engine is required"):
+            generate_output_location(
+                fake_benchmark,
+                datetime_str="20250111_160000",
+            )
+
+    def test_vectordb_path_requires_index(self, tmp_path):
+        """Without vdb_index/index_type, output-location generation fails."""
         from types import SimpleNamespace
 
         from mlpstorage_py.config import BENCHMARK_TYPES as _BT
@@ -411,13 +474,15 @@ class TestPreviewBenchmarkAccumulation:
                 vdb_engine="milvus",
             ),
         )
-        location = generate_output_location(fake_benchmark, datetime_str="20250111_160000")
-        assert location == str(
-            tmp_path / "vector_database" / "milvus" / "run" / "20250111_160000"
-        )
 
-    def test_vectordb_path_requires_engine(self, tmp_path):
-        """Without vdb_engine, generate_output_location refuses to build a path."""
+        with pytest.raises(ValueError, match="VectorDB index is required"):
+            generate_output_location(
+                fake_benchmark,
+                datetime_str="20250111_160000",
+            )
+
+    def test_vectordb_path_can_fall_back_to_index_type(self, tmp_path):
+        """Direct callers using the legacy index_type still get a labeled path."""
         from types import SimpleNamespace
 
         from mlpstorage_py.config import BENCHMARK_TYPES as _BT
@@ -427,28 +492,58 @@ class TestPreviewBenchmarkAccumulation:
             BENCHMARK_TYPE=_BT.vector_database,
             args=SimpleNamespace(
                 results_dir=str(tmp_path),
-                command="run",
-                # no vdb_engine
+                command="datagen",
+                vdb_engine="milvus",
+                index_type="HNSW",
             ),
         )
-        with pytest.raises(ValueError, match="VectorDB engine is required"):
-            generate_output_location(fake_benchmark, datetime_str="20250111_160000")
 
-    def test_vectordb_runs_distinguished_by_engine(self, tmp_path, mock_logger):
-        """Two vectordb engines accumulate in one results-dir without collision.
-        Each run's metadata records the engine in the model slot so workload
-        grouping by (model, accelerator) treats them as distinct workloads."""
+        location = generate_output_location(
+            fake_benchmark,
+            datetime_str="20250111_160000",
+        )
+
+        assert location == str(
+            tmp_path
+            / "vector_database"
+            / "milvus"
+            / "HNSW"
+            / "datagen"
+            / "20250111_160000"
+        )
+
+    def test_vectordb_runs_distinguished_by_engine_and_index(
+        self, tmp_path, mock_logger
+    ):
+        """Engine/index combinations remain separate in one results tree."""
         results_dir = tmp_path / "results"
-        make_vectordb_run(results_dir, engine="milvus", run_datetime="20250111_160000")
-        make_vectordb_run(results_dir, engine="milvus", run_datetime="20250111_160100")
-        # A hypothetical future engine in the same tree.
-        make_vectordb_run(results_dir, engine="elasticsearch", run_datetime="20250111_160200")
+        make_vectordb_run(
+            results_dir,
+            engine="milvus",
+            index="DISKANN",
+            run_datetime="20250111_160000",
+        )
+        make_vectordb_run(
+            results_dir,
+            engine="milvus",
+            index="HNSW",
+            run_datetime="20250111_160100",
+        )
+        make_vectordb_run(
+            results_dir,
+            engine="elasticsearch",
+            index="HNSW",
+            run_datetime="20250111_160200",
+        )
 
         runs = get_runs_files(str(results_dir), logger=mock_logger)
 
         assert len(runs) == 3
-        engines = sorted(r.model for r in runs)
-        assert engines == ["elasticsearch", "milvus", "milvus"]
+        assert sorted(run.model for run in runs) == [
+            "elasticsearch_HNSW",
+            "milvus_DISKANN",
+            "milvus_HNSW",
+        ]
 
     def test_kvcache_path_includes_model(self, tmp_path):
         """generate_output_location produces kv_cache/<model>/<command>/<datetime>/."""

--- a/tests/unit/test_benchmarks_vectordb.py
+++ b/tests/unit/test_benchmarks_vectordb.py
@@ -5,6 +5,7 @@ Tests cover:
 - Command method map structure
 - Metadata generation for history integration
 - Command-specific metadata fields
+- VectorDB index normalization and command generation
 """
 
 import os
@@ -98,6 +99,7 @@ class TestVectorDBMetadata:
             command='run',
             config='10m',
             vdb_engine='milvus',
+            vdb_index='DISKANN',
             host='192.168.1.100',
             port=19531,
             collection='test_collection',
@@ -121,6 +123,8 @@ class TestVectorDBMetadata:
             command='datagen',
             config='default',
             vdb_engine='milvus',
+            vdb_index='HNSW',
+            index_type=None,
             host='127.0.0.1',
             port=19530,
             collection='gen_collection',
@@ -169,10 +173,12 @@ class TestVectorDBMetadata:
             bm = VectorDBBenchmark(run_args)
             meta = bm.metadata
 
-        assert 'vectordb_config' in meta
-        assert 'host' in meta
-        assert 'port' in meta
-        assert 'collection' in meta
+        assert meta['vectordb_config'] == '10m'
+        assert meta['vdb_engine'] == 'milvus'
+        assert meta['vdb_index'] == 'DISKANN'
+        assert meta['host'] == '192.168.1.100'
+        assert meta['port'] == 19531
+        assert meta['collection'] == 'test_collection'
 
     def test_metadata_model_is_engine_config_preserved_separately(
         self, run_args, tmp_path
@@ -194,7 +200,9 @@ class TestVectorDBMetadata:
             bm = VectorDBBenchmark(run_args)
             meta = bm.metadata
 
-        assert meta['model'] == 'milvus'
+        assert meta['model'] == 'milvus_DISKANN'
+        assert meta['vdb_engine'] == 'milvus'
+        assert meta['vdb_index'] == 'DISKANN'
         assert meta['vectordb_config'] == '10m'
 
     def test_metadata_run_command_fields(self, run_args, tmp_path):
@@ -240,6 +248,10 @@ class TestVectorDBMetadata:
         assert meta['vector_dtype'] == 'FLOAT_VECTOR'
         assert 'distribution' in meta
         assert meta['distribution'] == 'normal'
+        assert meta['vdb_engine'] == 'milvus'
+        assert meta['vdb_index'] == 'HNSW'
+        assert meta['index_type'] == 'HNSW'
+        assert meta['model'] == 'milvus_HNSW'
 
     def test_metadata_connection_info(self, run_args, tmp_path):
         """Verify host/port connection info in metadata."""
@@ -414,3 +426,196 @@ class TestVectorDBConfigHandling:
             bm = VectorDBBenchmark(basic_args)
 
         assert bm.config_name == 'default'
+
+
+class TestVectorDBIndexResolution:
+    """Tests benchmark-side normalization for API/direct construction."""
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen"])
+    def test_default_index_populates_both_names(self, command):
+        from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
+        from mlpstorage_py.config import VDB_INDEX_DEFAULT
+
+        args = Namespace(command=command, vdb_index=None, index_type=None)
+
+        resolved = VectorDBBenchmark._resolve_vdb_index_arguments(args)
+
+        assert resolved == VDB_INDEX_DEFAULT
+        assert args.vdb_index == VDB_INDEX_DEFAULT
+        assert args.index_type == VDB_INDEX_DEFAULT
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen"])
+    def test_vdb_index_populates_index_type(self, command):
+        from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
+
+        args = Namespace(command=command, vdb_index='HNSW', index_type=None)
+
+        resolved = VectorDBBenchmark._resolve_vdb_index_arguments(args)
+
+        assert resolved == 'HNSW'
+        assert args.vdb_index == args.index_type == 'HNSW'
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen"])
+    def test_legacy_index_type_populates_vdb_index(self, command):
+        from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
+
+        args = Namespace(command=command, vdb_index=None, index_type='AISAQ')
+
+        resolved = VectorDBBenchmark._resolve_vdb_index_arguments(args)
+
+        assert resolved == 'AISAQ'
+        assert args.vdb_index == args.index_type == 'AISAQ'
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen"])
+    def test_conflicting_index_names_fail_before_result_dir_creation(
+        self, command
+    ):
+        from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
+
+        args = Namespace(
+            command=command,
+            vdb_index='DISKANN',
+            index_type='HNSW',
+        )
+
+        with pytest.raises(ValueError, match='must match'):
+            VectorDBBenchmark._resolve_vdb_index_arguments(args)
+
+    def test_run_defaults_index_without_creating_index_type(self):
+        from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
+        from mlpstorage_py.config import VDB_INDEX_DEFAULT
+
+        args = Namespace(command='run', vdb_index=None)
+
+        resolved = VectorDBBenchmark._resolve_vdb_index_arguments(args)
+
+        assert resolved == VDB_INDEX_DEFAULT
+        assert args.vdb_index == VDB_INDEX_DEFAULT
+        assert not hasattr(args, 'index_type')
+
+
+class TestVectorDBEffectiveIndexUse:
+    """Tests that datasize and datagen use the normalized Milvus index."""
+
+    @staticmethod
+    def _bare_benchmark(args):
+        from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
+
+        benchmark = object.__new__(VectorDBBenchmark)
+        benchmark.args = args
+        benchmark.command = args.command
+        benchmark.logger = MagicMock()
+        benchmark.write_metadata = MagicMock()
+        return benchmark
+
+    @staticmethod
+    def _datagen_args(**overrides):
+        values = {
+            'command': 'datagen',
+            'vdb_index': 'HNSW',
+            'index_type': None,
+            'host': '127.0.0.1',
+            'port': 19530,
+            'dimension': 768,
+            'num_shards': 1,
+            'vector_dtype': 'FLOAT_VECTOR',
+            'num_vectors': 1000,
+            'distribution': 'uniform',
+            'batch_size': 100,
+            'chunk_size': 500,
+            'metric_type': None,
+            'max_degree': None,
+            'search_list_size': None,
+            'M': None,
+            'ef_construction': None,
+            'inline_pq': None,
+            'monitor_interval': None,
+            'compact': False,
+            'force': False,
+            'ready_timeout': 7200,
+            'coordination': 'filesystem',
+            'rank_output_dir': '/tmp/mlps_vdb',
+            'seed': 42,
+            'what_if': True,
+        }
+        values.update(overrides)
+        return Namespace(**values)
+
+    def test_datasize_uses_vdb_index_when_index_type_is_omitted(self):
+        args = Namespace(
+            command='datasize',
+            vdb_index='HNSW',
+            index_type=None,
+            dimension=128,
+            num_vectors=1000,
+            num_shards=1,
+        )
+        benchmark = self._bare_benchmark(args)
+
+        rc = benchmark.execute_datasize()
+
+        assert rc == 0
+        assert args.index_type == 'HNSW'
+        assert args.vdb_index == 'HNSW'
+        assert any(
+            'Index type: HNSW' in call.args[0]
+            for call in benchmark.logger.result.call_args_list
+        )
+        benchmark.write_metadata.assert_called_once_with()
+
+    def test_single_node_datagen_passes_effective_index_to_load_vdb(self):
+        args = self._datagen_args()
+        benchmark = self._bare_benchmark(args)
+        benchmark._collection_name = MagicMock(return_value='test_collection')
+        benchmark.build_command = MagicMock(return_value='uv run load-vdb')
+        benchmark._execute_command = MagicMock(return_value=('', '', 0))
+
+        rc = benchmark._execute_datagen_single_node()
+
+        assert rc == 0
+        script_name, additional_params = benchmark.build_command.call_args.args
+        assert script_name == 'load-vdb'
+        assert additional_params['index-type'] == 'HNSW'
+        assert args.index_type == args.vdb_index == 'HNSW'
+        benchmark._execute_command.assert_called_once()
+        benchmark.write_metadata.assert_called_once_with()
+
+    def test_distributed_datagen_passes_effective_index_to_wrapper(
+        self, tmp_path
+    ):
+        args = self._datagen_args()
+        benchmark = self._bare_benchmark(args)
+        benchmark.run_result_output = str(tmp_path / 'run')
+        benchmark.config_file = '/tmp/default.yaml'
+        benchmark._base_output_dir = MagicMock(
+            return_value=str(tmp_path / 'run' / 'vectordb' / 'load')
+        )
+        benchmark._mpi_world_size = MagicMock(return_value=2)
+        benchmark._mpi_prefix = MagicMock(return_value='mpiexec -n 2')
+        benchmark._get_uv_prefix = MagicMock(return_value='uv run ')
+        benchmark._coordination_backend = MagicMock(return_value='filesystem')
+        benchmark._rank_output_dir = MagicMock(return_value='/tmp/mlps_vdb')
+        benchmark._run_id = MagicMock(return_value='20250111_160000')
+        benchmark._collection_name = MagicMock(return_value='test_collection')
+        benchmark._execute_command = MagicMock(return_value=('', '', 0))
+        benchmark._run_aggregate = MagicMock(return_value=0)
+
+        rc = benchmark._execute_datagen_distributed()
+
+        assert rc == 0
+        command = benchmark._execute_command.call_args.args[0]
+        assert '--index-type HNSW' in command
+        assert args.index_type == args.vdb_index == 'HNSW'
+        benchmark._run_aggregate.assert_not_called()
+        benchmark.write_metadata.assert_called_once_with()
+
+    def test_effective_index_rejects_conflicting_values(self):
+        args = Namespace(
+            command='datagen',
+            vdb_index='DISKANN',
+            index_type='HNSW',
+        )
+        benchmark = self._bare_benchmark(args)
+
+        with pytest.raises(ValueError, match='must match'):
+            benchmark._effective_index_type()

--- a/tests/unit/test_cli_parser.py
+++ b/tests/unit/test_cli_parser.py
@@ -217,6 +217,26 @@ class TestUpdateArgsAndConfig:
         assert updated_args.duration == 999
         assert updated_args.hosts == ['node1', 'node2']  # Special yaml handling for hosts
 
+    def test_update_args_allows_none_hosts_for_single_node(self):
+        """Optional --hosts=None must remain valid for single-node benchmarks."""
+        args = argparse.Namespace(
+            hosts=None,
+            num_client_hosts=None,
+        )
+
+        update_args(args)
+
+        assert args.hosts is None
+        assert args.num_client_hosts is None
+
+    def test_update_args_allows_missing_num_client_hosts_with_none_hosts(self):
+        """A namespace with hosts=None must not evaluate len(None)."""
+        args = argparse.Namespace(hosts=None)
+
+        update_args(args)
+
+        assert args.hosts is None
+        assert not hasattr(args, "num_client_hosts")
 
 # =====================================================================
 # 5. args.mode and args.benchmark attributes

--- a/tests/unit/test_cli_vectordb.py
+++ b/tests/unit/test_cli_vectordb.py
@@ -4,6 +4,7 @@ Tests for VectorDB benchmark CLI argument parsing.
 Tests cover:
 - VectorDB subcommand structure (run, datagen)
 - Common arguments (host, port, collection, config)
+- --vdb-index parsing and --index-type normalization
 - Datagen-specific arguments (dimension, num_vectors, distribution, etc.)
 - Run-specific arguments (num_query_processes, batch_size, runtime, queries)
 """
@@ -11,8 +12,35 @@ Tests cover:
 import argparse
 import pytest
 
-from mlpstorage_py.cli.vectordb_args import add_vectordb_arguments
-from mlpstorage_py.config import VECTOR_DTYPES, DISTRIBUTIONS
+from mlpstorage_py.cli.vectordb_args import (
+    add_vectordb_arguments,
+    validate_vectordb_arguments,
+)
+from mlpstorage_py.config import (
+    DISTRIBUTIONS,
+    VDB_INDEX_DEFAULT,
+    VDB_INDEX_TYPES,
+    VDB_INDEX_TYPES_CLOSED,
+    VECTOR_DTYPES,
+)
+
+
+def _parse_and_validate(parser, argv, *, mode="open"):
+    """Parse VectorDB arguments and run post-parse normalization."""
+    args = parser.parse_args(argv)
+    # The isolated parser used in this unit module does not have the outer
+    # closed/open/whatif parser that normally supplies args.mode.
+    args.mode = mode
+    validate_vectordb_arguments(args)
+    return args
+
+
+def _vdb_argv(command, *options):
+    """Build argv; datasize has no file/object storage subcommand."""
+    argv = [command, '--results-dir', '/tmp', *options]
+    if command in ('datagen', 'run'):
+        argv.append('file')
+    return argv
 
 
 class TestVectorDBSubcommands:
@@ -427,6 +455,111 @@ class TestVectorDBFullCommandParsing:
         assert args.runtime is None
 
 
+class TestVectorDBIndexArguments:
+    """Tests for --vdb-index and --index-type normalization."""
+
+    @pytest.fixture
+    def parser(self):
+        parser = argparse.ArgumentParser()
+        add_vectordb_arguments(parser, 'open')
+        return parser
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen", "run"])
+    def test_vdb_index_is_registered_on_all_subcommands(self, parser, command):
+        """All VectorDB commands expose --vdb-index."""
+        args = parser.parse_args(
+            _vdb_argv(command, '--vdb-index', 'HNSW')
+        )
+
+        assert args.vdb_index == 'HNSW'
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen"])
+    def test_parser_keeps_both_index_defaults_unresolved(self, parser, command):
+        """Parser-level None defaults preserve whether either flag was given."""
+        args = parser.parse_args(_vdb_argv(command))
+
+        assert args.vdb_index is None
+        assert args.index_type is None
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen"])
+    def test_neither_flag_uses_default_for_both_names(self, parser, command):
+        args = _parse_and_validate(parser, _vdb_argv(command))
+
+        assert args.vdb_index == VDB_INDEX_DEFAULT
+        assert args.index_type == VDB_INDEX_DEFAULT
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen"])
+    def test_vdb_index_supplies_milvus_index_type(self, parser, command):
+        args = _parse_and_validate(
+            parser,
+            _vdb_argv(command, '--vdb-index', 'HNSW'),
+        )
+
+        assert args.vdb_index == 'HNSW'
+        assert args.index_type == 'HNSW'
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen"])
+    def test_legacy_index_type_supplies_result_identity(self, parser, command):
+        """Existing commands using only --index-type remain correctly labeled."""
+        args = _parse_and_validate(
+            parser,
+            _vdb_argv(command, '--index-type', 'AISAQ'),
+        )
+
+        assert args.index_type == 'AISAQ'
+        assert args.vdb_index == 'AISAQ'
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen"])
+    def test_matching_index_flags_are_accepted(self, parser, command):
+        args = _parse_and_validate(
+            parser,
+            _vdb_argv(
+                command,
+                '--vdb-index',
+                'HNSW',
+                '--index-type',
+                'HNSW',
+            ),
+        )
+
+        assert args.vdb_index == args.index_type == 'HNSW'
+
+    @pytest.mark.parametrize("command", ["datasize", "datagen"])
+    def test_conflicting_index_flags_are_rejected(
+        self, parser, command, capsys
+    ):
+        args = parser.parse_args(
+            _vdb_argv(
+                command,
+                '--vdb-index',
+                'DISKANN',
+                '--index-type',
+                'HNSW',
+            )
+        )
+        args.mode = 'open'
+
+        with pytest.raises(SystemExit):
+            validate_vectordb_arguments(args)
+
+        assert "must match" in capsys.readouterr().err
+
+    def test_run_defaults_vdb_index_during_validation(self, parser):
+        args = _parse_and_validate(parser, _vdb_argv('run'))
+
+        assert args.vdb_index == VDB_INDEX_DEFAULT
+        assert not hasattr(args, 'index_type')
+
+    def test_run_preserves_explicit_vdb_index(self, parser):
+        args = _parse_and_validate(
+            parser,
+            _vdb_argv('run', '--vdb-index', 'HNSW'),
+        )
+
+        assert args.vdb_index == 'HNSW'
+        assert not hasattr(args, 'index_type')
+
+
 class TestVectorDBClosedMode:
     """Tests for add_vectordb_arguments in closed mode."""
 
@@ -455,3 +588,21 @@ class TestVectorDBClosedMode:
         if open_only:
             with pytest.raises(SystemExit):
                 parser.parse_args(['datasize', '--index-type', open_only[0]])
+
+    def test_closed_mode_restricts_vdb_index_choices(self, parser):
+        """Closed mode rejects open-only --vdb-index values on every command."""
+        open_only = [
+            value
+            for value in VDB_INDEX_TYPES
+            if value not in VDB_INDEX_TYPES_CLOSED
+        ]
+        if open_only:
+            for command in ('datasize', 'datagen', 'run'):
+                with pytest.raises(SystemExit):
+                    parser.parse_args(
+                        _vdb_argv(
+                            command,
+                            '--vdb-index',
+                            open_only[0],
+                        )
+                    )

--- a/tests/unit/test_directory_validator.py
+++ b/tests/unit/test_directory_validator.py
@@ -1,0 +1,195 @@
+"""Tests for VectorDB-aware results directory validation."""
+
+import json
+from pathlib import Path
+
+from mlpstorage_py.reporting.directory_validator import ResultsDirectoryValidator
+
+
+def _write_metadata(run_dir: Path, benchmark_type: str = "vector_database") -> Path:
+    """Create the minimum metadata file recognized by the validator."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = run_dir.name
+    metadata_path = run_dir / f"{benchmark_type}_{timestamp}_metadata.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "benchmark_type": benchmark_type,
+                "run_datetime": timestamp,
+                "result_dir": str(run_dir),
+            }
+        )
+    )
+    return run_dir
+
+
+def _validate(results_dir: Path):
+    return ResultsDirectoryValidator(str(results_dir)).validate()
+
+
+class TestVectorDBDirectoryLayouts:
+    """The validator accepts old and new VectorDB directory layouts."""
+
+    def test_accepts_index_aware_layout(self, tmp_path):
+        _write_metadata(
+            tmp_path
+            / "vector_database"
+            / "milvus"
+            / "DISKANN"
+            / "run"
+            / "20250115_160000"
+        )
+
+        result = _validate(tmp_path)
+
+        assert result.is_valid is True
+        assert result.errors == []
+        assert result.warnings == []
+        assert result.found_benchmark_types == {"vector_database"}
+        assert result.found_runs == 1
+
+    def test_accepts_pre_engine_legacy_layout(self, tmp_path):
+        _write_metadata(
+            tmp_path
+            / "vector_database"
+            / "run"
+            / "20250115_160000"
+        )
+
+        result = _validate(tmp_path)
+
+        assert result.errors == []
+        assert result.warnings == []
+        assert result.found_runs == 1
+
+    def test_accepts_engine_only_pr442_layout(self, tmp_path):
+        _write_metadata(
+            tmp_path
+            / "vector_database"
+            / "milvus"
+            / "run"
+            / "20250115_160000"
+        )
+
+        result = _validate(tmp_path)
+
+        assert result.errors == []
+        assert result.warnings == []
+        assert result.found_runs == 1
+
+    def test_accepts_multiple_engines_indexes_and_commands(self, tmp_path):
+        _write_metadata(
+            tmp_path
+            / "vector_database"
+            / "milvus"
+            / "DISKANN"
+            / "datagen"
+            / "20250115_160000"
+        )
+        _write_metadata(
+            tmp_path
+            / "vector_database"
+            / "milvus"
+            / "HNSW"
+            / "run"
+            / "20250115_160100"
+        )
+        _write_metadata(
+            tmp_path
+            / "vector_database"
+            / "elasticsearch"
+            / "HNSW"
+            / "run"
+            / "20250115_160200"
+        )
+
+        result = _validate(tmp_path)
+
+        assert result.errors == []
+        assert result.warnings == []
+        assert result.found_runs == 3
+
+    def test_missing_metadata_is_reported_in_index_aware_layout(self, tmp_path):
+        run_dir = (
+            tmp_path
+            / "vector_database"
+            / "milvus"
+            / "DISKANN"
+            / "run"
+            / "20250115_160000"
+        )
+        run_dir.mkdir(parents=True)
+
+        result = _validate(tmp_path)
+
+        assert result.found_runs == 0
+        assert len(result.errors) == 1
+        assert result.errors[0].error_type == "malformed"
+        assert "Missing metadata file" in result.errors[0].message
+        assert result.errors[0].path == str(run_dir)
+
+    def test_empty_index_directory_produces_actionable_warning(self, tmp_path):
+        index_dir = tmp_path / "vector_database" / "milvus" / "DISKANN"
+        index_dir.mkdir(parents=True)
+
+        result = _validate(tmp_path)
+
+        assert result.found_runs == 0
+        assert any(
+            "VectorDB index directory" in warning and "is empty" in warning
+            for warning in result.warnings
+        )
+        assert any(
+            "No valid VectorDB run directories" in warning
+            for warning in result.warnings
+        )
+
+    def test_unexpected_directory_below_index_is_warned(self, tmp_path):
+        unexpected = (
+            tmp_path
+            / "vector_database"
+            / "milvus"
+            / "DISKANN"
+            / "not-a-command"
+        )
+        unexpected.mkdir(parents=True)
+
+        result = _validate(tmp_path)
+
+        assert result.found_runs == 0
+        assert any(
+            "Unexpected directory in VectorDB index directory" in warning
+            and "not-a-command" in warning
+            for warning in result.warnings
+        )
+
+
+class TestDirectoryValidatorRegressionCoverage:
+    """VectorDB specialization does not change generic benchmark handling."""
+
+    def test_training_command_layout_still_validates(self, tmp_path):
+        run_dir = _write_metadata(
+            tmp_path
+            / "training"
+            / "unet3d"
+            / "run"
+            / "20250115_143022",
+            benchmark_type="training",
+        )
+        (run_dir / "summary.json").write_text("{}")
+
+        result = _validate(tmp_path)
+
+        assert result.errors == []
+        assert result.warnings == []
+        assert result.found_runs == 1
+
+    def test_help_documents_preferred_and_compatible_vdb_layouts(self, tmp_path):
+        validator = ResultsDirectoryValidator(str(tmp_path))
+
+        help_text = validator.get_expected_structure_help()
+
+        assert "milvus" in help_text
+        assert "DISKANN" in help_text
+        assert "vector_database/<command>/<datetime>/" in help_text
+        assert "vector_database/<engine>/<command>/<datetime>/" in help_text

--- a/vdb_benchmark/pyproject.toml
+++ b/vdb_benchmark/pyproject.toml
@@ -46,14 +46,13 @@ all = [
   "python-dotenv>=1.0.0",
 ]
 
+mpi = [
+  "mpi4py>=4.0.0",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/mlcommons/storage/tree/main/vdb_benchmark"
 "Bug Tracker" = "https://github.com/mlcommons/storage/issues"
-
-[project.optional-dependencies]
-mpi = [
-    "mpi4py>=4.0.0",
-]
 
 [project.scripts]
 compact-and-watch = "vdbbench.compact_and_watch:main"


### PR DESCRIPTION
1. Changes on top of PR https://github.com/mlcommons/storage/pull/442
2. Includes fix for issue #454 

#### Add VDB index-aware result paths and validation

Add --vdb-index to all VectorDB subcommands and organize results under `vector_database/<engine>/<index>/<command>/<timestamp>`.

- default the VDB index to DISKANN
- resolve `--vdb-index` and `--index-type` consistently for datasize/datagen
- preserve compatibility when only `--index-type` is provided
- reject conflicting `--vdb-index` and `--index-type` values
- use the effective index for datasize calculations and load-vdb commands
- include VDB engine and index in metadata and workload grouping
- support legacy, engine-only, and engine/index VectorDB result layouts
  in the directory validator
- fix single-node VectorDB commands when `--hosts` is unset
- fix duplicate optional-dependencies table in vdb_benchmark pyproject
- add CLI, benchmark, accumulation, and directory-validator tests

#### Testing
```
smrc@dskbd029:~/Storage_Repo_Tests/storage_mlp$ ./mlpstorage closed vectordb datagen \
  file \
  --vdb-engine milvus \
  --vdb-index DISKANN \
  --host 127.0.0.1 \
  --port 19530 \
  --config default \
  --collection mlps_pr442_diskann \
  --num-vectors 10000 \
  --dimension 1536 \
  --num-shards 1 \
  --index-type DISKANN \
  --force \
  --results-dir /tmp/vdb_pr442_actual
2026-06-19 04:38:03|STATUS: 
2026-06-19 04:38:03|STATUS: --- Run Configuration (mlpstorage 3.0.13) ---
2026-06-19 04:38:03|STATUS:   benchmark:                      vectordb
2026-06-19 04:38:03|STATUS:   command:                        datagen
2026-06-19 04:38:03|STATUS:   mode:                           closed
2026-06-19 04:38:03|STATUS:   data_dir:                       [not set]
2026-06-19 04:38:03|STATUS:   results_dir:                    /tmp/vdb_pr442_actual
2026-06-19 04:38:03|STATUS:   data_access_protocol:           file
2026-06-19 04:38:03|STATUS:   num_accelerators:               [not set]
2026-06-19 04:38:03|STATUS:   num_processes:                  [not set]
2026-06-19 04:38:03|STATUS:   accelerator_type:               [not set]
2026-06-19 04:38:03|STATUS:   client_host_memory_in_gb:       [not set]
2026-06-19 04:38:03|STATUS:   hosts:                          [not set]
2026-06-19 04:38:03|STATUS:   exec_type:                      [not set]
2026-06-19 04:38:03|STATUS:   mpi_bin:                        mpiexec
2026-06-19 04:38:03|STATUS:   loops:                          1
2026-06-19 04:38:03|STATUS: 
2026-06-19 04:38:03|STATUS: --- Environment ---
2026-06-19 04:38:03|STATUS:   MLPERF_RESULTS_DIR:             [not set]
2026-06-19 04:38:03|STATUS:   MPI_RUN_BIN:                    [not set]
2026-06-19 04:38:03|STATUS:   MPI_EXEC_BIN:                   [not set]
2026-06-19 04:38:03|STATUS: 
⠋ Validating environment... 0:00:002026-06-19 04:38:03|INFO: Environment validation passed
2026-06-19 04:38:03|STATUS: Benchmark results directory: /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/datagen/20260619_043803
2026-06-19 04:38:03|INFO: Created benchmark run: vector_database_datagen_milvus_DISKANN_20260619_043803
2026-06-19 04:38:03|STATUS: Verifying benchmark run for vector_database_datagen_milvus_DISKANN_20260619_043803
2026-06-19 04:38:03|STATUS: Open: [OPEN] VectorDB benchmark is in preview status - not accepted for closed submissions (Parameter: benchmark_status)
2026-06-19 04:38:03|STATUS: Benchmark run qualifies for OPEN category ([RunID(program='vector_database', command='datagen', model='milvus_DISKANN', run_datetime='2026
2026-06-19 04:38:03|WARNING: Running the benchmark without verification for open or closed configurations. These results are not valid for submission. Use closed or o
2026-06-19 04:38:03|STATUS: Instantiated the VectorDB Benchmark...
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:128: PyMilvusDeprecationWarning: `connections.connect` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  connections.connect(
2026-06-19 04:38:04,483 - INFO - Connected to Milvus server at 127.0.0.1:19530
2026-06-19 04:38:04,483 - WARNING - FLOAT16 data type not available in this version of pymilvus. Using FLOAT_VECTOR instead.
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:147: PyMilvusDeprecationWarning: `utility.has_collection` is an ORM-style PyMilvus API 
and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  if utility.has_collection(collection_name):
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:166: PyMilvusDeprecationWarning: `Collection` is an ORM-style PyMilvus API and will be 
removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection = Collection(name=collection_name, schema=schema, num_shards=num_shards)
2026-06-19 04:38:04,509 - INFO - Created collection 'mlps_pr442_diskann' with 1536 dimensions and 1 shards
2026-06-19 04:38:04,509 - INFO - Creating index with parameters: {'index_type': 'DISKANN', 'metric_type': 'COSINE', 'params': {'MaxDegree': 16, 'SearchListSize': 
200}}
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:266: PyMilvusDeprecationWarning: `Collection.create_index` is an ORM-style PyMilvus API 
and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection.create_index("vector", index_params)
2026-06-19 04:38:05,023 - INFO - Index creation command completed in 0.51 seconds
2026-06-19 04:38:05,023 - INFO - Generating 10000 vectors with 1536 dimensions using uniform distribution
2026-06-19 04:38:05,195 - INFO - Inserting 10000 vectors into collection 'mlps_pr442_diskann'
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:235: PyMilvusDeprecationWarning: `Collection.insert` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection.insert([ids, batch_vectors])
2026-06-19 04:38:05,468 - INFO - Inserted batch 1/10: 10.00% complete, rate: 3664.45 vectors/sec, id_range=[0, 999]
2026-06-19 04:38:05,713 - INFO - Inserted batch 2/10: 20.00% complete, rate: 3862.37 vectors/sec, id_range=[1000, 1999]
2026-06-19 04:38:05,952 - INFO - Inserted batch 3/10: 30.00% complete, rate: 3967.56 vectors/sec, id_range=[2000, 2999]
2026-06-19 04:38:06,171 - INFO - Inserted batch 4/10: 40.00% complete, rate: 4102.75 vectors/sec, id_range=[3000, 3999]
2026-06-19 04:38:06,377 - INFO - Inserted batch 5/10: 50.00% complete, rate: 4231.46 vectors/sec, id_range=[4000, 4999]
2026-06-19 04:38:06,571 - INFO - Inserted batch 6/10: 60.00% complete, rate: 4361.81 vectors/sec, id_range=[5000, 5999]
2026-06-19 04:38:06,767 - INFO - Inserted batch 7/10: 70.00% complete, rate: 4453.52 vectors/sec, id_range=[6000, 6999]
2026-06-19 04:38:06,974 - INFO - Inserted batch 8/10: 80.00% complete, rate: 4497.64 vectors/sec, id_range=[7000, 7999]
2026-06-19 04:38:07,202 - INFO - Inserted batch 9/10: 90.00% complete, rate: 4484.75 vectors/sec, id_range=[8000, 8999]
2026-06-19 04:38:07,442 - INFO - Inserted batch 10/10: 100.00% complete, rate: 4451.74 vectors/sec, id_range=[9000, 9999]
2026-06-19 04:38:07,442 - INFO - Inserted 10000 vectors in 2.25 seconds
2026-06-19 04:38:07,442 - INFO - Generated all 10,000 vectors in 2.42 seconds
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:256: PyMilvusDeprecationWarning: `Collection.flush` is an ORM-style PyMilvus API and will
be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection.flush()
2026-06-19 04:38:08,455 - INFO - Flush completed in 1.01 seconds
2026-06-19 04:38:08,456 - INFO - Starting to monitor index building progress (checking every 5 seconds)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/compact_and_watch.py:100: PyMilvusDeprecationWarning: `utility.index_building_progress` is an 
ORM-style PyMilvus API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  prev_progress = utility.index_building_progress(collection_name=collection_name)
2026-06-19 04:38:08,459 - INFO - Starting to monitor progress for collection: mlps_pr442_diskann
2026-06-19 04:38:08,459 - INFO - Initial state: 0 of 10,000 rows indexed
2026-06-19 04:38:08,459 - INFO - Initial pending rows: 10,000
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/compact_and_watch.py:123: PyMilvusDeprecationWarning: `utility.index_building_progress` is an 
ORM-style PyMilvus API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  progress = utility.index_building_progress(collection_name=collection_name)
2026-06-19 04:38:13,463 - INFO - Progress: 0.00% complete... (0/10,000 rows) | Pending rows: 10,000
2026-06-19 04:38:18,467 - INFO - No pending rows detected. Assuming indexing phase is complete.
2026-06-19 04:38:18,467 - INFO - No pending rows for 0.0 seconds (waiting for 10 seconds to confirm)
2026-06-19 04:38:23,470 - INFO - No pending rows for 5.0 seconds (waiting for 10 seconds to confirm)
2026-06-19 04:38:28,474 - INFO - No pending rows for 10.0 seconds (waiting for 10 seconds to confirm)
2026-06-19 04:38:28,474 - INFO - No pending rows detected for 0 minutes. Process is considered complete.
2026-06-19 04:38:28,474 - INFO - Process fully complete! Total time: 0:00:20
2026-06-19 04:38:28,474 - INFO - Compacting collection 'mlps_pr442_diskann'
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:400: PyMilvusDeprecationWarning: `Collection.compact` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection.compact()
2026-06-19 04:38:28,480 - INFO - Starting to monitor progress for collection: mlps_pr442_diskann
2026-06-19 04:38:28,481 - INFO - Initial state: 10,000 of 10,000 rows indexed
2026-06-19 04:38:28,481 - INFO - Initial pending rows: 0
2026-06-19 04:38:33,483 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 10,000
2026-06-19 04:38:38,486 - INFO - No pending rows detected. Assuming indexing phase is complete.
2026-06-19 04:38:38,486 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:38:38,486 - INFO - No pending rows for 0.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:38:43,490 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:38:43,490 - INFO - No pending rows for 5.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:38:48,493 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:38:48,493 - INFO - No pending rows for 10.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:38:53,497 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:38:53,497 - INFO - No pending rows for 15.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:38:58,502 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:38:58,502 - INFO - No pending rows for 20.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:39:03,506 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:39:03,506 - INFO - No pending rows for 25.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:39:08,510 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
Loaded vdbbench configuration from /home/smrc/Storage_Repo_Tests/storage_mlp/configs/vectordbbench/default.yaml
2026-06-19 04:39:08,510 - INFO - No pending rows for 30.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:39:08,510 - INFO - No pending rows detected for 30 seconds. Process is considered complete.
2026-06-19 04:39:08,510 - INFO - Process fully complete! Total time: 0:00:40
2026-06-19 04:39:08,510 - INFO - Collection 'mlps_pr442_diskann' compacted successfully.
2026-06-19 04:39:08,510 - INFO - Benchmark completed successfully!
2026-06-19 04:39:08|STATUS: Writing metadata for benchmark to: /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/datagen/20260619_043803/vector_database_20260619_0
smrc@dskbd029:~/Storage_Repo_Tests/storage_mlp$ ./mlpstorage closed vectordb run \
  file \
  --vdb-engine milvus \
  --vdb-index DISKANN \
  --host 127.0.0.1 \
  --port 19530 \
  --config default \
  --collection mlps_pr442_diskann \
  --benchmark-mode query_count \
  --queries 100 \
  --num-query-processes 1 \
  --batch-size 10 \
  --results-dir /tmp/vdb_pr442_actual
2026-06-19 04:40:13|STATUS: 
2026-06-19 04:40:13|STATUS: --- Run Configuration (mlpstorage 3.0.13) ---
2026-06-19 04:40:13|STATUS:   benchmark:                      vectordb
2026-06-19 04:40:13|STATUS:   command:                        run
2026-06-19 04:40:13|STATUS:   mode:                           closed
2026-06-19 04:40:13|STATUS:   data_dir:                       [not set]
2026-06-19 04:40:13|STATUS:   results_dir:                    /tmp/vdb_pr442_actual
2026-06-19 04:40:13|STATUS:   data_access_protocol:           file
2026-06-19 04:40:13|STATUS:   num_accelerators:               [not set]
2026-06-19 04:40:13|STATUS:   num_processes:                  [not set]
2026-06-19 04:40:13|STATUS:   accelerator_type:               [not set]
2026-06-19 04:40:13|STATUS:   client_host_memory_in_gb:       [not set]
2026-06-19 04:40:13|STATUS:   hosts:                          [not set]
2026-06-19 04:40:13|STATUS:   exec_type:                      [not set]
2026-06-19 04:40:13|STATUS:   mpi_bin:                        mpiexec
2026-06-19 04:40:13|STATUS:   loops:                          1
2026-06-19 04:40:13|STATUS: 
2026-06-19 04:40:13|STATUS: --- Environment ---
2026-06-19 04:40:13|STATUS:   MLPERF_RESULTS_DIR:             [not set]
2026-06-19 04:40:13|STATUS:   MPI_RUN_BIN:                    [not set]
2026-06-19 04:40:13|STATUS:   MPI_EXEC_BIN:                   [not set]
2026-06-19 04:40:13|STATUS: 
⠋ Validating environment... 0:00:002026-06-19 04:40:13|INFO: Environment validation passed
2026-06-19 04:40:13|STATUS: Benchmark results directory: /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run/20260619_044013
2026-06-19 04:40:13|INFO: Created benchmark run: vector_database_run_milvus_DISKANN_20260619_044013
2026-06-19 04:40:13|STATUS: Verifying benchmark run for vector_database_run_milvus_DISKANN_20260619_044013
2026-06-19 04:40:13|STATUS: Open: [OPEN] VectorDB benchmark is in preview status - not accepted for closed submissions (Parameter: benchmark_status)
2026-06-19 04:40:13|STATUS: Benchmark run qualifies for OPEN category ([RunID(program='vector_database', command='run', model='milvus_DISKANN', run_datetime='20260619
2026-06-19 04:40:13|WARNING: Running the benchmark without verification for open or closed configurations. These results are not valid for submission. Use closed or o
2026-06-19 04:40:13|STATUS: Instantiated the VectorDB Benchmark...
Loaded vdbbench configuration from /home/smrc/Storage_Repo_Tests/storage_mlp/configs/vectordbbench/default.yaml

==================================================
OUTPUT CONFIGURATION
==================================================
Results will be saved to: /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run/20260619_044013

==================================================
Database Verification and Loading
==================================================
Verifying database connection and loading collection
Connecting to Milvus server at 127.0.0.1:19530...
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:775: PyMilvusDeprecationWarning: `connections.connect` is an ORM-style PyMilvus API 
and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  connections.connect(alias="default", host=host, port=port)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:1080: PyMilvusDeprecationWarning: `Collection` is an ORM-style PyMilvus API and will 
be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection = Collection(collection_name)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:1089: PyMilvusDeprecationWarning: `utility.load_state` is an ORM-style PyMilvus API 
and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  state = utility.load_state(collection_name)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:1098: PyMilvusDeprecationWarning: `Collection.load` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection.load()
Loading collection mlps_pr442_diskann...
Collection mlps_pr442_diskann loaded in 1.83 seconds
Getting collection statistics...
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/list_collections.py:67: PyMilvusDeprecationWarning: `Collection` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection = Collection(collection_name)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/list_collections.py:71: PyMilvusDeprecationWarning: `Collection.num_entities` is an ORM-style 
PyMilvus API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  row_count = collection.num_entities
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/list_collections.py:84: PyMilvusDeprecationWarning: `Collection.has_index` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  if collection.has_index():
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/list_collections.py:85: PyMilvusDeprecationWarning: `Collection.index` is an ORM-style PyMilvus API 
and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  index = collection.index()
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/list_collections.py:94: PyMilvusDeprecationWarning: `Collection.partitions` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  partitions = collection.partitions

Tabulating information...
+--------------------+----------------+-------------+---------------+----------------+--------------+
| Collection Name    |   Vector Count |   Dimension | Index Types   | Metric Types   |   Partitions |
+====================+================+=============+===============+================+==============+
| mlps_pr442_diskann |          10000 |        1536 | DISKANN       | COSINE         |            1 |
+--------------------+----------------+-------------+---------------+----------------+--------------+

COLLECTION INFORMATION: {'name': 'mlps_pr442_diskann', 'row_count': 10000, 'dimension': 1536, 'schema': "{'auto_id': False, 'description': 'Benchmark Collection', 
'fields': [{'name': 'id', 'description': '', 'type': <DataType.INT64: 5>, 'is_primary': True, 'auto_id': False}, {'name': 'vector', 'description': '', 'type': 
<DataType.FLOAT_VECTOR: 101>, 'params': {'dim': 1536}}], 'enable_dynamic_field': False, 'enable_namespace': False}", 'index_info': [{'field_name': 'vector', 
'index_type': 'DISKANN', 'metric_type': 'COSINE', 'params': {'MaxDegree': 16, 'SearchListSize': 200}}], 'partitions': [{'name': '_default', 'description': ''}]}
Writing configuration to /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run/20260619_044013/config.json

==================================================
RECALL SETUP (outside benchmark timing)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:1372: PyMilvusDeprecationWarning: `connections.disconnect` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  connections.disconnect("default")
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:1423: PyMilvusDeprecationWarning: `Collection` is an ORM-style PyMilvus API and will 
be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  src_coll = Collection(args.collection_name)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:1425: PyMilvusDeprecationWarning: `connections.disconnect` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  connections.disconnect("default")
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:291: PyMilvusDeprecationWarning: `connections.connect` is an ORM-style PyMilvus API 
and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  connections.connect(alias=conn_alias, host=host, port=port)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:297: PyMilvusDeprecationWarning: `utility.has_collection` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  if utility.has_collection(flat_collection_name, using=conn_alias):
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:322: PyMilvusDeprecationWarning: `Collection` is an ORM-style PyMilvus API and will 
be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  source_coll = Collection(source_collection_name, using=conn_alias)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:323: PyMilvusDeprecationWarning: `Collection.load` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  source_coll.load()
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:324: PyMilvusDeprecationWarning: `Collection.flush` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  source_coll.flush()
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:326: PyMilvusDeprecationWarning: `Collection.num_entities` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  total_vectors = source_coll.num_entities
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:362: PyMilvusDeprecationWarning: `Collection` is an ORM-style PyMilvus API and will 
be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  flat_coll = Collection(flat_collection_name, schema, using=conn_alias)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:389: PyMilvusDeprecationWarning: `Collection.insert` is an ORM-style PyMilvus API and
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  flat_coll.insert([pk_values, vectors])
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:528: PyMilvusDeprecationWarning: `Collection.flush` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  flat_coll.flush()
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:531: PyMilvusDeprecationWarning: `Collection.num_entities` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  actual_count = flat_coll.num_entities
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:541: PyMilvusDeprecationWarning: `Collection.num_entities` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  if flat_coll.num_entities < copied:
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:548: PyMilvusDeprecationWarning: `Collection.create_index` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  flat_coll.create_index(
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:556: PyMilvusDeprecationWarning: `Collection.load` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  flat_coll.load()
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:560: PyMilvusDeprecationWarning: `Collection.num_entities` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  f"{flat_coll.num_entities} vectors."
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:574: PyMilvusDeprecationWarning: `connections.disconnect` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  connections.disconnect(conn_alias)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:595: PyMilvusDeprecationWarning: `connections.connect` is an ORM-style PyMilvus API 
and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  connections.connect(alias=conn_alias, host=host, port=port)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:601: PyMilvusDeprecationWarning: `Collection` is an ORM-style PyMilvus API and will 
be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  flat_coll = Collection(flat_collection_name, using=conn_alias)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:602: PyMilvusDeprecationWarning: `Collection.load` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  flat_coll.load()
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:604: PyMilvusDeprecationWarning: `Collection.num_entities` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  entity_count = flat_coll.num_entities
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:629: PyMilvusDeprecationWarning: `Collection.search` is an ORM-style PyMilvus API and
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  results = flat_coll.search(
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:658: PyMilvusDeprecationWarning: `connections.disconnect` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  connections.disconnect(conn_alias)
==================================================
Ground truth is pre-computed using a FLAT/brute-force index.
This does NOT affect performance measurements.

Using metric type: COSINE
Detected source vector field: 'vector'

Generating 1000 query vectors (dim=1536, seed=42)...
Generated 1000 query vectors.

Setting up FLAT collection: mlps_pr442_diskann_flat_gt
Creating FLAT collection 'mlps_pr442_diskann_flat_gt' from source 'mlps_pr442_diskann'...
Source schema: pk_field='id' (INT64), vec_field='vector', vectors=10000
Copying 10000 vectors to FLAT collection (batch_size=5000)...
  Copied 10000/10000 vectors (100.0%)
Building FLAT index...
FLAT collection 'mlps_pr442_diskann_flat_gt' ready with 10000 vectors.
Pre-computing ground truth for 1000 queries using FLAT index (top_k=10)...
Ground truth pre-computation complete: 1000 queries in 1.46s
Ground truth ready: 1000 queries pre-computed.

Collecting initial disk statistics...

==================================================
Benchmark Execution
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:824: PyMilvusDeprecationWarning: `Collection` is an ORM-style PyMilvus API and will 
be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection = Collection(collection_name)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:826: PyMilvusDeprecationWarning: `Collection.load` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection.load()
==================================================
Starting benchmark with 1 processes and 100 total queries
Recall measurement: using 1000 pre-generated queries, recall@10
NOTE: batch_end timing is placed BEFORE recall capture; performance is unaffected.
Running single process benchmark...
Process 0 initialized
Process 0: loading collection
Process 0: writing results to /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run/20260619_044013/milvus_benchmark_p0.csv
Process 0: starting benchmark
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:882: PyMilvusDeprecationWarning: `Collection.search` is an ORM-style PyMilvus API and
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  results = collection.search(
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/simple_bench.py:940: PyMilvusDeprecationWarning: `connections.disconnect` is an ORM-style PyMilvus 
API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  connections.disconnect("default")
Process 0: finished. Executed 100 queries in 0.20 seconds.
Reading final disk statistics...

Calculating recall from captured ANN results...
Calculating benchmark statistics...

Benchmark statistics as JSON:
{"total_queries": 100, "total_time_seconds": 0.1115720272064209, "min_latency_ms": 0.8307218551635, "max_latency_ms": 1.2333393096923, "mean_latency_ms": 
0.9997701644896904, "median_latency_ms": 0.9494781494140001, "p95_latency_ms": 1.2333393096923, "p99_latency_ms": 1.2333393096923, "p999_latency_ms": 1.2333393096923,
"p9999_latency_ms": 1.2333393096923, "throughput_qps": 896.2820027907951, "batch_count": 10, "successful_batches": 10, "failed_batches": 0, "min_batch_time_ms": 
8.307218551635701, "max_batch_time_ms": 12.3333930969238, "mean_batch_time_ms": 9.99770164489741, "median_batch_time_ms": 9.49478149414055, "p95_batch_time_ms": 
12.097465991973818, "p99_batch_time_ms": 12.286207675933804, "p999_batch_time_ms": 12.3286745548248, "p9999_batch_time_ms": 12.3329212427139, "recall": 
{"recall_at_k": 0.5700000000000001, "num_queries_evaluated": 100, "k": 10, "min_recall": 0.2, "max_recall": 1.0, "mean_recall": 0.5700000000000001, "median_recall": 
0.6, "p5_recall": 0.3, "p95_recall": 0.8, "p99_recall": 0.9010000000000006, "per_query_recall": [0.3, 0.7, 0.4, 0.4, 0.7, 0.6, 0.3, 0.5, 0.4, 0.3, 0.6, 0.8, 0.4, 0.8,
0.7, 0.8, 0.5, 0.6, 0.5, 0.6, 0.4, 0.8, 0.8, 1.0, 0.6, 0.7, 0.5, 0.2, 0.6, 0.6, 0.3, 0.5, 0.5, 0.5, 0.7, 0.3, 0.8, 0.8, 0.6, 0.6, 0.7, 0.4, 0.3, 0.6, 0.6, 0.7, 0.7, 
0.6, 0.7, 0.6, 0.6, 0.8, 0.7, 0.3, 0.6, 0.7, 0.6, 0.7, 0.3, 0.5, 0.4, 0.6, 0.5, 0.3, 0.6, 0.7, 0.5, 0.8, 0.4, 0.6, 0.9, 0.5, 0.7, 0.8, 0.6, 0.5, 0.9, 0.7, 0.5, 0.7, 
0.3, 0.6, 0.4, 0.4, 0.7, 0.7, 0.7, 0.6, 0.3, 0.7, 0.5, 0.5, 0.5, 0.2, 0.7, 0.7, 0.3, 0.2, 0.8, 0.6], "recall_by_query": {"0": 0.3, "1": 0.7, "2": 0.4, "3": 0.4, "4": 
0.7, "5": 0.6, "6": 0.3, "7": 0.5, "8": 0.4, "9": 0.3, "10": 0.6, "11": 0.8, "12": 0.4, "13": 0.8, "14": 0.7, "15": 0.8, "16": 0.5, "17": 0.6, "18": 0.5, "19": 0.6, 
"20": 0.4, "21": 0.8, "22": 0.8, "23": 1.0, "24": 0.6, "25": 0.7, "26": 0.5, "27": 0.2, "28": 0.6, "29": 0.6, "30": 0.3, "31": 0.5, "32": 0.5, "33": 0.5, "34": 0.7, 
"35": 0.3, "36": 0.8, "37": 0.8, "38": 0.6, "39": 0.6, "40": 0.7, "41": 0.4, "42": 0.3, "43": 0.6, "44": 0.6, "45": 0.7, "46": 0.7, "47": 0.6, "48": 0.7, "49": 0.6, 
"50": 0.6, "51": 0.8, "52": 0.7, "53": 0.3, "54": 0.6, "55": 0.7, "56": 0.6, "57": 0.7, "58": 0.3, "59": 0.5, "60": 0.4, "61": 0.6, "62": 0.5, "63": 0.3, "64": 0.6, 
"65": 0.7, "66": 0.5, "67": 0.8, "68": 0.4, "69": 0.6, "70": 0.9, "71": 0.5, "72": 0.7, "73": 0.8, "74": 0.6, "75": 0.5, "76": 0.9, "77": 0.7, "78": 0.5, "79": 0.7, 
"80": 0.3, "81": 0.6, "82": 0.4, "83": 0.4, "84": 0.7, "85": 0.7, "86": 0.7, "87": 0.6, "88": 0.3, "89": 0.7, "90": 0.5, "91": 0.5, "92": 0.5, "93": 0.2, "94": 0.7, 
"95": 0.7, "96": 0.3, "97": 0.2, "98": 0.8, "99": 0.6}}, "disk_io": {"total_bytes_read": 10289152, "total_bytes_read_per_sec": 92219817.61578915, 
"total_bytes_written": 0, "total_bytes_written_per_sec": 0.0, "total_read_formatted": "9.81 MB", "total_write_formatted": "0.00 B", "devices": {"nvme3n1": 
{"bytes_read": 10289152, "bytes_written": 0, "read_formatted": "9.81 MB", "write_formatted": "0.00 B"}}}}
2026-06-19 04:40:25|STATUS: Writing metadata for benchmark to: /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run/20260619_044013/vector_database_20260619_04401
smrc@dskbd029:~/Storage_Repo_Tests/storage_mlp$ find /tmp/vdb_pr442_actual/vector_database -maxdepth 7 -type d | sort
find /tmp/vdb_pr442_actual/vector_database -name '*_metadata.json' -print | sort
find /tmp/vdb_pr442_actual/vector_database -name 'statistics.json' -print | sort
/tmp/vdb_pr442_actual/vector_database
/tmp/vdb_pr442_actual/vector_database/milvus
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/datagen
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/datagen/20260619_043803
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run/20260619_044013
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/datagen/20260619_043803/vector_database_20260619_043803_metadata.json
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run/20260619_044013/vector_database_20260619_044013_metadata.json
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run/20260619_044013/statistics.json
smrc@dskbd029:~/Storage_Repo_Tests/storage_mlp$ python - <<'PY'
import json
from pathlib import Path

root = Path("/tmp/vdb_pr442_actual")

for p in sorted(root.glob("vector_database/milvus/DISKANN/*/*/*_metadata.json")):
    meta = json.loads(p.read_text())
    print("\nmetadata:", p)
    print("model:", meta.get("model"))
    print("vdb_engine:", meta.get("vdb_engine"))
    print("vdb_index:", meta.get("vdb_index"))
    print("vectordb_config:", meta.get("vectordb_config"))
    print("result_dir:", meta.get("result_dir"))
PY
Command 'python' not found, did you mean:
  command 'python3' from deb python3
  command 'python' from deb python-is-python3
smrc@dskbd029:~/Storage_Repo_Tests/storage_mlp$ uv run python - <<'PY'
import json
from pathlib import Path

root = Path("/tmp/vdb_pr442_actual")

for p in sorted(root.glob("vector_database/milvus/DISKANN/*/*/*_metadata.json")):
    meta = json.loads(p.read_text())
    print("\nmetadata:", p)
    print("model:", meta.get("model"))
    print("vdb_engine:", meta.get("vdb_engine"))
    print("vdb_index:", meta.get("vdb_index"))
    print("vectordb_config:", meta.get("vectordb_config"))
    print("result_dir:", meta.get("result_dir"))
PY

metadata: /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/datagen/20260619_043803/vector_database_20260619_043803_metadata.json
model: milvus_DISKANN
vdb_engine: milvus
vdb_index: DISKANN
vectordb_config: default
result_dir: /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/datagen/20260619_043803

metadata: /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run/20260619_044013/vector_database_20260619_044013_metadata.json
model: milvus_DISKANN
vdb_engine: milvus
vdb_index: DISKANN
vectordb_config: default
result_dir: /tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run/20260619_044013
smrc@dskbd029:~/Storage_Repo_Tests/storage_mlp$ ./mlpstorage closed vectordb datagen \
  file \
  --vdb-engine milvus \
  --vdb-index HNSW \
  --host 127.0.0.1 \
  --port 19530 \
  --config default \
  --collection mlps_pr442_hnsw \
  --num-vectors 10000 \
  --dimension 1536 \
  --num-shards 1 \
  --index-type HNSW \
  --force \
  --results-dir /tmp/vdb_pr442_actual
2026-06-19 04:42:25|STATUS: 
2026-06-19 04:42:25|STATUS: --- Run Configuration (mlpstorage 3.0.13) ---
2026-06-19 04:42:25|STATUS:   benchmark:                      vectordb
2026-06-19 04:42:25|STATUS:   command:                        datagen
2026-06-19 04:42:25|STATUS:   mode:                           closed
2026-06-19 04:42:25|STATUS:   data_dir:                       [not set]
2026-06-19 04:42:25|STATUS:   results_dir:                    /tmp/vdb_pr442_actual
2026-06-19 04:42:25|STATUS:   data_access_protocol:           file
2026-06-19 04:42:25|STATUS:   num_accelerators:               [not set]
2026-06-19 04:42:25|STATUS:   num_processes:                  [not set]
2026-06-19 04:42:25|STATUS:   accelerator_type:               [not set]
2026-06-19 04:42:25|STATUS:   client_host_memory_in_gb:       [not set]
2026-06-19 04:42:25|STATUS:   hosts:                          [not set]
2026-06-19 04:42:25|STATUS:   exec_type:                      [not set]
2026-06-19 04:42:25|STATUS:   mpi_bin:                        mpiexec
2026-06-19 04:42:25|STATUS:   loops:                          1
2026-06-19 04:42:25|STATUS: 
2026-06-19 04:42:25|STATUS: --- Environment ---
2026-06-19 04:42:25|STATUS:   MLPERF_RESULTS_DIR:             [not set]
2026-06-19 04:42:25|STATUS:   MPI_RUN_BIN:                    [not set]
2026-06-19 04:42:25|STATUS:   MPI_EXEC_BIN:                   [not set]
2026-06-19 04:42:25|STATUS: 
⠋ Validating environment... 0:00:002026-06-19 04:42:25|INFO: Environment validation passed
2026-06-19 04:42:25|STATUS: Benchmark results directory: /tmp/vdb_pr442_actual/vector_database/milvus/HNSW/datagen/20260619_044225
2026-06-19 04:42:25|INFO: Created benchmark run: vector_database_datagen_milvus_HNSW_20260619_044225
2026-06-19 04:42:25|STATUS: Verifying benchmark run for vector_database_datagen_milvus_HNSW_20260619_044225
2026-06-19 04:42:25|STATUS: Open: [OPEN] VectorDB benchmark is in preview status - not accepted for closed submissions (Parameter: benchmark_status)
2026-06-19 04:42:25|STATUS: Benchmark run qualifies for OPEN category ([RunID(program='vector_database', command='datagen', model='milvus_HNSW', run_datetime='2026061
2026-06-19 04:42:25|WARNING: Running the benchmark without verification for open or closed configurations. These results are not valid for submission. Use closed or o
2026-06-19 04:42:25|STATUS: Instantiated the VectorDB Benchmark...
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:128: PyMilvusDeprecationWarning: `connections.connect` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  connections.connect(
2026-06-19 04:42:26,324 - INFO - Connected to Milvus server at 127.0.0.1:19530
2026-06-19 04:42:26,324 - WARNING - FLOAT16 data type not available in this version of pymilvus. Using FLOAT_VECTOR instead.
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:147: PyMilvusDeprecationWarning: `utility.has_collection` is an ORM-style PyMilvus API 
and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  if utility.has_collection(collection_name):
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:166: PyMilvusDeprecationWarning: `Collection` is an ORM-style PyMilvus API and will be 
removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection = Collection(name=collection_name, schema=schema, num_shards=num_shards)
2026-06-19 04:42:26,334 - INFO - Created collection 'mlps_pr442_hnsw' with 1536 dimensions and 1 shards
2026-06-19 04:42:26,334 - INFO - Creating index with parameters: {'index_type': 'HNSW', 'metric_type': 'COSINE', 'params': {'M': 16, 'efConstruction': 200}}
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:266: PyMilvusDeprecationWarning: `Collection.create_index` is an ORM-style PyMilvus API 
and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection.create_index("vector", index_params)
2026-06-19 04:42:26,843 - INFO - Index creation command completed in 0.51 seconds
2026-06-19 04:42:26,843 - INFO - Generating 10000 vectors with 1536 dimensions using uniform distribution
2026-06-19 04:42:27,005 - INFO - Inserting 10000 vectors into collection 'mlps_pr442_hnsw'
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:235: PyMilvusDeprecationWarning: `Collection.insert` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection.insert([ids, batch_vectors])
2026-06-19 04:42:27,252 - INFO - Inserted batch 1/10: 10.00% complete, rate: 4049.45 vectors/sec, id_range=[0, 999]
2026-06-19 04:42:27,473 - INFO - Inserted batch 2/10: 20.00% complete, rate: 4280.25 vectors/sec, id_range=[1000, 1999]
2026-06-19 04:42:27,711 - INFO - Inserted batch 3/10: 30.00% complete, rate: 4249.50 vectors/sec, id_range=[2000, 2999]
2026-06-19 04:42:27,937 - INFO - Inserted batch 4/10: 40.00% complete, rate: 4292.66 vectors/sec, id_range=[3000, 3999]
2026-06-19 04:42:28,143 - INFO - Inserted batch 5/10: 50.00% complete, rate: 4392.97 vectors/sec, id_range=[4000, 4999]
2026-06-19 04:42:28,363 - INFO - Inserted batch 6/10: 60.00% complete, rate: 4419.97 vectors/sec, id_range=[5000, 5999]
2026-06-19 04:42:28,544 - INFO - Inserted batch 7/10: 70.00% complete, rate: 4547.79 vectors/sec, id_range=[6000, 6999]
2026-06-19 04:42:28,747 - INFO - Inserted batch 8/10: 80.00% complete, rate: 4592.72 vectors/sec, id_range=[7000, 7999]
2026-06-19 04:42:28,908 - INFO - Inserted batch 9/10: 90.00% complete, rate: 4731.18 vectors/sec, id_range=[8000, 8999]
2026-06-19 04:42:29,083 - INFO - Inserted batch 10/10: 100.00% complete, rate: 4813.29 vectors/sec, id_range=[9000, 9999]
2026-06-19 04:42:29,083 - INFO - Inserted 10000 vectors in 2.08 seconds
2026-06-19 04:42:29,083 - INFO - Generated all 10,000 vectors in 2.24 seconds
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:256: PyMilvusDeprecationWarning: `Collection.flush` is an ORM-style PyMilvus API and will
be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection.flush()
2026-06-19 04:42:30,097 - INFO - Flush completed in 1.01 seconds
2026-06-19 04:42:30,097 - INFO - Starting to monitor index building progress (checking every 5 seconds)
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/compact_and_watch.py:100: PyMilvusDeprecationWarning: `utility.index_building_progress` is an 
ORM-style PyMilvus API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  prev_progress = utility.index_building_progress(collection_name=collection_name)
2026-06-19 04:42:30,101 - INFO - Starting to monitor progress for collection: mlps_pr442_hnsw
2026-06-19 04:42:30,101 - INFO - Initial state: 0 of 10,000 rows indexed
2026-06-19 04:42:30,101 - INFO - Initial pending rows: 10,000
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/compact_and_watch.py:123: PyMilvusDeprecationWarning: `utility.index_building_progress` is an 
ORM-style PyMilvus API and will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  progress = utility.index_building_progress(collection_name=collection_name)
2026-06-19 04:42:35,105 - INFO - No pending rows detected. Assuming indexing phase is complete.
2026-06-19 04:42:35,105 - INFO - No pending rows for 0.0 seconds (waiting for 10 seconds to confirm)
2026-06-19 04:42:40,108 - INFO - No pending rows for 5.0 seconds (waiting for 10 seconds to confirm)
2026-06-19 04:42:45,112 - INFO - No pending rows for 10.0 seconds (waiting for 10 seconds to confirm)
2026-06-19 04:42:45,112 - INFO - No pending rows detected for 0 minutes. Process is considered complete.
2026-06-19 04:42:45,112 - INFO - Process fully complete! Total time: 0:00:15
2026-06-19 04:42:45,112 - INFO - Compacting collection 'mlps_pr442_hnsw'
/home/smrc/Storage_Repo_Tests/storage_mlp/vdb_benchmark/vdbbench/load_vdb.py:400: PyMilvusDeprecationWarning: `Collection.compact` is an ORM-style PyMilvus API and 
will be removed in PyMilvus 3.1. Use `MilvusClient` instead.
  collection.compact()
2026-06-19 04:42:45,120 - INFO - Starting to monitor progress for collection: mlps_pr442_hnsw
2026-06-19 04:42:45,120 - INFO - Initial state: 10,000 of 10,000 rows indexed
2026-06-19 04:42:45,120 - INFO - Initial pending rows: 0
2026-06-19 04:42:50,124 - INFO - No pending rows detected. Assuming indexing phase is complete.
2026-06-19 04:42:50,124 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:42:50,124 - INFO - No pending rows for 0.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:42:55,128 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:42:55,128 - INFO - No pending rows for 5.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:43:00,132 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:43:00,132 - INFO - No pending rows for 10.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:43:05,135 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:43:05,136 - INFO - No pending rows for 15.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:43:10,139 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:43:10,139 - INFO - No pending rows for 20.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:43:15,142 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
2026-06-19 04:43:15,142 - INFO - No pending rows for 25.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:43:20,146 - INFO - Progress: 100.00% complete... (10,000/10,000 rows) | Pending rows: 0
Loaded vdbbench configuration from /home/smrc/Storage_Repo_Tests/storage_mlp/configs/vectordbbench/default.yaml
2026-06-19 04:43:20,146 - INFO - No pending rows for 30.0 seconds (waiting for 30 seconds to confirm)
2026-06-19 04:43:20,146 - INFO - No pending rows detected for 30 seconds. Process is considered complete.
2026-06-19 04:43:20,146 - INFO - Process fully complete! Total time: 0:00:35
2026-06-19 04:43:20,146 - INFO - Collection 'mlps_pr442_hnsw' compacted successfully.
2026-06-19 04:43:20,146 - INFO - Benchmark completed successfully!
2026-06-19 04:43:20|STATUS: Writing metadata for benchmark to: /tmp/vdb_pr442_actual/vector_database/milvus/HNSW/datagen/20260619_044225/vector_database_20260619_0442
smrc@dskbd029:~/Storage_Repo_Tests/storage_mlp$ find /tmp/vdb_pr442_actual/vector_database/milvus -maxdepth 2 -type d | sort
/tmp/vdb_pr442_actual/vector_database/milvus
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/datagen
/tmp/vdb_pr442_actual/vector_database/milvus/DISKANN/run
/tmp/vdb_pr442_actual/vector_database/milvus/HNSW
/tmp/vdb_pr442_actual/vector_database/milvus/HNSW/datagen
```