### PR TITLE
chore(deps): bump version to 3.0.14 and track DLIO main @ PR #26 merge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.13"
+version = "3.0.14"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -132,7 +132,7 @@ torchaudio = [{ index = "pytorch-cpu" }]
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #24 fix for storage #448 (per-node worker-memory budget)
 #   - DLIO PR #25 fix for storage #455 (sampler floor division — equal per-rank shards)
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "cbe200103b05fb65f04110157a7d0dd6d6d88ead" }
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "ef58613b59d4ad510f467dd53b2b326f25829f1b" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=cbe200103b05fb65f04110157a7d0dd6d6d88ead#cbe200103b05fb65f04110157a7d0dd6d6d88ead" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=ef58613b59d4ad510f467dd53b2b326f25829f1b#ef58613b59d4ad510f467dd53b2b326f25829f1b" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.13"
+version = "3.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=cbe200103b05fb65f04110157a7d0dd6d6d88ead" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=cbe200103b05fb65f04110157a7d0dd6d6d88ead" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=ef58613b59d4ad510f467dd53b2b326f25829f1b" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=ef58613b59d4ad510f467dd53b2b326f25829f1b" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary
- Bump `mlpstorage` version from 3.0.13 to 3.0.14
- Update `dlio-benchmark` pin to `ef58613` — latest `DLIO_local_changes` main following PR #26 (MPI rank-0 streamed file listing with hash sharding and shared memory)
- Refresh `uv.lock` to match

## Test plan
- [ ] CI passes on the branch
- [ ] `uv lock --check` is clean
- [ ] Spot-check a training datagen / run still works against the new DLIO pin