### PR TITLE
test(kvcache): stub time.sleep in mlperf_wrapper TestMain helper

### DIFF
--- a/tests/unit/test_mlperf_wrapper.py
+++ b/tests/unit/test_mlperf_wrapper.py
@@ -111,7 +111,8 @@ class TestMain:
             return MagicMock(returncode=0)
 
         with patch('sys.argv', argv), \
-             patch.object(wrapper_module.subprocess, 'run', side_effect=fake_run):
+             patch.object(wrapper_module.subprocess, 'run', side_effect=fake_run), \
+             patch.object(wrapper_module.time, 'sleep'):
             with pytest.raises(SystemExit) as exc_info:
                 wrapper_module.main()
 


### PR DESCRIPTION
## Summary
- `kv_cache_benchmark/mlperf_wrapper.py` `main()` calls `time.sleep(90)` twice (before and after the subprocess invocation) to let the SUT quiesce between phases.
- The `TestMain` cases in `tests/unit/test_mlperf_wrapper.py` invoke `main()` directly with `subprocess.run` patched, but they did not patch `time.sleep`, so each test slept for the full 180s.
- This caused the unit test job on PR #478 to be cancelled after running well past the CI timeout (5 `TestMain` tests × ~3 min each, killed mid-6th).
- Fix: patch `wrapper_module.time.sleep` in the `_run_main` helper alongside the existing `subprocess.run` patch. Production sleeps are unchanged; unit tests no longer pay for them.

After the fix, `pytest tests/unit/test_mlperf_wrapper.py -v` runs all 18 tests in ~0.04s.

## Test plan
- [x] `pytest tests/unit/test_mlperf_wrapper.py -v` — 18 passed in 0.04s locally
- [ ] CI unit test job completes within timeout