### PR TITLE
Fix #489: abort simple_bench when FLAT ground-truth collection is empty or under-covered

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.18"
+version = "3.0.19"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.18"
+version = "3.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },

--- a/vdb_benchmark/tests/tests/test_issue_489_flat_gt_guard.py
+++ b/vdb_benchmark/tests/tests/test_issue_489_flat_gt_guard.py
@@ -1,0 +1,405 @@
+"""
+Regression tests for issue #489:
+
+    vdb_benchmark simple_bench can silently continue with an empty FLAT
+    ground-truth collection after the Milvus copy fallback fails, producing
+    a "successful" run whose recall.num_queries_evaluated == 0.
+
+Root cause(s) in ``vdbbench/simple_bench.py``:
+
+  1. The pk-cursor fallback initialized the int64 cursor at ``-2**63``,
+     producing the expression ``pk > -9223372036854775808``. Milvus parses
+     the operand magnitude (9223372036854775808) as int64, which overflows
+     INT64_MAX by one and raises a parse error, breaking the copy loop with
+     ``copied == 0``.
+  2. After copying zero vectors the loop printed a hard-coded
+     ``Copied 0/N vectors (100.0%)``.
+  3. ``create_flat_collection`` returned ``True`` even with an empty FLAT
+     collection (it only failed on exceptions), so the caller's
+     ``if not flat_ok`` guard never tripped.
+  4. The run still produced QPS/latency numbers even though
+     ``num_queries_evaluated == 0``.
+  5. The ``query_iterator`` fast path used an unbounded batch size, so wide
+     vectors exceeded Milvus' 256MB gRPC message limit and forced the broken
+     fallback in the first place.
+
+These tests verify the fixes WITHOUT requiring a live Milvus or the pymilvus
+package: a minimal fake ``pymilvus`` is injected into ``sys.modules`` before
+the module under test is imported, and the empty-collection paths are driven
+with mocks.
+"""
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make the package importable regardless of where pytest is invoked from.
+# ---------------------------------------------------------------------------
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+# ---------------------------------------------------------------------------
+# simple_bench.py imports pymilvus at module load and calls sys.exit(1) on
+# ImportError. CI does not have pymilvus installed, so we inject a fake module
+# exposing exactly the names simple_bench imports. DataType members only need
+# to compare by identity and expose a ``.name`` attribute.
+# ---------------------------------------------------------------------------
+def _install_fake_pymilvus():
+    if "pymilvus" in sys.modules:
+        return
+
+    fake = types.ModuleType("pymilvus")
+
+    class _DataTypeMember:
+        def __init__(self, name):
+            self.name = name
+
+    class DataType:
+        INT64 = _DataTypeMember("INT64")
+        INT32 = _DataTypeMember("INT32")
+        INT16 = _DataTypeMember("INT16")
+        INT8 = _DataTypeMember("INT8")
+        VARCHAR = _DataTypeMember("VARCHAR")
+        FLOAT_VECTOR = _DataTypeMember("FLOAT_VECTOR")
+        BINARY_VECTOR = _DataTypeMember("BINARY_VECTOR")
+        FLOAT16_VECTOR = _DataTypeMember("FLOAT16_VECTOR")
+        BFLOAT16_VECTOR = _DataTypeMember("BFLOAT16_VECTOR")
+
+    fake.DataType = DataType
+    fake.Collection = MagicMock(name="Collection")
+    fake.CollectionSchema = MagicMock(name="CollectionSchema")
+    fake.FieldSchema = MagicMock(name="FieldSchema")
+    fake.connections = MagicMock(name="connections")
+    fake.utility = MagicMock(name="utility")
+
+    sys.modules["pymilvus"] = fake
+
+
+_install_fake_pymilvus()
+
+# Now the import is safe in a dependency-free CI environment.
+from vdbbench import simple_bench  # noqa: E402
+from vdbbench.simple_bench import (  # noqa: E402
+    calc_recall,
+    create_flat_collection,
+    precompute_ground_truth,
+)
+
+# The bad cursor expression this issue is about. Constructing it dynamically
+# avoids any chance of a copy/paste typo masking a regression.
+_BAD_INT_EXPR = f"pk > {-2 ** 63}"  # "pk > -9223372036854775808"
+
+
+def _make_field(name, dtype, is_primary=False):
+    field = MagicMock()
+    field.name = name
+    field.dtype = dtype
+    field.is_primary = is_primary
+    return field
+
+
+def _make_source_schema(pk_dtype):
+    """A minimal source collection schema: int/varchar pk + float vector."""
+    DataType = simple_bench.DataType
+    schema = MagicMock()
+    schema.fields = [
+        _make_field("id", pk_dtype, is_primary=True),
+        _make_field("vector", DataType.FLOAT_VECTOR, is_primary=False),
+    ]
+    return schema
+
+
+# ===========================================================================
+# Fix 1: int64 fallback cursor must not produce the out-of-range expression
+# ===========================================================================
+class TestCursorExpressionInRange:
+    """The pk-cursor first-page expression must be parseable by Milvus."""
+
+    def test_source_no_longer_uses_min_int64_sentinel(self):
+        """The -2**63 cursor sentinel must be gone from executable code.
+
+        (Comments may still reference -2**63 to explain the fix, so we scan
+        only non-comment code by stripping the part after any ``#``.)
+        """
+        code_lines = []
+        for line in open(simple_bench.__file__, encoding="utf-8"):
+            code = line.split("#", 1)[0]
+            code_lines.append(code)
+        code = "\n".join(code_lines)
+
+        assert "-2**63" not in code and "-2 ** 63" not in code, (
+            "simple_bench still initializes the pk cursor at -2**63, which "
+            "produces the out-of-range expression 'id > -9223372036854775808'."
+        )
+        # And the safe sentinel must be present in code.
+        assert "last_pk: Union[int, str] = -1 if is_int_pk else" in code
+
+    def test_int_first_page_expression_is_in_range(self):
+        """
+        Reproduce the cursor-init logic for an int PK and assert the first-page
+        expression is valid (operand within int64 range), not the overflowing
+        form the issue reported.
+        """
+        is_int_pk = True
+        last_pk = -1 if is_int_pk else ""  # post-fix sentinel
+        expr = f"id > {last_pk}"
+
+        assert expr == "id > -1"
+        assert expr != _BAD_INT_EXPR
+
+        # The operand magnitude must fit in signed int64.
+        operand = int(expr.split(">")[1])
+        assert -(2 ** 63) <= operand <= (2 ** 63 - 1)
+
+    def test_min_int64_operand_overflows_but_minus_one_does_not(self):
+        """Document precisely why -2**63 fails and -1 is safe for Milvus int64."""
+        int64_max = 2 ** 63 - 1
+        # The magnitude Milvus tries to parse from the bad expression.
+        bad_operand_magnitude = int("9223372036854775808")
+        assert bad_operand_magnitude > int64_max  # overflow by one -> parse error
+        # The fixed sentinel's magnitude is trivially in range.
+        assert abs(-1) <= int64_max
+
+    def test_varchar_first_page_uses_closed_lower_bound(self):
+        """VARCHAR PKs should start with '>= \"\"' so no valid key is skipped."""
+        is_int_pk = False
+        first_page = True
+        last_pk = -1 if is_int_pk else ""
+
+        if is_int_pk:
+            expr = f"id > {last_pk}"
+        else:
+            expr = 'id >= ""' if first_page else f'id > "{last_pk}"'
+
+        assert expr == 'id >= ""'
+
+
+# ===========================================================================
+# Fix 3: create_flat_collection must abort when coverage is too low
+# ===========================================================================
+def _patch_milvus(monkeypatch, source_coll, flat_coll):
+    """Wire simple_bench's module-level Milvus symbols to mocks."""
+    connections = MagicMock()
+    utility = MagicMock()
+    utility.has_collection.return_value = False  # force the create path
+
+    def _collection_factory(name, *args, **kwargs):
+        # First positional construction in the create path is the source
+        # (Collection(source_name, using=...)); the schema-bearing call builds
+        # the flat collection (Collection(flat_name, schema, using=...)).
+        if name == "source":
+            return source_coll
+        return flat_coll
+
+    Collection = MagicMock(side_effect=_collection_factory)
+
+    monkeypatch.setattr(simple_bench, "connections", connections)
+    monkeypatch.setattr(simple_bench, "utility", utility)
+    monkeypatch.setattr(simple_bench, "Collection", Collection)
+    return connections, utility, Collection
+
+
+class TestCoverageGuard:
+    """create_flat_collection must return False on insufficient coverage."""
+
+    def test_empty_flat_collection_returns_false(self, monkeypatch):
+        """
+        Source reports 1000 vectors; the copy path inserts nothing and the FLAT
+        collection stays at 0 entities. The function must abort (return False),
+        not declare success.
+        """
+        DataType = simple_bench.DataType
+
+        source_coll = MagicMock()
+        source_coll.schema = _make_source_schema(DataType.INT64)
+        source_coll.name = "source"
+        # num_entities is read multiple times; source always reports 1000.
+        type(source_coll).num_entities = property(lambda self: 1000)
+        # Make the copy yield nothing regardless of path taken.
+        source_coll.query.return_value = []
+        source_coll.search.return_value = []
+        # Force the pk-cursor fallback rather than query_iterator.
+        del source_coll.query_iterator
+
+        flat_coll = MagicMock()
+        flat_coll.name = "..._flat_gt"
+        # Flat collection never gets populated -> 0 entities throughout.
+        type(flat_coll).num_entities = property(lambda self: 0)
+
+        _patch_milvus(monkeypatch, source_coll, flat_coll)
+
+        result = create_flat_collection(
+            host="127.0.0.1",
+            port="19530",
+            source_collection_name="source",
+            flat_collection_name="..._flat_gt",
+            vector_dim=8,
+            metric_type="COSINE",
+        )
+
+        assert result is False, (
+            "create_flat_collection must abort when the FLAT ground-truth "
+            "collection covers ~0% of the source (issue #489)."
+        )
+        # The empty FLAT collection must never reach index construction.
+        flat_coll.create_index.assert_not_called()
+
+    def test_coverage_threshold_math(self):
+        """The 99% coverage rule accepts full coverage and rejects partial."""
+        def passes(flat_count, total):
+            coverage = (flat_count / total) if total else 0.0
+            return coverage >= 0.99
+
+        assert passes(1_000_000, 1_000_000) is True
+        assert passes(995_000, 1_000_000) is True       # 99.5%
+        assert passes(0, 1_000_000) is False             # the bug's case
+        assert passes(10_000, 1_000_000) is False        # ~1% (issue #375 shape)
+        assert passes(980_000, 1_000_000) is False       # 98%
+
+
+# ===========================================================================
+# Fix 2: progress output must reflect the true copied percentage
+# ===========================================================================
+class TestProgressOutput:
+    """The post-copy summary line must not be hard-coded to 100.0%."""
+
+    def test_source_has_no_hardcoded_full_progress(self):
+        src = open(simple_bench.__file__, encoding="utf-8").read()
+        assert 'vectors (100.0%)"' not in src, (
+            "simple_bench still prints a hard-coded '(100.0%)' progress line "
+            "even when 0 vectors were copied (issue #489)."
+        )
+
+    @pytest.mark.parametrize(
+        "copied,total,expected",
+        [
+            (0, 1_000_000, "0.0%"),
+            (500_000, 1_000_000, "50.0%"),
+            (1_000_000, 1_000_000, "100.0%"),
+            (0, 0, "0.0%"),  # guard against div-by-zero
+        ],
+    )
+    def test_progress_percentage_is_accurate(self, copied, total, expected):
+        final_pct = (100.0 * copied / total) if total else 0.0
+        assert f"{final_pct:.1f}%" == expected
+
+
+# ===========================================================================
+# Fix 4: an empty / all-invalid ground truth must invalidate the run
+# ===========================================================================
+class TestEmptyGroundTruthInvalidatesRun:
+    """precompute_ground_truth and the num_queries_evaluated guard."""
+
+    def test_precompute_returns_empty_when_all_neighbors_empty(self, monkeypatch):
+        """
+        A FLAT collection with no usable vectors yields empty neighbor lists for
+        every query. precompute_ground_truth must return {} so the caller's
+        'if not ground_truth' guard aborts the run.
+        """
+        flat_coll = MagicMock()
+        type(flat_coll).num_entities = property(lambda self: 0)
+
+        # Every search returns one hit-list per query, each empty.
+        def _empty_search(data, **kwargs):
+            return [[] for _ in data]
+
+        flat_coll.search.side_effect = _empty_search
+
+        monkeypatch.setattr(simple_bench, "Collection", lambda *a, **k: flat_coll)
+        monkeypatch.setattr(simple_bench, "connections", MagicMock())
+
+        queries = [[0.0] * 8 for _ in range(5)]
+        gt = precompute_ground_truth(
+            host="127.0.0.1",
+            port="19530",
+            flat_collection_name="..._flat_gt",
+            query_vectors=queries,
+            top_k=10,
+            metric_type="COSINE",
+        )
+
+        assert gt == {}, (
+            "Ground truth that is empty for every query must be reported as "
+            "failure (empty dict), not silently returned (issue #489)."
+        )
+
+    def test_calc_recall_reports_zero_evaluated_for_empty_gt(self):
+        """
+        With empty ground-truth lists, calc_recall evaluates 0 queries — the
+        signal the run-level guard uses to mark the benchmark invalid.
+        """
+        ann_results = {i: [i, i + 1, i + 2] for i in range(5)}
+        empty_gt = {i: [] for i in range(5)}
+
+        stats = calc_recall(ann_results, empty_gt, k=10)
+
+        assert stats["num_queries_evaluated"] == 0
+        assert stats["recall_at_k"] == 0.0
+
+    def test_run_level_guard_condition(self):
+        """
+        The decision the run path makes: num_queries_evaluated == 0 -> FAILED.
+        Asserting the predicate keeps the contract explicit.
+        """
+        invalid = {"num_queries_evaluated": 0}
+        valid = {"num_queries_evaluated": 124_000}
+
+        def run_is_invalid(recall_stats):
+            return recall_stats.get("num_queries_evaluated", 0) == 0
+
+        assert run_is_invalid(invalid) is True
+        assert run_is_invalid(valid) is False
+
+    def test_calc_recall_valid_when_gt_present(self):
+        """Sanity: a populated ground truth still produces a valid recall."""
+        ann_results = {0: [1, 2, 3], 1: [4, 5, 6]}
+        ground_truth = {0: [1, 2, 9], 1: [4, 5, 6]}
+
+        stats = calc_recall(ann_results, ground_truth, k=3)
+
+        assert stats["num_queries_evaluated"] == 2
+        # Query 0: 2/3 overlap, query 1: 3/3 overlap -> mean (2/3 + 1)/2.
+        assert stats["recall_at_k"] == pytest.approx((2 / 3 + 1.0) / 2)
+
+
+# ===========================================================================
+# Fix 5: query_iterator batch size must be bounded under the gRPC limit
+# ===========================================================================
+class TestIteratorBatchSizeBound:
+    """The fast-path iterator must cap its batch to stay under 256MB gRPC."""
+
+    def test_source_caps_iterator_batch_size(self):
+        src = open(simple_bench.__file__, encoding="utf-8").read()
+        assert "iter_batch_size" in src, (
+            "simple_bench no longer bounds the query_iterator batch size; wide "
+            "vectors can exceed the 256MB gRPC limit (issue #489, root cause)."
+        )
+
+    @pytest.mark.parametrize(
+        "vector_dim,copy_batch_size",
+        [
+            (1536, 5000),   # the issue's configuration
+            (128, 5000),
+            (4096, 5000),
+        ],
+    )
+    def test_iter_batch_size_stays_under_grpc_limit(self, vector_dim, copy_batch_size):
+        """The computed batch must keep one response well under 256MB."""
+        bytes_per_row = max(vector_dim * 4, 1)
+        safe_rows = max(1, (24 * 1024 * 1024) // bytes_per_row)
+        iter_batch_size = min(copy_batch_size, safe_rows, 16384)
+
+        approx_response_bytes = iter_batch_size * bytes_per_row
+        assert approx_response_bytes <= 256 * 1024 * 1024
+        assert iter_batch_size >= 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))
+

--- a/vdb_benchmark/vdbbench/simple_bench.py
+++ b/vdb_benchmark/vdbbench/simple_bench.py
@@ -373,8 +373,17 @@ def create_flat_collection(
 
         if use_iterator:
             try:
+                # Cap the iterator batch size so a single gRPC response stays
+                # well under Milvus' default 256MB max-message limit. For wide
+                # vectors (e.g. 1536-dim float32 ~= 6KB/row) a 5000-row batch
+                # can exceed the limit and trigger RESOURCE_EXHAUSTED, forcing
+                # the fragile pk-cursor fallback. ~24MB/batch is a safe ceiling.
+                bytes_per_row = max(vector_dim * 4, 1)
+                safe_rows = max(1, (24 * 1024 * 1024) // bytes_per_row)
+                iter_batch_size = min(copy_batch_size, safe_rows, 16384)
+
                 iterator = source_coll.query_iterator(
-                    batch_size=copy_batch_size,
+                    batch_size=iter_batch_size,
                     output_fields=[src_pk_field, src_vec_field],
                 )
 
@@ -416,7 +425,14 @@ def create_flat_collection(
                 DataType.INT8,
             )
 
-            last_pk: Union[int, str] = -2**63 if is_int_pk else ""
+            # NOTE: do NOT initialize the int cursor at -2**63. The expression
+            # "pk > -9223372036854775808" makes Milvus parse the operand
+            # 9223372036854775808 (magnitude, before the sign) as int64, which
+            # overflows INT64_MAX by one and raises a parse error, breaking the
+            # copy loop with 0 vectors. Benchmark IDs are >= 0, so -1 is a safe
+            # in-range sentinel that yields the valid first-page expr "pk > -1".
+            last_pk: Union[int, str] = -1 if is_int_pk else ""
+            first_page = True
             page_limit = min(copy_batch_size, 16384)
 
             dummy_vec = np.random.random(vector_dim).astype(np.float32)
@@ -427,7 +443,14 @@ def create_flat_collection(
                 if is_int_pk:
                     expr = f"{src_pk_field} > {last_pk}"
                 else:
-                    expr = f'{src_pk_field} > "{last_pk}"'
+                    # First page for VARCHAR PKs uses a closed lower bound so an
+                    # empty-string sentinel does not skip valid keys; subsequent
+                    # pages advance with a strict cursor on the last seen key.
+                    if first_page:
+                        expr = f'{src_pk_field} >= ""'
+                    else:
+                        expr = f'{src_pk_field} > "{last_pk}"'
+                first_page = False
 
                 try:
                     pk_batch = source_coll.query(
@@ -523,7 +546,8 @@ def create_flat_collection(
                         f"({pct:.1f}%)"
                     )
 
-        print(f"  Copied {copied}/{total_vectors} vectors (100.0%)")
+        final_pct = (100.0 * copied / total_vectors) if total_vectors else 0.0
+        print(f"  Copied {copied}/{total_vectors} vectors ({final_pct:.1f}%)")
 
         flat_coll.flush()
 
@@ -543,6 +567,23 @@ def create_flat_collection(
                 f"  WARNING: Only {flat_coll.num_entities}/{copied} vectors "
                 f"visible after flush. Proceeding anyway."
             )
+
+        # Coverage guard: a FLAT ground-truth collection that does not cover the
+        # source collection cannot produce valid recall. Without this guard the
+        # function would build an empty FLAT index, return True, and let the
+        # benchmark report a "successful" run with recall.num_queries_evaluated=0
+        # (see issue #489). Abort here so the caller's `if not flat_ok` fires.
+        final_count = flat_coll.num_entities
+        coverage = (final_count / total_vectors) if total_vectors else 0.0
+        MIN_COVERAGE = 0.99
+        if coverage < MIN_COVERAGE:
+            print(
+                f"ERROR: FLAT ground-truth collection covers only "
+                f"{final_count}/{total_vectors} ({coverage * 100:.2f}%) of the "
+                f"source collection (minimum required: {MIN_COVERAGE * 100:.0f}%). "
+                f"Cannot compute valid recall — aborting FLAT setup."
+            )
+            return False
 
         print("Building FLAT index...")
         flat_coll.create_index(
@@ -643,6 +684,19 @@ def precompute_ground_truth(
             f"Ground truth pre-computation complete: "
             f"{len(ground_truth)} queries in {gt_elapsed:.2f}s"
         )
+
+        # If every query came back with an empty neighbor list, the FLAT
+        # collection had no usable vectors and recall would be silently 0.
+        # Return an empty dict so the caller's `if not ground_truth` guard
+        # aborts the run instead of reporting an invalid benchmark (issue #489).
+        non_empty = sum(1 for neighbors in ground_truth.values() if neighbors)
+        if non_empty == 0:
+            print(
+                "ERROR: Ground truth is empty for all queries "
+                "(FLAT collection has no usable vectors). "
+                "Recall cannot be computed."
+            )
+            return {}
 
         return ground_truth
 
@@ -1637,6 +1691,17 @@ def main():
     with open(recall_output_file, "w", encoding="utf-8") as f:
         json.dump(recall_stats, f, indent=2)
 
+    # A run in which zero queries had valid ground truth produced no measurable
+    # recall, so its QPS/latency numbers must not be reported as a successful
+    # benchmark. recall_stats.json is written above for diagnostics, then we
+    # abort with a non-zero exit code (issue #489).
+    if recall_stats.get("num_queries_evaluated", 0) == 0:
+        print(
+            "ERROR: 0 queries had valid ground truth; recall is invalid. "
+            "Marking run as FAILED (see recall_stats.json for details)."
+        )
+        sys.exit(1)
+
     print("Calculating benchmark statistics...")
     stats = calculate_statistics(output_dir, recall_stats=recall_stats)
 
@@ -1776,3 +1841,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary

Fixes #489.

`mlpstorage closed vectordb run file` (which routes through `vdbbench/simple_bench.py`) could silently emit a "successful" benchmark with valid-looking QPS/latency numbers while recall was never actually computed (`recall.num_queries_evaluated == 0`). This happened whenever FLAT ground-truth (GT) collection creation produced **0 vectors** — the run did not abort, so the throughput summary looked fine even though the correctness path
had completely failed.

This PR fixes the root cause of the empty copy, adds guards so a missing/ under-covered FLAT GT collection fails the run instead of passing silently, and hardens the fast copy path that triggered the fallback in the first place.

## Root cause

For a 1M × 1536-dim source collection, the FLAT-copy fast path (`query_iterator`) returned a gRPC response larger than Milvus' default 256MB limit and raised `RESOURCE_EXHAUSTED`. The code fell back to pk-cursor
pagination, but that fallback initialized the int64 cursor at `-2**63`, producing the expression `id > -9223372036854775808`. Milvus parses the operand magnitude (`9223372036854775808`) as int64, which overflows `INT64_MAX` by one and raises a parse error — so the copy loop broke immediately with `copied == 0`. The benchmark then built an empty FLAT index, reported success, and ran the timed query phase against ground truth that did not exist.

## Changes (`vdbbench/simple_bench.py`)

1. **Fix the int64 fallback cursor.** Initialize the pk cursor at `-1` instead
   of `-2**63`, yielding the valid first-page expression `id > -1`. VARCHAR PKs
   now use a closed lower bound (`pk >= ""`) on the first page and a strict
   cursor thereafter, so no valid key is skipped.
2. **Add a FLAT GT coverage guard.** After the copy/flush, `create_flat_collection`
   now computes coverage against the source and returns `False` (aborting the
   run via the existing `if not flat_ok: sys.exit(1)`) when coverage is below
   the threshold, instead of building an empty index and returning `True`.
3. **Invalidate runs with no evaluated queries.** `precompute_ground_truth`
   returns `{}` when GT is empty for every query (tripping the existing
   `if not ground_truth` guard), and `main` exits non-zero when
   `recall_stats["num_queries_evaluated"] == 0`. `recall_stats.json` is still
   written first for diagnostics.
4. **Report the true copy percentage.** Replaced the hard-coded
   `Copied 0/N vectors (100.0%)` line with the actual computed percentage.
5. **Harden the fast path (root cause).** Cap the `query_iterator` batch size
   based on `vector_dim` so a single response stays well under the 256MB gRPC
   limit, keeping the fast path working for wide vectors and avoiding the
   fragile fallback entirely.

## Tests

Adds `vdb_benchmark/tests/tests/test_issue_489_flat_gt_guard.py` — a
dependency-free regression suite (no live Milvus, no `pymilvus` required; a
minimal fake `pymilvus` is injected into `sys.modules`, matching how
`conftest.py` already handles the missing dependency). It covers all five
fixes, including driving the real `create_flat_collection` and
`precompute_ground_truth` through mocks for the empty-collection paths.


```bash
# run the new suite + existing simple_bench tests
python3 -m pytest \
  vdb_benchmark/tests/tests/test_issue_489_flat_gt_guard.py \
  vdb_benchmark/tests/tests/test_simple_bench.py -v
```