### PR TITLE
fix(code-image): hash source_root at capture to eliminate walker parity dependency (#505)

### DIFF
--- a/mlpstorage_py/submission_checker/tools/code_image.py
+++ b/mlpstorage_py/submission_checker/tools/code_image.py
@@ -242,11 +242,23 @@ def capture_code_image(source_root: Path, target_dir: Path, log) -> CodeImage:
     # tmp tree and only logs a warning. Wrap hash + JSON-write + rename in
     # try/except BaseException so KeyboardInterrupt / SystemExit also clean up.
     try:
-        # Behavior 3/4: Hash the captured copy
-        digest = compute_code_tree_md5(str(code_tmp), log)
+        # Hash source_root directly, not the just-made copy in code_tmp/. (#505)
+        #
+        # verify_source_against_image at runtime calls
+        # compute_code_tree_md5(source_root) and compares to this stored digest.
+        # If we hash code_tmp here, the comparison only succeeds when
+        # shutil.copytree's `ignore` callback walks the tree byte-for-byte
+        # identically to compute_code_tree_md5's filtered os.walk — any
+        # divergence (and real trees DO diverge: differing handling of
+        # `.egg-info`, symlinks, deep prefix matches, etc.) silently breaks
+        # CLOSED-run verification on the very first re-invocation. Hashing
+        # source_root on both sides eliminates the walker-parity dependency by
+        # construction; the code_tmp/ → code/ copy remains for archival
+        # forensics.
+        digest = compute_code_tree_md5(str(source_root), log)
         if digest is None:
-            # This shouldn't happen if _atomic_capture succeeded, but for safety:
-            raise SourceRootNotFound(f"Failed to hash captured tree at {code_tmp}")
+            # source_root vanished between _atomic_capture and the hash call.
+            raise SourceRootNotFound(f"Failed to hash source tree at {source_root}")
 
         # Behavior 6: Build payload
         payload = {


### PR DESCRIPTION
## Summary

Closes #505.

dslik reported that a fresh CLOSED kvcache run on a clean checkout failed with `changes to the codebase are not allowed in a CLOSED run` despite no actual code changes between capture and verify. Root cause is a walker-parity bug in the code-image module:

- `capture_code_image` hashed `code_tmp/` (the just-made copy via `shutil.copytree`).
- `verify_source_against_image` hashed `source_root` (the live tree).
- The comparison only succeeds if `shutil.copytree`'s `ignore` callback and `compute_code_tree_md5`'s filtered `os.walk` produce **byte-for-byte identical trees** from the same input.
- Both walkers reference the same exclusion constants, but apply them via independent code paths. On real trees (richer than the test fixtures) they diverge, the hashes differ, and CLOSED verification fires the literal spec message with no actual change.

The discrepancy was already known and documented in the test suite at `mlpstorage_py/tests/test_cli_code_image.py:247-252`, which monkeypatches `verify_source_against_image` to forcibly return `False` rather than relying on the natural flow:

```python
# Force a hash mismatch on the second call by monkeypatching
# verify_source_against_image to return False. This isolates the
# mismatch code path from the Phase 1 capture-vs-verify hash
# discrepancy documented in deferred-items.md.
```

## Fix

One-line change in `mlpstorage_py/submission_checker/tools/code_image.py:capture_code_image`:

```python
- digest = compute_code_tree_md5(str(code_tmp), log)
+ digest = compute_code_tree_md5(str(source_root), log)
```

Now both sides — capture and verify — hash `source_root` using the same walker. Parity by construction; no dependency on `shutil.copytree`'s `ignore` callback matching `compute_code_tree_md5`'s filtered `os.walk` byte-for-byte. The `code_tmp/ → code/` copy remains in place as the archival snapshot for forensics; only the digest source changed.

## Why dslik's workaround is unsafe

dslik's bypass (`#if matched:` so the verify always reports success) disables ALL change detection in CLOSED mode — silently lets users modify the codebase mid-CLOSED-run-set without surfacing it. The same monkeypatch test the suite already relied on (forcing `False` to exercise the failure path) is the same shape of unsafe-in-production change. Don't ship it; this PR makes verify actually work.

## verify_image_self_consistent

`verify_image_self_consistent` (which hashes the on-disk `code/` tree to detect post-capture tampering) is intentionally unchanged. It has no production callers in the runtime path and its existing tests use small synthetic trees that don't trigger the walker discrepancy, so they keep passing. If someone wires this function up against real captures later, follow-up will be needed to make `code/`-hash also parity-clean.

## Test plan

- [x] `pytest` (default `testpaths = ["tests"]`, what CI runs) → **1,628 passed, 15 skipped, 12 deselected, 0 failures**. No `--ignore` flags.
- [x] Existing `TestVerifyImageSelfConsistent` and `test_closed_second_run_matches` tests continue to pass — they use simple synthetic trees that don't trigger the walker discrepancy in either direction.
- [x] `test_closed_mismatch_raises_with_literal_message` still relies on the `verify_source_against_image` monkeypatch — that workaround could be retired in a follow-up since `source_root`-hashing now lets us provoke real mismatches naturally, but it's harmless and isolating the test from real-walker behavior is still defensible. Left for a separate cleanup PR.
- [ ] Manual: re-run dslik's kvcache CLOSED scenario on a real checkout to confirm the verify step no longer false-positives.

## Note for the reviewer

There are 7 failing tests in `mlpstorage_py/tests/` that surfaced when I ran pytest against that directory. They are **pre-existing**, **not in any open PR**, and **not in CI** — `pyproject.toml:88` sets `testpaths = ["tests"]` so CI never collects from `mlpstorage_py/tests/`. They're stale tests referencing older production-code signatures (`add_universal_arguments(parser)` without `req_results`, older `MD5_EXCLUDE_PREFIXES` tuple, pre-`--vdb-engine` `generate_output_location`). Out of scope for this PR; worth its own cleanup decision — either delete `mlpstorage_py/tests/` if dead, or add it to `testpaths` so the rot gets caught.
