### PR TITLE
Change minimum AU% for RetinaNet from 90% to 85%

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -491,7 +491,7 @@ The benchmark suite provides workload [configurations](https://github.com/mlcomm
 | Area | Problem | Model | Data Loader | Dataset seed | Minimum AU% |
 | ---- | ------- | ----- | ----------- | ------------ | ----------- |
 | Vision | Image Classification | Unet3D | PyTorch | ??? | 90% |
-| Vision | Image Recognition | RetinaNet | PyTorch | ??? | 90% |
+| Vision | Image Recognition | RetinaNet | PyTorch | ??? | 85% |
 
 Table 1: Benchmark description
 


### PR DESCRIPTION
Updated minimum AU% for RetinaNet in the benchmark table to match the 85% value in the workload definition json file.