### PR TITLE
fix(rules): distinguish tool-injected from user-supplied params in training validation (fixes #494)

### DIFF
--- a/mlpstorage_py/rules/run_checkers/training.py
+++ b/mlpstorage_py/rules/run_checkers/training.py
@@ -38,6 +38,30 @@ class TrainingRunRulesChecker(RunRulesChecker):
         'reader.data_loader',
     ]
 
+    # Parameters that the mlpstorage tool injects into the DLIO config without
+    # the user typing --params for them.  They show up in override_parameters
+    # alongside genuine user overrides because both share the same dotted-key
+    # surface, so check_allowed_params() must filter them out before deciding
+    # CLOSED-vs-OPEN-vs-INVALID — otherwise a closed run is marked INVALID for
+    # params the tool itself set (mlcommons/storage#494).
+    #
+    # When adding a new tool-side setter in mlpstorage_py/benchmarks/dlio.py
+    # (or anywhere that writes to self.params_dict outside of args.params),
+    # add the dotted-key here too.
+    TOOL_INJECTED_PARAMS = frozenset({
+        # _apply_skip_listing_params (#483)
+        'dataset.skip_listing',
+        'dataset.listing_validation_interval',
+        # add_datadir_param — derived from --data-dir + model
+        'dataset.data_folder',
+        # _apply_object_storage_params — derived from --object + BUCKET / env
+        'storage.storage_type',
+        'storage.storage_root',
+        'storage.storage_options.storage_library',
+        'storage.storage_options.uri_scheme',
+        'storage.s3_force_path_style',
+    })
+
     def check_benchmark_type(self) -> Optional[Issue]:
         """Verify this is a training benchmark."""
         if self.benchmark_run.benchmark_type != BENCHMARK_TYPES.training:
@@ -107,7 +131,10 @@ class TrainingRunRulesChecker(RunRulesChecker):
         Verify that only allowed parameters were overridden.
 
         Returns list of issues describing which parameters are allowed
-        for CLOSED, OPEN, or are invalid.
+        for CLOSED, OPEN, or are invalid.  Tool-injected params (see
+        TOOL_INJECTED_PARAMS) are reported under a separate "Tool-injected
+        parameter" message so reviewers can audit them, but never count as
+        user overrides for the CLOSED-vs-OPEN-vs-INVALID gate.
         """
         issues = []
         for param, value in self.benchmark_run.override_parameters.items():
@@ -117,7 +144,17 @@ class TrainingRunRulesChecker(RunRulesChecker):
 
             self.logger.debug(f"Processing override parameter: {param} = {value}")
 
-            if param in self.CLOSED_ALLOWED_PARAMS:
+            if param in self.TOOL_INJECTED_PARAMS:
+                # Tool-managed knob (skip_listing, object-storage backend,
+                # auto-resolved data_folder, etc).  Surface it for audit but
+                # don't subject it to the user-override allow-list.
+                issues.append(Issue(
+                    validation=PARAM_VALIDATION.CLOSED,
+                    message=f"Tool-injected parameter: {param} = {value}",
+                    parameter="Tool-Injected Parameters",
+                    actual=value
+                ))
+            elif param in self.CLOSED_ALLOWED_PARAMS:
                 issues.append(Issue(
                     validation=PARAM_VALIDATION.CLOSED,
                     message=f"Closed parameter override allowed: {param} = {value}",

--- a/tests/unit/test_rules_checkers.py
+++ b/tests/unit/test_rules_checkers.py
@@ -419,6 +419,72 @@ class TestTrainingRunRulesChecker:
 
         assert len(issues) == 0
 
+    def test_check_allowed_params_skip_listing_is_tool_injected(self, mock_logger):
+        """Regression for #494: skip_listing pair is reported as tool-injected,
+        not as an invalid user override."""
+        data = BenchmarkRunData(
+            benchmark_type=BENCHMARK_TYPES.training,
+            model="retinanet",
+            command="run",
+            run_datetime="20250111_143022",
+            num_processes=40,
+            parameters={
+                "dataset": {"num_files_train": 5319553, "num_subfolders_train": 532},
+                "reader": {"read_threads": 8}
+            },
+            override_parameters={
+                # The two #494 culprits — tool-injected for large datasets:
+                "dataset.skip_listing": "True",
+                "dataset.listing_validation_interval": "1000",
+                # Mixed with a genuine user override (closed-allowed):
+                "dataset.num_files_train": "5319553",
+            }
+        )
+        run = BenchmarkRun.from_data(data, mock_logger)
+        checker = TrainingRunRulesChecker(run, logger=mock_logger)
+        issues = checker.check_allowed_params()
+
+        # Three issues: two tool-injected, one closed-allowed user override.
+        # The critical assertion: zero INVALID issues (the pre-fix behavior
+        # produced two INVALID issues for skip_listing + listing_validation_interval).
+        assert all(i.validation != PARAM_VALIDATION.INVALID for i in issues), (
+            f"Tool-injected params must not be marked INVALID; got: "
+            f"{[(i.message, i.validation) for i in issues]}"
+        )
+        tool_msgs = [i for i in issues if i.message.startswith("Tool-injected parameter:")]
+        closed_msgs = [i for i in issues if i.message.startswith("Closed parameter override allowed:")]
+        assert len(tool_msgs) == 2
+        assert len(closed_msgs) == 1
+        # Both tool-injected lines carry CLOSED validation so they never gate the run.
+        assert all(i.validation == PARAM_VALIDATION.CLOSED for i in tool_msgs)
+        # Tool-injected issues report under a distinct parameter label so the
+        # run-summary log can section them off from genuine user overrides.
+        assert all(i.parameter == "Tool-Injected Parameters" for i in tool_msgs)
+        assert all(i.parameter == "Overrode Parameters" for i in closed_msgs)
+
+    def test_tool_injected_params_constant_includes_storage_keys(self):
+        """All known tool-side setters in dlio.py must have their keys listed.
+        Drift between the setters and this constant re-introduces #494-class bugs."""
+        from mlpstorage_py.rules.run_checkers.training import TrainingRunRulesChecker
+
+        # Keys touched by _apply_object_storage_params in dlio.py.
+        for key in ("storage.storage_type", "storage.storage_root",
+                    "storage.storage_options.storage_library",
+                    "storage.storage_options.uri_scheme",
+                    "storage.s3_force_path_style"):
+            assert key in TrainingRunRulesChecker.TOOL_INJECTED_PARAMS, (
+                f"{key} is written by _apply_object_storage_params but missing "
+                f"from TOOL_INJECTED_PARAMS — closed-mode object-storage runs "
+                f"will be flagged INVALID."
+            )
+
+        # Keys touched by _apply_skip_listing_params (#483, #494).
+        for key in ("dataset.skip_listing", "dataset.listing_validation_interval"):
+            assert key in TrainingRunRulesChecker.TOOL_INJECTED_PARAMS
+
+        # Key touched by add_datadir_param.
+        assert "dataset.data_folder" in TrainingRunRulesChecker.TOOL_INJECTED_PARAMS
+
     def test_check_odirect_unsupported_model(self, mock_logger):
         """check_odirect_supported_model returns INVALID for non-unet3d."""
         data = BenchmarkRunData(


### PR DESCRIPTION
## Summary

Fixes #494 — `RetinaNet closed run becomes INVALID due to automatic skip_listing parameter overrides`.

PR #483 added `_apply_skip_listing_params()` in `dlio.py`, which unconditionally writes `dataset.skip_listing` and `dataset.listing_validation_interval` into `self.params_dict` for every training run. `BenchmarkRunData.from_benchmark()` then maps `params_dict → override_parameters`, conflating user-supplied `--params` with tool-managed internal knobs. `TrainingRunRulesChecker.check_allowed_params()` treats both kinds the same and flags the skip_listing pair as INVALID in closed mode, even though the user never typed them.

## Approach

Centralise the list of tool-injected dotted-keys on `TrainingRunRulesChecker` and filter them out of the user-override allow-list:

```python
TOOL_INJECTED_PARAMS = frozenset({
    'dataset.skip_listing',                     # _apply_skip_listing_params (#483)
    'dataset.listing_validation_interval',
    'dataset.data_folder',                      # add_datadir_param
    'storage.storage_type',                     # _apply_object_storage_params
    'storage.storage_root',
    'storage.storage_options.storage_library',
    'storage.storage_options.uri_scheme',
    'storage.s3_force_path_style',
})
```

`check_allowed_params` branches on this first. Matching keys emit a `Tool-injected parameter: <key> = <value>` issue under a distinct `parameter="Tool-Injected Parameters"` label (vs. the existing `"Overrode Parameters"`) — so the verifier's summary log can section them off from genuine user overrides. They're still classified as `PARAM_VALIDATION.CLOSED` so they never gate a run.

## Why centralised instead of provenance-tracked (Option 1)

The alternative was threading a `tool_injected_keys: set[str]` through every tool-side setter in `dlio.py` (`_set_tool_param` helper) and through metadata serialisation. That has the same operational effect with more moving parts. Centralising it in the checker captures the same semantic distinction (tool-managed vs user-supplied) with fewer surfaces to keep in sync.

**Drift risk:** when adding a new tool-side setter in `dlio.py`, also add the dotted-key to `TOOL_INJECTED_PARAMS`. A comment on the constant flags this contract, and a drift-guard test enumerates every key written by the known setters.

## Scope

Training only. Checkpointing's `add_checkpoint_params` also writes derived keys (`checkpoint.mode`, `checkpoint.num_checkpoints_*`, etc.) but the checkpointing rule checker doesn't currently use a `CLOSED_ALLOWED_PARAMS`-style gate, so #494 doesn't manifest there. If checkpointing grows a similar gate, the same approach applies.

## Test plan

- [x] `pytest tests/unit/test_rules_checkers.py` — 46 pass, including two new cases:
  - `test_check_allowed_params_skip_listing_is_tool_injected`: the exact scenario from #494 (skip_listing + listing_validation_interval + num_files_train override) produces zero INVALID issues, two `Tool-injected parameter` issues, and one `Closed parameter override allowed` issue.
  - `test_tool_injected_params_constant_includes_storage_keys`: drift guard asserting every key written by the known `dlio.py` setters is in `TOOL_INJECTED_PARAMS`.
- [x] `pytest tests/unit --ignore=...` — 1376 pass, 4 skipped, 0 failures.
- [ ] Manual: rerun the command from #494 (`mlpstorage closed training retinanet run file --num-files_train=5319553 ...`); verify the run completes as CLOSED-valid and the log shows two `Tool-injected parameter:` lines for skip_listing / listing_validation_interval, with `dataset.num_files_train` still under `Closed parameter override allowed`.

## Log output, before vs after

Before (#494):
```
STATUS: Closed: [CLOSED] Closed parameter override allowed: dataset.num_files_train = 5319553
ERROR: INVALID: [INVALID] Disallowed parameter override: dataset.skip_listing = True
ERROR: INVALID: [INVALID] Disallowed parameter override: dataset.listing_validation_interval = 1000
STATUS: Benchmark run is INVALID due to 2 issues
```

After:
```
STATUS: Closed: [CLOSED] Closed parameter override allowed: dataset.num_files_train = 5319553
STATUS: Closed: [CLOSED] Tool-injected parameter: dataset.skip_listing = True
STATUS: Closed: [CLOSED] Tool-injected parameter: dataset.listing_validation_interval = 1000
STATUS: Benchmark run qualifies for CLOSED category
```