### PR TITLE
Fix #463: apply nested index_params and default-valued config keys

### DIFF
--- a/configs/vectordbbench/10m.yaml
+++ b/configs/vectordbbench/10m.yaml
@@ -19,8 +19,9 @@ index:
   index_type: DISKANN
   metric_type: COSINE
   index_params:
-    M: 64
-    ef_construction: 200
+    max_degree: 64
+    search_list_size: 200
 
 workflow:
   compact: True
+

--- a/configs/vectordbbench/default.yaml
+++ b/configs/vectordbbench/default.yaml
@@ -19,8 +19,8 @@ index:
   index_type: DISKANN
   metric_type: COSINE
   index_params:
-    M: 64
-    ef_construction: 200
+    max_degree: 64
+    search_list_size: 200
 
 workflow:
   compact: True
@@ -32,3 +32,4 @@ benchmark:
   report_count: 100
   recall_k: 10
   search_limit: 10
+

--- a/vdb_benchmark/tests/tests/test_issue_463_nested_index_params.py
+++ b/vdb_benchmark/tests/tests/test_issue_463_nested_index_params.py
@@ -127,3 +127,63 @@ def test_empty_config_is_noop():
     out = merge_config_with_args({}, args)
     assert out.M == 16 and out.index_type == "DISKANN"
 
+
+def test_cross_section_same_leaf_does_not_collide():
+    """
+    dataset.batch_size and benchmark.batch_size both exist in the shipped
+    configs. They mean different things and must not collapse into one value.
+    The earlier section (dataset) wins for the shared argparse dest.
+
+    Regression for PR #497 review (ram-sangle): _flatten_config must not let a
+    later section silently overwrite an earlier same-named leaf.
+    """
+    cfg = yaml.safe_load("""
+    dataset:
+      batch_size: 10
+    benchmark:
+      batch_size: 1
+    """)
+    flat = _flatten_config(cfg)
+    assert flat["batch_size"] == 10  # dataset (earlier) wins, not benchmark
+
+
+def test_intra_section_index_params_collision_raises():
+    """
+    A collision *within* one section (a section-level key duplicated by a key
+    nested under index_params) is a genuine mistake and must surface, not be
+    silently resolved.
+    """
+    import pytest
+
+    cfg = yaml.safe_load("""
+    index:
+      index_type: HNSW
+      M: 16
+      index_params:
+        M: 64
+    """)
+    with pytest.raises(ValueError):
+        _flatten_config(cfg)
+
+
+def test_diskann_config_uses_diskann_params():
+    """
+    The shipped DISKANN configs must declare max_degree/search_list_size, not
+    HNSW's M/ef_construction. Regression for PR #497 review (ram-sangle).
+    """
+    cfg = yaml.safe_load("""
+    index:
+      index_type: DISKANN
+      metric_type: COSINE
+      index_params:
+        max_degree: 64
+        search_list_size: 200
+    """)
+    args = merge_config_with_args(cfg, _make_args())
+    assert args.index_type == "DISKANN"
+    assert args.max_degree == 64
+    assert args.search_list_size == 200
+    # HNSW params remain at their defaults, untouched.
+    assert args.M == 16
+    assert args.ef_construction == 200
+

--- a/vdb_benchmark/tests/tests/test_issue_463_nested_index_params.py
+++ b/vdb_benchmark/tests/tests/test_issue_463_nested_index_params.py
@@ -1,0 +1,129 @@
+"""
+Regression tests for issue #463:
+vdb_benchmark indexing parameter values from config files were not getting used.
+
+Two root causes:
+  1. Index tuning parameters nested under an `index_params:` block were
+     silently dropped by merge_config_with_args (only one level was walked).
+  2. A config value equal to the argparse default was treated as "still
+     default" and not applied.
+
+See: https://github.com/mlcommons/storage/issues/463
+"""
+import argparse
+
+import yaml
+
+from vdbbench.config_loader import merge_config_with_args, _flatten_config
+
+
+def _make_args():
+    args = argparse.Namespace(
+        index_type="DISKANN", metric_type="COSINE",
+        M=16, ef_construction=200, max_degree=16, search_list_size=200,
+        collection_name=None, num_vectors=None, dimension=None,
+    )
+    args.is_default = {
+        "index_type": True, "metric_type": True, "M": True,
+        "ef_construction": True, "max_degree": True, "search_list_size": True,
+        "collection_name": True, "num_vectors": True, "dimension": True,
+    }
+    return args
+
+
+def test_nested_index_params_are_applied():
+    cfg = yaml.safe_load("""
+    index:
+      index_type: HNSW
+      metric_type: COSINE
+      index_params:
+        M: 32
+        ef_construction: 100
+    """)
+    args = merge_config_with_args(cfg, _make_args())
+    assert args.index_type == "HNSW"
+    assert args.M == 32
+    assert args.ef_construction == 100
+
+
+def test_flat_index_params_still_work():
+    cfg = yaml.safe_load("""
+    index:
+      index_type: HNSW
+      M: 64
+      ef_construction: 200
+    """)
+    args = merge_config_with_args(cfg, _make_args())
+    assert args.M == 64
+    assert args.ef_construction == 200
+
+
+def test_config_value_equal_to_default_is_applied():
+    cfg = yaml.safe_load("""
+    index:
+      index_type: HNSW
+      M: 16
+      ef_construction: 100
+    """)
+    args = merge_config_with_args(cfg, _make_args())
+    assert args.M == 16
+    assert args.ef_construction == 100
+
+
+def test_cli_flag_overrides_config():
+    cfg = yaml.safe_load("""
+    index:
+      index_type: HNSW
+      index_params:
+        M: 32
+        ef_construction: 100
+    """)
+    args = _make_args()
+    args.M = 99               # user passed --M 99
+    args.is_default["M"] = False
+    merge_config_with_args(cfg, args)
+    assert args.M == 99
+    assert args.ef_construction == 100
+
+
+def test_diskann_nested_params():
+    cfg = yaml.safe_load("""
+    index:
+      index_type: DISKANN
+      index_params:
+        max_degree: 96
+        search_list_size: 250
+    """)
+    args = merge_config_with_args(cfg, _make_args())
+    assert args.max_degree == 96
+    assert args.search_list_size == 250
+
+
+def test_unknown_config_keys_are_ignored():
+    cfg = yaml.safe_load("""
+    database:
+      max_receive_message_length: 514983574
+    index:
+      index_type: HNSW
+      index_params:
+        M: 48
+    """)
+    args = merge_config_with_args(cfg, _make_args())
+    assert args.M == 48
+
+
+def test_flatten_lifts_nested_leaves():
+    flat = _flatten_config(yaml.safe_load("""
+    index:
+      index_type: HNSW
+      index_params:
+        M: 32
+    """))
+    assert flat == {"index_type": "HNSW", "M": 32}
+
+
+def test_empty_config_is_noop():
+    args = _make_args()
+    out = merge_config_with_args({}, args)
+    assert out.M == 16 and out.index_type == "DISKANN"
+

--- a/vdb_benchmark/vdbbench/config_loader.py
+++ b/vdb_benchmark/vdbbench/config_loader.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 import yaml
 import os
- 
- 
+
+
 def load_config(config_file=None):
     """
     Load configuration from a YAML file.
- 
+
     Args:
         config_file (str): Path to the YAML configuration file
- 
+
     Returns:
         dict: Configuration dictionary or empty dict if file not found
     """
     if not config_file:
         return {}
- 
+
     path_exists = os.path.exists(config_file)
     configs_path_exists = os.path.exists(os.path.join("configs", config_file))
     if path_exists or configs_path_exists:
@@ -23,7 +23,7 @@ def load_config(config_file=None):
     else:
         print(f"ERROR: Configuration file not found: {config_file}")
         return {}
- 
+
     try:
         with open(config_file, 'r') as f:
             config = yaml.safe_load(f)
@@ -32,91 +32,151 @@ def load_config(config_file=None):
     except Exception as e:
         print(f"ERROR - Error loading configuration file: {str(e)}")
         return {}
- 
- 
-def _flatten_config(config):
+
+
+def _flatten_section(section, section_name=None):
     """
-    Flatten a (possibly nested) configuration dict into a single-level
-    mapping of leaf parameter name -> value.
- 
-    The vdbbench YAML configs group parameters into sections
-    (database, dataset, index, workflow, ...) and may additionally nest
-    index tuning parameters under an ``index_params:`` block, e.g.::
- 
+    Flatten a single configuration *section* into a one-level mapping of
+    leaf parameter name -> value.
+
+    The vdbbench YAML configs group parameters into top-level sections
+    (database, dataset, index, workflow, benchmark, ...) and may additionally
+    nest index tuning parameters under an ``index_params:`` block, e.g.::
+
         index:
           index_type: HNSW
           index_params:
             M: 32
             ef_construction: 100
- 
-    Argparse, however, exposes those tuning parameters as top-level flags
-    (``--M``, ``--ef-construction``). Without flattening, the inner
-    ``index_params`` dict is seen as a single unknown key and silently
-    dropped, so the values never reach the parsed args. Flattening walks
-    every nested dict and lifts each leaf key to the top level.
- 
-    Later (deeper) keys win on collision, which is harmless here because the
-    config files do not reuse leaf names across sections.
- 
+
+    Argparse exposes those tuning parameters as top-level flags (``--M``,
+    ``--ef-construction``). Without flattening, the inner ``index_params``
+    dict is seen as a single unknown key and silently dropped, so the values
+    never reach the parsed args.
+
+    Flattening is performed **per section**, not globally, to avoid collapsing
+    same-named leaf keys that legitimately live in different sections (for
+    example ``dataset.batch_size`` and ``benchmark.batch_size``). Collisions
+    are only possible within a single section (between a section-level key and
+    a key nested under ``index_params:``); those are unexpected, so we raise
+    rather than silently pick a winner.
+
     Args:
-        config (dict): Configuration dictionary loaded from YAML.
- 
+        section (dict): One top-level section of the config.
+        section_name (str): Name of the section, used for error messages.
+
     Returns:
-        dict: Flat mapping of parameter name -> value.
+        dict: Flat mapping of leaf parameter name -> value for this section.
     """
     flat = {}
- 
+
     def _walk(node):
         if isinstance(node, dict):
             for key, value in node.items():
                 if isinstance(value, dict):
                     _walk(value)
                 else:
+                    if key in flat and flat[key] != value:
+                        raise ValueError(
+                            f"Conflicting values for '{key}' within config "
+                            f"section '{section_name}': {flat[key]!r} vs "
+                            f"{value!r}. Rename one of the keys."
+                        )
                     flat[key] = value
- 
-    _walk(config)
+
+    _walk(section)
     return flat
- 
- 
+
+
+def _flatten_config(config):
+    """
+    Flatten a (possibly nested) configuration dict into a single-level
+    mapping of leaf parameter name -> value, flattening each top-level
+    section independently.
+
+    Flattening section-by-section (rather than over the whole document at
+    once) prevents a leaf key in one section from silently overwriting a
+    same-named key in another section. If the *same* leaf name appears in two
+    different sections, the first occurrence (in document order) is kept and a
+    warning is printed, because such cross-section duplication is almost always
+    a mistake for the keys vdbbench consumes.
+
+    Args:
+        config (dict): Configuration dictionary loaded from YAML.
+
+    Returns:
+        dict: Flat mapping of parameter name -> value.
+    """
+    flat = {}
+
+    if not isinstance(config, dict):
+        return flat
+
+    for section_name, section in config.items():
+        if isinstance(section, dict):
+            section_flat = _flatten_section(section, section_name)
+        else:
+            # Top-level scalar (rare); keep as-is.
+            section_flat = {section_name: section}
+
+        for key, value in section_flat.items():
+            if key in flat and flat[key] != value:
+                # The same leaf name appears in two sections (e.g.
+                # dataset.batch_size vs benchmark.batch_size). These denote
+                # different things for different consumers, so we must NOT let
+                # a later section silently clobber an earlier one. Keep the
+                # first occurrence (document order) and warn.
+                print(
+                    f"WARNING - configuration key '{key}' appears in multiple "
+                    f"sections; keeping value {flat[key]!r} from the earlier "
+                    f"section and ignoring {value!r} from section "
+                    f"'{section_name}'."
+                )
+                continue
+            flat[key] = value
+
+    return flat
+
+
 def merge_config_with_args(config, args):
     """
     Merge configuration from YAML into parsed command line arguments.
- 
+
     Precedence (highest first):
         1. Arguments explicitly provided on the command line.
         2. Values from the YAML configuration file.
         3. Argparse defaults.
- 
+
     This means a value present in the config file is always applied unless
     the user also passed that flag explicitly on the command line, even when
     the config value happens to equal the argparse default.
- 
+
     Explicit-CLI detection relies on ``args.is_default`` when present (a dict
     of ``{arg_name: True_if_still_default}`` maintained by the callers). When
     that map is unavailable, config values fill only args that are currently
     ``None``.
- 
+
     Args:
         config (dict): Configuration dictionary from YAML (may be nested).
         args (Namespace): Parsed command line arguments.
- 
+
     Returns:
         Namespace: Updated arguments with values applied from config.
     """
     if not config:
         return args
- 
+
     args_dict = vars(args)
     is_default = getattr(args, 'is_default', None)
     flat_config = _flatten_config(config)
- 
+
     for key, value in flat_config.items():
         if key not in args_dict:
             # Config keys that are not exposed as CLI args (e.g. database
             # connection tuning like max_receive_message_length) are ignored
             # here; callers consume those directly from the config dict.
             continue
- 
+
         if is_default is not None:
             # Apply config unless the user explicitly set this flag on the CLI.
             # An arg is "explicitly set" when is_default reports False for it.
@@ -127,5 +187,6 @@ def merge_config_with_args(config, args):
             # No explicit-vs-default tracking available: only fill holes.
             if args_dict[key] is None:
                 args_dict[key] = value
- 
+
     return args
+

--- a/vdb_benchmark/vdbbench/config_loader.py
+++ b/vdb_benchmark/vdbbench/config_loader.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
 import yaml
 import os
-
+ 
+ 
 def load_config(config_file=None):
     """
     Load configuration from a YAML file.
-    
+ 
     Args:
         config_file (str): Path to the YAML configuration file
-        
+ 
     Returns:
         dict: Configuration dictionary or empty dict if file not found
     """
     if not config_file:
         return {}
-
+ 
     path_exists = os.path.exists(config_file)
     configs_path_exists = os.path.exists(os.path.join("configs", config_file))
     if path_exists or configs_path_exists:
@@ -22,40 +23,109 @@ def load_config(config_file=None):
     else:
         print(f"ERROR: Configuration file not found: {config_file}")
         return {}
-        
+ 
     try:
         with open(config_file, 'r') as f:
             config = yaml.safe_load(f)
             print(f"Loaded vdbbench configuration from {config_file}")
             return config
     except Exception as e:
-        print("ERROR - Error loading configuration file: {str(e)}")
+        print(f"ERROR - Error loading configuration file: {str(e)}")
         return {}
-
-
+ 
+ 
+def _flatten_config(config):
+    """
+    Flatten a (possibly nested) configuration dict into a single-level
+    mapping of leaf parameter name -> value.
+ 
+    The vdbbench YAML configs group parameters into sections
+    (database, dataset, index, workflow, ...) and may additionally nest
+    index tuning parameters under an ``index_params:`` block, e.g.::
+ 
+        index:
+          index_type: HNSW
+          index_params:
+            M: 32
+            ef_construction: 100
+ 
+    Argparse, however, exposes those tuning parameters as top-level flags
+    (``--M``, ``--ef-construction``). Without flattening, the inner
+    ``index_params`` dict is seen as a single unknown key and silently
+    dropped, so the values never reach the parsed args. Flattening walks
+    every nested dict and lifts each leaf key to the top level.
+ 
+    Later (deeper) keys win on collision, which is harmless here because the
+    config files do not reuse leaf names across sections.
+ 
+    Args:
+        config (dict): Configuration dictionary loaded from YAML.
+ 
+    Returns:
+        dict: Flat mapping of parameter name -> value.
+    """
+    flat = {}
+ 
+    def _walk(node):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if isinstance(value, dict):
+                    _walk(value)
+                else:
+                    flat[key] = value
+ 
+    _walk(config)
+    return flat
+ 
+ 
 def merge_config_with_args(config, args):
     """
-    Merge configuration from YAML with command line arguments.
-    Command line arguments take precedence over YAML configuration.
-    
+    Merge configuration from YAML into parsed command line arguments.
+ 
+    Precedence (highest first):
+        1. Arguments explicitly provided on the command line.
+        2. Values from the YAML configuration file.
+        3. Argparse defaults.
+ 
+    This means a value present in the config file is always applied unless
+    the user also passed that flag explicitly on the command line, even when
+    the config value happens to equal the argparse default.
+ 
+    Explicit-CLI detection relies on ``args.is_default`` when present (a dict
+    of ``{arg_name: True_if_still_default}`` maintained by the callers). When
+    that map is unavailable, config values fill only args that are currently
+    ``None``.
+ 
     Args:
-        config (dict): Configuration dictionary from YAML
-        args (Namespace): Parsed command line arguments
-        
+        config (dict): Configuration dictionary from YAML (may be nested).
+        args (Namespace): Parsed command line arguments.
+ 
     Returns:
-        Namespace: Updated arguments with values from config where not specified in args
+        Namespace: Updated arguments with values applied from config.
     """
-    # Convert args to a dictionary
+    if not config:
+        return args
+ 
     args_dict = vars(args)
-
-    # For each key in config, if the corresponding arg is None or has a default value,
-    # update it with the value from config
-    for section, params in config.items():
-        for key, value in params.items():
-            if key in args_dict and (args_dict[key] is None or
-                                     (hasattr(args, 'is_default') and
-                                      key in args.is_default and
-                                      args.is_default[key])):
+    is_default = getattr(args, 'is_default', None)
+    flat_config = _flatten_config(config)
+ 
+    for key, value in flat_config.items():
+        if key not in args_dict:
+            # Config keys that are not exposed as CLI args (e.g. database
+            # connection tuning like max_receive_message_length) are ignored
+            # here; callers consume those directly from the config dict.
+            continue
+ 
+        if is_default is not None:
+            # Apply config unless the user explicitly set this flag on the CLI.
+            # An arg is "explicitly set" when is_default reports False for it.
+            cli_explicit = (key in is_default) and (not is_default[key])
+            if not cli_explicit:
                 args_dict[key] = value
-    
+        else:
+            # No explicit-vs-default tracking available: only fill holes.
+            if args_dict[key] is None:
+                args_dict[key] = value
+ 
     return args


### PR DESCRIPTION
Fix #463: vdb_benchmark config index params (nested + default-valued) not applied:

1. Root cause 1 — nested index_params: is silently dropped. `merge_config_with_args` loops for section, params in config.items() then for key, value in params.items(), i.e. exactly two levels. When tuning params are nested as index: { index_params: { M, ef_construction } }, the inner loop sees key="index_params" with a dict value. index_params is not an argparse destination, so the whole block is skipped and M/ef_construction stay at their argparse defaults (16/200). That is precisely the log line in the issue: index_type updates to HNSW (it sits one level up, so it merges), but M/efConstruction revert to 16/200.

2. Root cause 2 — config values equal to the argparse default are ignored. The merge only writes a config value when the arg is None or is_default[key] is True. It can't distinguish "user typed --M 16" from "config asked for 16," and a config value that happens to equal the default is treated as still-default and dropped. This bites flat configs too.

Note main's flat configs (M/ef_construction directly under index:) merge correctly today because they aren't nested — so the bug surfaces whenever someone uses the index_params: nesting shown in the issue, or sets a value matching a default.

### Fix
In `vdb_benchmark/vdbbench/config_loader.py`:

1. Added `_flatten_config()` that recursively lifts every leaf key to the top level, so index_params.M becomes M.
Reworked precedence to: explicit CLI flag > YAML config > argparse default. A YAML value is now always applied unless the user explicitly set that flag on the CLI (detected via the existing args.is_default map). Unknown config keys (e.g. max_receive_message_length) are ignored exactly as before, and callers that consume those directly from the config dict are unaffected.

This single change fixes every caller (`load_vdb`, `simple_bench`, `enhanced_bench`, `mpi_wrapper`, `compact_and_watch`), since they all share this function. Added 8 regression tests in 1tests/tests/test_issue_463_nested_index_params.py`.
