### PR TITLE
fix(kvcache): honor --num-processes for cluster rank count (#500)

### DIFF
--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -260,8 +260,9 @@ class KVCacheBenchmark(Benchmark):
         config = config_arg
 
         hosts = getattr(self.args, 'hosts', None) or ['localhost']
-        npernode = getattr(self.args, 'npernode', 1)
-        total_ranks = npernode * len(hosts)
+        npernode, total_ranks = self._resolve_rank_layout(hosts)
+        if total_ranks is None:
+            return 1  # error already logged
         cache_dir = (
             getattr(self.args, 'cache_dir', None)
             or str(Path(self.run_result_output) / 'kvcache_cache')
@@ -374,6 +375,63 @@ class KVCacheBenchmark(Benchmark):
         for key, value in params.items():
             out.extend([f'--{key}', str(value)])
         return out
+
+    def _resolve_rank_layout(self, hosts):
+        """Resolve (npernode, total_ranks) from user-supplied --num-processes and
+        --npernode, given the host list. Issue #500.
+
+        Semantics:
+          - `--num-processes` is total ranks across the cluster (matches the flag's
+            existing help text and DLIO's `--num-accelerators` convention).
+          - `--npernode` is ranks per host.
+          - If only `--num-processes` is set, `npernode = num_processes // len(hosts)`;
+            num_processes must divide evenly across hosts.
+          - If only `--npernode` is set, `total_ranks = npernode * len(hosts)`
+            (today's behavior — preserves backward compat for existing users).
+          - If both are set, they must be consistent
+            (`num_processes == npernode * len(hosts)`); otherwise the run fails.
+          - If neither is set, defaults to one rank per host.
+
+        Returns:
+            (npernode, total_ranks) on success, or (None, None) after logging
+            an error on inconsistent / non-divisible input.
+        """
+        host_count = len(hosts)
+        np_arg = getattr(self.args, 'num_processes', None)
+        npn_arg = getattr(self.args, 'npernode', None)
+
+        if np_arg is not None and npn_arg is not None and npn_arg != 1:
+            # Both explicitly set — require consistency. npn_arg defaults to 1
+            # in the CLI builder, so we only treat npernode as "explicitly set"
+            # when it diverges from the default to keep CLI default behavior
+            # backward-compatible.
+            if np_arg != npn_arg * host_count:
+                self.logger.error(
+                    f"--num-processes ({np_arg}) and --npernode ({npn_arg}) are "
+                    f"inconsistent for {host_count} host(s): "
+                    f"expected num_processes == npernode * len(hosts) "
+                    f"({npn_arg * host_count}). Pass only one of the two, or "
+                    f"set them to consistent values."
+                )
+                return None, None
+            return npn_arg, np_arg
+
+        if np_arg is not None:
+            if np_arg <= 0:
+                self.logger.error(f"--num-processes must be positive, got {np_arg}")
+                return None, None
+            if np_arg % host_count != 0:
+                self.logger.error(
+                    f"--num-processes ({np_arg}) must divide evenly across "
+                    f"--hosts ({host_count} host(s)). Adjust --num-processes or "
+                    f"the host list so num_processes %% len(hosts) == 0."
+                )
+                return None, None
+            return np_arg // host_count, np_arg
+
+        # np_arg is None: fall back to --npernode (default 1)
+        npernode = npn_arg if npn_arg is not None else 1
+        return npernode, npernode * host_count
 
     def _execute_datasize(self) -> int:
         """Calculate memory requirements for KV cache.

--- a/mlpstorage_py/cli/kvcache_args.py
+++ b/mlpstorage_py/cli/kvcache_args.py
@@ -67,7 +67,11 @@ KVCACHE_HELP_MESSAGES = {
         "OPEN submissions only — fixed at 42 in CLOSED."
     ),
     'kvcache_bin_path': "Path to kv-cache.py script. Auto-detected if not specified.",
-    'npernode': "Number of kv-cache instances per client host (ranks per node).",
+    'npernode': (
+        "Number of kv-cache instances per client host (ranks per node). "
+        "Total cluster ranks = npernode * len(hosts). Use either this or "
+        "--num-processes; if both are set they must be consistent."
+    ),
     'trials': (
         "Number of trial runs per option (default 3). "
         "OPEN submissions only — fixed at 3 in CLOSED."
@@ -378,7 +382,12 @@ def _add_kvcache_distributed_arguments(parser):
     distributed_group.add_argument(
         '--num-processes', '-np',
         type=int,
-        help="Number of MPI processes (ranks) to spawn for distributed execution."
+        help=(
+            "Total number of MPI processes (ranks) to spawn across all hosts. "
+            "Must divide evenly by --hosts count; per-host rank count is "
+            "derived as num_processes // len(hosts). Use either this or "
+            "--npernode; if both are set they must be consistent."
+        )
     )
 
     # Add host arguments from common_args

--- a/mlpstorage_py/config.py
+++ b/mlpstorage_py/config.py
@@ -144,10 +144,21 @@ ALLOW_RUN_AS_ROOT = True
 
 MAX_NUM_FILES_TRAIN = 128*1024
 
-DEFAULT_RESULTS_DIR = os.environ.get(
-    "MLPERF_RESULTS_DIR",
-    os.path.join(tempfile.gettempdir(), "mlperf_storage_results"),
-)
+def _resolve_default_results_dir() -> str:
+    """Resolve DEFAULT_RESULTS_DIR from MLPERF_RESULTS_DIR or tempdir.
+
+    Extracted so tests can exercise the env-driven branch without
+    reloading this module — reload re-creates the PARAM_VALIDATION enum
+    class, which then fails `in`-checks against any pre-imported copy
+    held by other modules (notably the rules verifier).
+    """
+    return os.environ.get(
+        "MLPERF_RESULTS_DIR",
+        os.path.join(tempfile.gettempdir(), "mlperf_storage_results"),
+    )
+
+
+DEFAULT_RESULTS_DIR = _resolve_default_results_dir()
 
 import enum
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.17"
+version = "3.0.18"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -18,9 +18,13 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch, PropertyMock, call
 from argparse import Namespace
 
-# Stub out optional heavy deps so benchmark imports succeed without the full ML stack
+# Stub out optional heavy deps so benchmark imports succeed without the full
+# ML stack. Use importlib.util.find_spec — checking sys.modules alone would
+# install a MagicMock for a perfectly importable module that just hasn't been
+# imported yet, which then poisons later test collections (e.g. test_parquet_reader).
+import importlib.util as _ilu
 for _dep in ('pyarrow', 'pyarrow.ipc', 'psutil'):
-    if _dep not in sys.modules:
+    if _ilu.find_spec(_dep) is None and _dep not in sys.modules:
         sys.modules[_dep] = MagicMock()
 
 from mlpstorage_py.config import BENCHMARK_TYPES, EXEC_TYPE

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -1341,3 +1341,138 @@ class TestWrapperCommandForwardsPerOptionArgs:
         # And the wrapper-adjacent default must NOT also be present.
         assert 'kv_cache_benchmark/config.yaml' not in cmd0, \
             f"Default config path leaked into cmd alongside user override: {cmd0}"
+
+
+class TestResolveRankLayout:
+    """Tests for KVCacheBenchmark._resolve_rank_layout (issue #500).
+
+    --num-processes was previously a dead flag — registered on the kvcache
+    distributed-execution group but never read by _execute_run. Total ranks
+    were computed solely from npernode * len(hosts), so a user passing
+    --num-processes 2 with the default --npernode 1 still got one rank per
+    host. This class covers the new resolver semantics:
+
+      - --num-processes is total cluster ranks (matches the flag's help
+        text and DLIO's --num-accelerators convention).
+      - --npernode is ranks per host.
+      - When only one is set, the other is derived.
+      - When both are set, they must be consistent.
+      - --num-processes must divide evenly across the host list.
+    """
+
+    def test_only_npernode_uses_today_behavior(self, tmp_path):
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.num_processes = None
+        bm.args.npernode = 4
+        npn, total = bm._resolve_rank_layout(['h1', 'h2'])
+        assert npn == 4
+        assert total == 8
+
+    def test_only_num_processes_single_host(self, tmp_path):
+        """The exact scenario dslik reproduced in issue #500."""
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.num_processes = 2
+        bm.args.npernode = 1  # the CLI default — treated as 'not explicitly set'
+        npn, total = bm._resolve_rank_layout(['localhost'])
+        assert total == 2, "num_processes=2 with one host must produce 2 total ranks"
+        assert npn == 2
+
+    def test_only_num_processes_multi_host_even_divide(self, tmp_path):
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.num_processes = 8
+        bm.args.npernode = 1
+        npn, total = bm._resolve_rank_layout(['h1', 'h2', 'h3', 'h4'])
+        assert total == 8
+        assert npn == 2
+
+    def test_num_processes_not_divisible_by_hosts_fails(self, tmp_path):
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.num_processes = 5
+        bm.args.npernode = 1
+        npn, total = bm._resolve_rank_layout(['h1', 'h2'])
+        assert (npn, total) == (None, None)
+
+    def test_both_set_consistent(self, tmp_path):
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.num_processes = 6
+        bm.args.npernode = 3
+        npn, total = bm._resolve_rank_layout(['h1', 'h2'])
+        assert npn == 3
+        assert total == 6
+
+    def test_both_set_inconsistent_fails(self, tmp_path):
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.num_processes = 5
+        bm.args.npernode = 3
+        npn, total = bm._resolve_rank_layout(['h1', 'h2'])
+        assert (npn, total) == (None, None)
+
+    def test_neither_set_defaults_one_per_host(self, tmp_path):
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.num_processes = None
+        bm.args.npernode = None
+        npn, total = bm._resolve_rank_layout(['h1', 'h2', 'h3'])
+        assert npn == 1
+        assert total == 3
+
+    def test_negative_num_processes_fails(self, tmp_path):
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.num_processes = -1
+        bm.args.npernode = 1
+        npn, total = bm._resolve_rank_layout(['h1'])
+        assert (npn, total) == (None, None)
+
+
+class TestExecuteRunHonorsNumProcesses:
+    """End-to-end check that _execute_run actually uses --num-processes.
+
+    Repro of issue #500: with --num-processes 2 on a single host, the
+    wrapper-launch mpirun command must request 2 ranks (not 1)."""
+
+    def _capture_first_cmd(self, bm):
+        executed = []
+        def fake_execute(cmd, **kwargs):
+            executed.append(cmd)
+            return ('', '', 0)
+        agg = {
+            'option': 1, 'aggregated_read_bandwidth_gbps': 0.0,
+            'aggregated_write_bandwidth_gbps': 0.0,
+            'aggregated_avg_throughput_tokens_per_sec': 0.0,
+            'aggregated_storage_throughput_tokens_per_sec': 0.0,
+            'aggregated_p95_latency_ms': 0.0,
+            'rank_count': 1, 'trial_count': 1,
+            'partial_failure': False, 'missing_files': [], 'cpu_tier_ranks': [],
+        }
+        with patch.object(bm, '_execute_command', side_effect=fake_execute), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results', return_value=agg), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'):
+            bm._execute_run()
+        return executed[0] if executed else None
+
+    def test_num_processes_2_single_host_launches_2_ranks(self, tmp_path):
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.trials = 1
+        bm.args.inter_option_delay = 0
+        bm.args.num_processes = 2
+        bm.args.hosts = ['localhost']
+        cmd = self._capture_first_cmd(bm)
+        assert cmd is not None, "Expected at least one wrapper command"
+        assert '-n 2 ' in cmd, f"Expected '-n 2' in mpirun cmd, got: {cmd}"
+        assert '--npernode 2' in cmd, f"Expected '--npernode 2' in mpirun cmd, got: {cmd}"
+
+    def test_num_processes_inconsistent_fails_run(self, tmp_path):
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.trials = 1
+        bm.args.inter_option_delay = 0
+        bm.args.num_processes = 5  # not divisible by 2 hosts
+        bm.args.hosts = ['h1', 'h2']
+        with patch.object(bm, '_execute_command') as mock_exec, \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results'), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'):
+            rc = bm._execute_run()
+        assert rc == 1
+        mock_exec.assert_not_called()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -332,24 +332,20 @@ class TestDefaultResultsDir:
             assert DEFAULT_RESULTS_DIR == expected
 
     def test_env_var_overrides_tempdir_default(self, monkeypatch):
-        """When MLPERF_RESULTS_DIR is set, DEFAULT_RESULTS_DIR uses that value."""
-        import mlpstorage_py.config as cfg_mod
+        """When MLPERF_RESULTS_DIR is set, the resolver returns that value.
+
+        Calls the helper directly rather than reloading mlpstorage_py.config:
+        reload would rebuild the PARAM_VALIDATION enum class, breaking
+        identity comparisons in modules that already imported the original.
+        """
+        from mlpstorage_py.config import _resolve_default_results_dir
         monkeypatch.setenv('MLPERF_RESULTS_DIR', '/custom/mlperf/results')
-        importlib.reload(cfg_mod)
-        try:
-            assert cfg_mod.DEFAULT_RESULTS_DIR == '/custom/mlperf/results'
-        finally:
-            monkeypatch.delenv('MLPERF_RESULTS_DIR', raising=False)
-            importlib.reload(cfg_mod)  # restore original state for other tests
+        assert _resolve_default_results_dir() == '/custom/mlperf/results'
 
     def test_falls_back_to_tempdir_when_env_not_set(self, monkeypatch):
-        """When MLPERF_RESULTS_DIR is absent, DEFAULT_RESULTS_DIR is under tempdir."""
-        import mlpstorage_py.config as cfg_mod
+        """When MLPERF_RESULTS_DIR is absent, the resolver uses tempdir."""
+        from mlpstorage_py.config import _resolve_default_results_dir
         monkeypatch.delenv('MLPERF_RESULTS_DIR', raising=False)
-        importlib.reload(cfg_mod)
-        try:
-            expected = os.path.join(tempfile.gettempdir(), 'mlperf_storage_results')
-            assert cfg_mod.DEFAULT_RESULTS_DIR == expected
-        finally:
-            importlib.reload(cfg_mod)  # restore original state for other tests
+        expected = os.path.join(tempfile.gettempdir(), 'mlperf_storage_results')
+        assert _resolve_default_results_dir() == expected
 

--- a/tests/unit/test_dlio_object_storage.py
+++ b/tests/unit/test_dlio_object_storage.py
@@ -20,9 +20,13 @@ from unittest.mock import MagicMock, patch, call
 
 import pytest
 
-# Stub optional heavy deps so this file can be collected in isolation
+# Stub optional heavy deps so this file can be collected in isolation. Use
+# importlib.util.find_spec — checking sys.modules alone would install a
+# MagicMock for a perfectly importable module that just hasn't been imported
+# yet, which then poisons later test collections.
+import importlib.util as _ilu
 for _dep in ('pyarrow', 'pyarrow.ipc', 'dotenv'):
-    if _dep not in sys.modules:
+    if _ilu.find_spec(_dep) is None and _dep not in sys.modules:
         sys.modules[_dep] = MagicMock()
 
 from mlpstorage_py.benchmarks.dlio import DLIOBenchmark

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.17"
+version = "3.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
## Summary

Closes #500.

`--num-processes` was registered on the kvcache distributed-execution group but never read by `_execute_run`. Total ranks were computed solely from `npernode * len(hosts)`, so a user passing `--num-processes 2` with the default `--npernode 1` got one rank per host instead of two. dslik confirmed the dead-flag behavior in #500 after PR #501 merged (which fixed #498 but not #500 — a distinct root cause that was originally conflated).

This PR also drops two `--ignore`-flag workarounds that had been hiding test-infrastructure bugs.

## Part 1 — Honor `--num-processes` (closes #500)

New `KVCacheBenchmark._resolve_rank_layout()` derives `(npernode, total_ranks)` from whichever of `--num-processes` / `--npernode` the user supplied:

- **Only `--npernode` set** → today's behavior: `total = npernode * hosts`. Backward-compatible for existing users.
- **Only `--num-processes` set** → must divide evenly across hosts; `npernode = num_processes // len(hosts)`.
- **Both set** → must be consistent (`num_processes == npernode * len(hosts)`); otherwise the run fails with an actionable error.
- **Neither set** → defaults to one rank per host.

`--num-processes` is treated as **total cluster ranks** because that's what its existing help text claims ("Number of MPI processes (ranks) to spawn for distributed execution") and what DLIO's `--num-accelerators` already means project-wide.

The per-rank cache-dir partitioning the wrapper already does (`<rank-cache-base>/rank_<N>/`) avoids the cross-instance cache collision hazemawadalla raised in the issue thread — no additional layout change is needed once the rank count is right.

Help text for both flags updated so the relationship is explicit.

## Part 2 — Make the full test suite runnable without `--ignore`

The historical incantation `pytest tests/unit --ignore=tests/unit/test_benchmarks_base.py --ignore=tests/unit/test_parquet_reader.py --ignore=tests/unit/test_vdb_modular_fake_backend.py` was hiding two unrelated test-infrastructure bugs:

1. **`test_benchmarks_kvcache.py` and `test_dlio_object_storage.py`** installed `MagicMock` stubs for `('pyarrow', 'pyarrow.ipc', 'psutil', 'dotenv')` into `sys.modules` unconditionally at import time. The intent was "fall back when optional deps are missing"; the actual behavior, once those deps ARE installed, was to poison the import system so `test_parquet_reader.py` later failed collection with `'pyarrow is not a package'`. Guarded the stub with `importlib.util.find_spec` so the real module wins when available.

2. **`test_config.py::test_env_var_overrides_tempdir_default`** and **`::test_falls_back_to_tempdir_when_env_not_set`** called `importlib.reload(mlpstorage_py.config)` to re-evaluate `DEFAULT_RESULTS_DIR` under monkeypatched env. Each reload built a fresh `PARAM_VALIDATION` enum class, breaking `in`-checks for modules that had already imported the original — five integration tests in `test_benchmark_flow.py` were silently failing identity checks (e.g. `INVALID-from-old-class not in [..., INVALID-from-new-class]`). Extracted `_resolve_default_results_dir()` in `config.py` and rewrote both tests to call it directly; no reload, no enum churn.

## Test plan

- [x] `pytest tests/unit/test_benchmarks_kvcache.py::TestResolveRankLayout` — 8 new cases covering all branches of the new resolver.
- [x] `pytest tests/unit/test_benchmarks_kvcache.py::TestExecuteRunHonorsNumProcesses` — 2 new cases:
  - `--num-processes 2` on one host produces `mpirun -n 2 ... --npernode 2` (the exact #500 repro).
  - `--num-processes` not divisible by host count → `_execute_run` returns 1, no commands launched.
- [x] `pytest tests/unit tests/integration` (no `--ignore`, no selective collection) → **1,628 passed, 15 skipped, 12 deselected, 0 failures**. The 15 skips are all legitimate `skipif` conditions for missing external resources (fixture data on disk, submission packages, standalone-MPI tests). The 12 deselected are the existing `-m 'not slow'` filter from `pyproject.toml`.
