### PR TITLE
chore(code-image): clarify mismatch / bad-image location messages

### DIFF
--- a/mlpstorage_py/submission_checker/tools/code_image.py
+++ b/mlpstorage_py/submission_checker/tools/code_image.py
@@ -717,7 +717,7 @@ def capture_or_verify_code_image(args, env, log):
         matched = verify_source_against_image(source_root, code_dir, log)
     except (MissingHashFile, MalformedHashFile) as e:
         log.error(str(e))
-        log.error(f"code image at: {code_dir}")
+        log.error(f"affected code image at: {code_dir}")
         log.error(
             "either delete `code/` and re-run to re-capture, "
             "or restore the original capture."
@@ -734,5 +734,5 @@ def capture_or_verify_code_image(args, env, log):
     else:  # mode == "open"
         msg = "all runs of this type must use the same codebase"
     log.error(msg)
-    log.error(f"code image at: {code_dir}")
+    log.error(f"the running code does not match the captured code image at: {code_dir}")
     raise CodeImageError(msg)

--- a/mlpstorage_py/tests/test_cli_code_image.py
+++ b/mlpstorage_py/tests/test_cli_code_image.py
@@ -263,7 +263,10 @@ class TestRuntimeMismatchCLOSED:
             for e in mock_logger.errors
         ), mock_logger.errors
         code_dir = tmp_path / "closed" / "acme" / "code"
-        assert any(f"code image at: {code_dir}" in e for e in mock_logger.errors), mock_logger.errors
+        assert any(
+            f"the running code does not match the captured code image at: {code_dir}" in e
+            for e in mock_logger.errors
+        ), mock_logger.errors
 
 
 # ---------------------------------------------------------------------------
@@ -301,7 +304,10 @@ class TestRuntimeMismatchOPEN:
             tmp_path / "open" / "acme" / "results" / "sys-1"
             / "training" / "unet3d" / "code"
         )
-        assert any(f"code image at: {code_dir}" in e for e in mock_logger.errors), mock_logger.errors
+        assert any(
+            f"the running code does not match the captured code image at: {code_dir}" in e
+            for e in mock_logger.errors
+        ), mock_logger.errors
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The hash-mismatch branch in `capture_or_verify_code_image` logged a bare `code image at: <path>` line after the primary spec error, leaving users to infer the path's relevance. Reworded to `the running code does not match the captured code image at: <path>`.
- The sibling missing/malformed-hash-file branch had the same problem; reworded to `affected code image at: <path>` to pair clearly with the preceding exception text.
- Literal VALR-02 / VALR-04 spec strings (`changes to the codebase are not allowed in a CLOSED run`, `all runs of this type must use the same codebase`) are untouched — only the supplementary location line is reworded.
- Pinned test assertions in `test_cli_code_image.py` updated to the new mismatch wording.

## Test plan
- [x] `pytest mlpstorage_py/tests/test_cli_code_image.py` — all 32 tests pass locally