### PR TITLE
fix: remove preview-status OPEN bump from VectorDB and KV Cache run checkers

### DIFF
--- a/mlpstorage_py/cli/common_args.py
+++ b/mlpstorage_py/cli/common_args.py
@@ -196,8 +196,8 @@ HELP_MESSAGES = {
 PROGRAM_DESCRIPTIONS = {
     'training': "Run the MLPerf Storage training benchmark",
     'checkpointing': "Run the MLPerf Storage checkpointing benchmark",
-    'vectordb': "Run the MLPerf Storage Preview of a VectorDB benchmark (not available in closed submissions)",
-    'kvcache': "Run the KV Cache benchmark for LLM inference storage testing (preview)",
+    'vectordb': "Run the MLPerf Storage VectorDB benchmark",
+    'kvcache': "Run the KV Cache benchmark for LLM inference storage testing",
     'reports': "Generate reports from benchmark results",
     'history': "View and manage benchmark history",
 }

--- a/mlpstorage_py/reporting/formatters.py
+++ b/mlpstorage_py/reporting/formatters.py
@@ -284,12 +284,11 @@ class ClosedRequirementsFormatter:
     }
 
     VECTORDB_REQUIREMENTS = {
-        'title': 'VectorDB Benchmark Requirements (Preview)',
+        'title': 'VectorDB Benchmark Requirements',
         'requirements': [
             'Minimum runtime of 30 seconds',
             'Valid collection configuration',
             'Database host and port accessible',
-            'Note: VectorDB is in preview and not yet accepted for CLOSED submissions',
         ],
         'allowed_params': [],
     }

--- a/mlpstorage_py/reporting/formatters.py
+++ b/mlpstorage_py/reporting/formatters.py
@@ -273,12 +273,11 @@ class ClosedRequirementsFormatter:
     }
 
     KVCACHE_REQUIREMENTS = {
-        'title': 'KV Cache Benchmark Requirements (Preview)',
+        'title': 'KV Cache Benchmark Requirements',
         'requirements': [
             'Minimum runtime of 30 seconds',
             'Valid model configuration',
             'At least 1 concurrent user',
-            'Note: KV Cache is in preview and not yet accepted for CLOSED submissions',
         ],
         'allowed_params': [],
     }

--- a/mlpstorage_py/rules/run_checkers/kvcache.py
+++ b/mlpstorage_py/rules/run_checkers/kvcache.py
@@ -2,8 +2,6 @@
 KV Cache benchmark run rules checker.
 
 Validates KV Cache benchmark parameters for individual runs.
-Note: KV Cache is currently a preview benchmark, so validation
-rules are less strict than training/checkpointing.
 """
 
 from typing import Optional, List
@@ -26,8 +24,6 @@ class KVCacheRunRulesChecker(RunRulesChecker):
     - Multi-tier cache configurations (GPU → CPU → NVMe)
     - Multi-user simulation
     - Phase-aware processing (prefill/decode)
-
-    Currently in preview mode - rules are informational rather than strict.
     """
 
     # Minimum requirements for valid KV Cache runs
@@ -184,16 +180,3 @@ class KVCacheRunRulesChecker(RunRulesChecker):
             )
 
         return None
-
-    def check_preview_status(self) -> Optional[Issue]:
-        """
-        Return informational issue that KV Cache is in preview.
-
-        This is always returned to inform users that this benchmark
-        is not yet accepted for closed submissions.
-        """
-        return Issue(
-            validation=PARAM_VALIDATION.OPEN,
-            message="KV Cache benchmark is in preview status - not accepted for closed submissions",
-            parameter="benchmark_status"
-        )

--- a/mlpstorage_py/rules/run_checkers/vectordb.py
+++ b/mlpstorage_py/rules/run_checkers/vectordb.py
@@ -2,8 +2,6 @@
 VectorDB benchmark run rules checker.
 
 Validates VectorDB benchmark parameters for individual runs.
-Note: VectorDB is currently a preview benchmark, so all runs
-automatically receive OPEN status regardless of other validations.
 """
 
 from typing import Optional
@@ -23,10 +21,6 @@ class VectorDBRunRulesChecker(RunRulesChecker):
     - Index building and search operations
     - Concurrent query handling
     - Various distance metrics and index types
-
-    Currently in preview mode - all runs return OPEN status regardless
-    of other validation results, as the benchmark is not yet accepted
-    for closed submissions.
     """
 
     # Minimum requirements for valid VectorDB runs
@@ -58,16 +52,3 @@ class VectorDBRunRulesChecker(RunRulesChecker):
             )
 
         return None
-
-    def check_preview_status(self) -> Optional[Issue]:
-        """
-        Return informational issue that VectorDB is in preview.
-
-        This is always returned to inform users that this benchmark
-        is not yet accepted for closed submissions.
-        """
-        return Issue(
-            validation=PARAM_VALIDATION.OPEN,
-            message="VectorDB benchmark is in preview status - not accepted for closed submissions",
-            parameter="benchmark_status"
-        )

--- a/mlpstorage_py/rules/verifier.py
+++ b/mlpstorage_py/rules/verifier.py
@@ -113,7 +113,7 @@ class BenchmarkVerifier:
             elif benchmark_type == BENCHMARK_TYPES.checkpointing:
                 self.rules_checker = CheckpointSubmissionRulesChecker(self.benchmark_runs, logger=self.logger)
             elif benchmark_type == BENCHMARK_TYPES.kv_cache:
-                # KV Cache preview - use base multi-run checker
+                # KV Cache has no dedicated submission-rules checker; use base multi-run checker.
                 self.rules_checker = MultiRunRulesChecker(self.benchmark_runs, logger=self.logger)
             elif benchmark_type == BENCHMARK_TYPES.vector_database:
                 # VectorDB has no dedicated submission-rules checker; use base multi-run checker.

--- a/mlpstorage_py/rules/verifier.py
+++ b/mlpstorage_py/rules/verifier.py
@@ -116,7 +116,7 @@ class BenchmarkVerifier:
                 # KV Cache preview - use base multi-run checker
                 self.rules_checker = MultiRunRulesChecker(self.benchmark_runs, logger=self.logger)
             elif benchmark_type == BENCHMARK_TYPES.vector_database:
-                # VectorDB preview - use base multi-run checker
+                # VectorDB has no dedicated submission-rules checker; use base multi-run checker.
                 self.rules_checker = MultiRunRulesChecker(self.benchmark_runs, logger=self.logger)
             else:
                 raise ValueError(f"Unsupported benchmark type for multi-run: {benchmark_type}")

--- a/mlpstorage_py/validation_helpers.py
+++ b/mlpstorage_py/validation_helpers.py
@@ -392,11 +392,6 @@ def validate_closed_requirements(args, benchmark_type: str, logger=None) -> Tupl
             warnings.append("num_checkpoints should be >= 1")
             is_eligible = False
 
-    elif benchmark_type == 'kvcache':
-        # KV Cache is preview only - always OPEN
-        warnings.append("KV Cache benchmark is in preview status - qualifies for OPEN only")
-        is_eligible = False
-
     if logger and warnings:
         for warning in warnings:
             logger.warning(f"CLOSED requirement: {warning}")

--- a/tests/unit/test_rules_vectordb.py
+++ b/tests/unit/test_rules_vectordb.py
@@ -4,7 +4,6 @@ Tests for VectorDBRunRulesChecker in mlpstorage.rules module.
 Tests cover:
 - Benchmark type validation (valid and invalid)
 - Runtime validation (valid, insufficient, missing/default)
-- Preview status (always returns OPEN)
 - run_checks integration
 """
 
@@ -111,38 +110,24 @@ class TestVectorDBRunRulesChecker:
 
         assert issue is None
 
-    def test_check_preview_status_always_open(self, mock_logger, valid_vectordb_run):
-        """check_preview_status always returns OPEN issue with preview status message."""
-        checker = VectorDBRunRulesChecker(valid_vectordb_run, logger=mock_logger)
-        issue = checker.check_preview_status()
-
-        assert issue is not None
-        assert issue.validation == PARAM_VALIDATION.OPEN
-        assert "preview status" in issue.message.lower()
-
-    def test_run_checks_collects_all_issues(self, mock_logger, valid_vectordb_run):
-        """run_checks collects all issues from check methods."""
+    def test_run_checks_no_preview_issue(self, mock_logger, valid_vectordb_run):
+        """run_checks does not emit a preview-status issue (de-previewed)."""
         checker = VectorDBRunRulesChecker(valid_vectordb_run, logger=mock_logger)
         issues = checker.run_checks()
 
-        # Should have at least 1 issue (the preview status)
-        assert len(issues) >= 1
-        # Verify the preview status issue is included
         preview_issues = [i for i in issues if "preview" in i.message.lower()]
-        assert len(preview_issues) == 1
+        assert preview_issues == []
 
-    def test_all_valid_run_returns_open_due_to_preview(self, mock_logger, valid_vectordb_run):
-        """A valid VectorDB run returns OPEN (not CLOSED) due to preview status."""
+    def test_valid_run_is_closed_clean(self, mock_logger, valid_vectordb_run):
+        """A valid VectorDB run has no INVALID or OPEN issues — qualifies for CLOSED."""
         checker = VectorDBRunRulesChecker(valid_vectordb_run, logger=mock_logger)
         issues = checker.run_checks()
 
-        # No INVALID issues should be present for a valid run
         invalid_issues = [i for i in issues if i.validation == PARAM_VALIDATION.INVALID]
-        assert len(invalid_issues) == 0
+        assert invalid_issues == []
 
-        # At least one OPEN issue should be present (preview status)
         open_issues = [i for i in issues if i.validation == PARAM_VALIDATION.OPEN]
-        assert len(open_issues) >= 1
+        assert open_issues == []
 
     def test_check_benchmark_type_with_checkpointing(self, mock_logger):
         """check_benchmark_type returns INVALID for checkpointing benchmark."""


### PR DESCRIPTION
## Summary

- Commit dd17168 removed the preview mention from `vdb_benchmark/README.md` but left the runtime rule-checker in place, so every `closed vectordb` run was still auto-bumped to OPEN category via `VectorDBRunRulesChecker.check_preview_status()` (which unconditionally returned `Issue(validation=OPEN, ...)`).
- KV Cache had the identical pattern and is fixed the same way.
- Both checkers' `check_preview_status()` methods are deleted (the base class auto-discovers all `check_*` methods, so the only safe removal is to drop the method entirely).
- Knock-on cleanup: drops "(Preview)" / "Note: ... not yet accepted for CLOSED submissions" rows from `VECTORDB_REQUIREMENTS` and `KVCACHE_REQUIREMENTS` in the formatter, refreshes the misleading "preview - use base multi-run checker" comments in `verifier.py`, drops the dead kvcache branch in `validate_closed_requirements()`, and clears "(preview)" / "Preview of a VectorDB benchmark (not available in closed submissions)" from the CLI program descriptions.

## Files changed

| File | Change |
|---|---|
| `mlpstorage_py/rules/run_checkers/vectordb.py` | Delete `check_preview_status()`; drop preview text from docstrings |
| `mlpstorage_py/rules/run_checkers/kvcache.py` | Same as above for KV Cache |
| `mlpstorage_py/reporting/formatters.py` | Drop `(Preview)` from `VECTORDB_REQUIREMENTS` and `KVCACHE_REQUIREMENTS` titles + matching Note rows |
| `mlpstorage_py/rules/verifier.py` | Replace misleading `# VectorDB preview` / `# KV Cache preview` comments |
| `mlpstorage_py/validation_helpers.py` | Remove `elif benchmark_type == 'kvcache'` branch that unconditionally marked the benchmark CLOSED-ineligible |
| `mlpstorage_py/cli/common_args.py` | Drop `(preview)` from `kvcache` and `(Preview of a VectorDB benchmark ...)` from `vectordb` program descriptions |
| `tests/unit/test_rules_vectordb.py` | Delete `test_check_preview_status_always_open`; flip two tests to assert a valid run is CLOSED-clean |

Net: 13 insertions, 71 deletions across 7 files.

## Test plan

- [x] `pytest tests/unit/ --ignore=tests/unit/test_parquet_reader.py` — 1456 passed, 4 skipped, 0 failed (parquet ignore is for an unrelated `pyarrow` collection error pre-existing on main)
- [x] `pytest tests/unit/test_rules_vectordb.py -v` — 11 passed
- [x] Source-side preview sweep: `grep -rn "preview" mlpstorage_py/ | grep -iE "kv.cache|kvcache|vectordb|vector.database"` returns 0 matches
- [x] Branch verified standalone vs `origin/main` (no implicit dependencies on Phase 1/2 work)
- [ ] After merge: rerun `./mlpstorage closed vectordb run file --dry-run --results-dir /tmp/r1 --systemname sys-v1-vdb --vdb-engine milvus --vdb-index DISKANN` (requires Phase 2 CLI plumbing to invoke as shown) and confirm no `[OPEN] VectorDB benchmark is in preview status` line is emitted and the run is no longer bumped to OPEN category

## Notes

- `mlpstorage_py/rules_legacy.py` left untouched on purpose (different code path, marked legacy)
- The `validate_closed_requirements()` function in `validation_helpers.py` turned out to have no callers; only the kvcache-preview text was removed, the function itself was left in place to keep the diff minimal