### PR TITLE
fix(kvcache): honor --mpi-params in `mlpstorage closed kvcache run` (#520)

### DIFF
--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -272,13 +272,21 @@ class KVCacheBenchmark(Benchmark):
         # Wrapper-adjacent config.yaml is the default; CLOSED forbids overriding.
         config_path = config or str(Path(self.kvcache_bin_path).parent / 'config.yaml')
 
+        # User --mpi-params (already shlex-flattened by the central CLI parser)
+        # are passed through first; the mandatory --mca is appended last so
+        # that OpenMPI's last-wins resolution for repeated --mca keys keeps
+        # the abort-suppression flag authoritative even if the user supplies a
+        # conflicting value (kvcache expects per-rank non-zero exits).
+        user_mpi_params = list(getattr(self.args, 'mpi_params', None) or [])
+        mpi_params = user_mpi_params + ['--mca', 'orte_abort_on_non_zero_status', '0']
+
         mpi_prefix = generate_mpi_prefix_cmd(
             mpi_cmd=getattr(self.args, 'mpi_bin', 'mpirun'),
             hosts=hosts,
             num_processes=total_ranks,
             oversubscribe=getattr(self.args, 'oversubscribe', False),
             allow_run_as_root=getattr(self.args, 'allow_run_as_root', False),
-            params=['--mca orte_abort_on_non_zero_status 0'],
+            params=mpi_params,
             logger=self.logger,
             processes_per_node=npernode,
         )

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -821,6 +821,35 @@ class TestExecuteRun:
         assert '--mca orte_abort_on_non_zero_status 0' in cmd0, \
             f"Missing --mca orte_abort_on_non_zero_status 0 in: {cmd0}"
 
+    def test_mpirun_passes_through_user_mpi_params(self, bm, fake_agg_result):
+        """User --mpi-params must reach mpirun, ordered before the mandatory
+        --mca orte_abort_on_non_zero_status 0 flag so OpenMPI's last-wins
+        resolution keeps the abort-suppression authoritative (#520)."""
+        # Shape matches what cli_parser.py emits post-shlex.split.
+        bm.args.mpi_params = ['-genv', 'PMI_VERSION=2', '--mca', 'btl', 'tcp,self']
+        bm.args.trials = 1
+        bm.args.inter_option_delay = 0
+        executed_cmds = []
+        def fake_execute(cmd, **kwargs):
+            executed_cmds.append(cmd)
+            return ('', '', 0)
+        with patch.object(bm, '_execute_command', side_effect=fake_execute), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results', return_value=fake_agg_result), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'):
+            bm._execute_run()
+        cmd0 = executed_cmds[0]
+        assert '-genv PMI_VERSION=2' in cmd0, \
+            f"Missing user --mpi-params in: {cmd0}"
+        assert '--mca btl tcp,self' in cmd0, \
+            f"Missing user --mpi-params in: {cmd0}"
+        # Mandatory --mca must follow user params (OpenMPI last-wins).
+        user_idx = cmd0.index('--mca btl tcp,self')
+        mandatory_idx = cmd0.index('--mca orte_abort_on_non_zero_status 0')
+        assert mandatory_idx > user_idx, \
+            f"Mandatory --mca must come after user --mpi-params in: {cmd0}"
+
     def test_mpirun_contains_npernode(self, bm, fake_agg_result):
         """mpirun command must contain '--npernode 2' when npernode=2 (DIST-03)."""
         bm.args.npernode = 2


### PR DESCRIPTION
Fixes #520.

## Summary
`KVCacheBenchmark._execute_run()` called `generate_mpi_prefix_cmd()` with a hardcoded `params=['--mca orte_abort_on_non_zero_status 0']`, silently dropping `self.args.mpi_params`. The reporter on the issue diagnosed this exactly and pointed at the working passthrough patterns in `vectordbbench.py` and `dlio.py`.

This change reads `self.args.mpi_params` (already shlex-flattened to a token list by `cli_parser.py:314-330`) and concatenates the mandatory `--mca orte_abort_on_non_zero_status 0` flag onto the end.

## Why append the mandatory flag *after* user params
OpenMPI uses last-wins resolution for repeated `--mca` keys, so appending the mandatory flag keeps abort-suppression authoritative even if a user supplies a conflicting `--mca orte_abort_on_non_zero_status 1`. The flag is benchmark-correctness (kvcache expects per-rank non-zero exits), not a user preference.

## Why no flattening helper
`cli_parser.py:314-330` centralizes `--mpi-params` flattening for all benchmarks — by the time the benchmark reads `self.args.mpi_params` it is already a flat `List[str]`. (vectordbbench has its own `_flatten_mpi_params` because it has a non-MPI MPICH/Hydra code path; the openmpi path here doesn't need it.)

## Test plan
- [x] `uv run pytest tests/unit/test_benchmarks_kvcache.py` — all 100 tests pass, including the new `TestExecuteRun::test_mpirun_passes_through_user_mpi_params` regression that asserts both passthrough and ordering.
- [x] `uv run pytest tests/unit/test_cli_parser.py` — 25 tests pass; no behavior change in the central flattener.
- [x] Pre-existing `test_mpirun_contains_mca_orte_flag` (DIST-08) still passes — the mandatory flag is still present in the command, just composed from three tokens instead of one space-joined string.