### PR TITLE
Fix #521: kvcache fails fast when --results-dir is not on a shared filesystem

### DIFF
--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -17,13 +17,16 @@ Classes:
 
 import json
 import os
+import shlex
 import sys
 import time
+import uuid
 from pathlib import Path
 from typing import Dict, Any, List
 from statistics import fmean
 
 from mlpstorage_py.benchmarks.base import Benchmark
+from mlpstorage_py.cluster_collector import _is_localhost
 from mlpstorage_py.config import (
     BENCHMARK_TYPES,
     KVCACHE_DEFAULT_DURATION,
@@ -283,6 +286,13 @@ class KVCacheBenchmark(Benchmark):
             processes_per_node=npernode,
         )
 
+        # Issue #521: rank result JSONs are written on the node where each rank
+        # lands, but aggregation globs them locally on the controller. Without a
+        # shared filesystem, remote-host results are invisible and the run
+        # silently records partial_failure. Fail fast with an actionable error.
+        if not getattr(self.args, 'what_if', False):
+            self._probe_results_dir_shared(hosts)
+
         option_results = {}
         for option in [1, 2, 3]:
             option_kv_args = self._build_option_kvcache_args(option, is_closed)
@@ -488,6 +498,103 @@ class KVCacheBenchmark(Benchmark):
                 self.logger.info("Inter-option sleep interrupted by user.")
                 raise
 
+    def _probe_results_dir_shared(self, hosts: List[str]) -> None:
+        """Verify --results-dir is visible at the same path on every host.
+
+        Issue #521: ``mlperf_wrapper.py`` writes ``kvcache_results_*.json``
+        on whichever node each rank lands on, but
+        ``_aggregate_option_results`` globs locally on the controller. Without
+        a filesystem mounted at the same path on every host listed in
+        ``--hosts``, the controller never sees the remote-host result files
+        and the run silently records ``partial_failure``.
+
+        We probe by asking each unique host (1 rank per host) to drop a
+        sentinel file inside ``self.run_result_output``. If the FS is shared,
+        the controller sees N sentinels; if not, it sees only the sentinel
+        from the host(s) it shares storage with. We fail closed with a
+        diagnostic that names the shared-FS requirement, so the user is not
+        stuck debugging a partial-failure summary after the option loop has
+        already run for ~15+ minutes.
+
+        No-ops when every entry in ``hosts`` resolves to the local machine
+        (single-host runs cannot exhibit the bug).
+        """
+        unique_hosts: List[str] = []
+        seen = set()
+        for raw in hosts or []:
+            hostname = raw.split(':')[0] if ':' in raw else raw
+            if hostname and hostname not in seen:
+                seen.add(hostname)
+                unique_hosts.append(hostname)
+
+        if len(unique_hosts) <= 1:
+            return
+        if all(_is_localhost(h) for h in unique_hosts):
+            return
+
+        probe_id = uuid.uuid4().hex[:12]
+        probe_dir = Path(self.run_result_output) / '.fs_probe'
+        probe_dir.mkdir(parents=True, exist_ok=True)
+
+        # Inline probe: each rank tags a sentinel with its hostname so we can
+        # tell from the controller which hosts share the FS and which do not.
+        # ``mkdir(parents=True, exist_ok=True)`` lets the rank succeed even
+        # when --results-dir was never created on its node (it writes to its
+        # own local filesystem; controller will not see those sentinels).
+        inline = (
+            "import os,socket,pathlib;"
+            f"d=pathlib.Path({str(probe_dir)!r});"
+            "d.mkdir(parents=True,exist_ok=True);"
+            "r=os.environ.get('OMPI_COMM_WORLD_RANK',os.environ.get('PMI_RANK','x'));"
+            "h=socket.gethostname();"
+            f"(d/('{probe_id}__rank'+r+'__'+h+'.ok')).write_text(h)"
+        )
+
+        probe_hosts_arg = ",".join(f"{h}:1" for h in unique_hosts)
+        mpi_bin = getattr(self.args, 'mpi_bin', 'mpirun')
+        probe_prefix = (
+            f"{mpi_bin} -n {len(unique_hosts)} -host {probe_hosts_arg} "
+            f"--map-by node --bind-to none"
+        )
+        if getattr(self.args, 'allow_run_as_root', False):
+            probe_prefix += " --allow-run-as-root"
+
+        probe_cmd = f"{probe_prefix} {sys.executable} -c {shlex.quote(inline)}"
+
+        self.logger.status(
+            f"Probing --results-dir visibility across "
+            f"{len(unique_hosts)} host(s)..."
+        )
+        self._execute_command(
+            probe_cmd,
+            output_file_prefix=f"kvcache_fs_probe_{self.run_datetime}",
+            print_stdout=False,
+            print_stderr=False,
+        )
+
+        found_hosts: set = set()
+        for marker in probe_dir.glob(f"{probe_id}__rank*__*.ok"):
+            try:
+                found_hosts.add(marker.read_text().strip())
+            except Exception:
+                continue
+
+        if len(found_hosts) >= len(unique_hosts):
+            return
+
+        raise RuntimeError(
+            "kvcache --results-dir is not visible on every host listed in "
+            f"--hosts. Probed {len(unique_hosts)} host(s) "
+            f"({sorted(unique_hosts)}); only {len(found_hosts)} wrote a "
+            f"sentinel into {self.run_result_output} "
+            f"({sorted(found_hosts)}). The kvcache benchmark requires "
+            "--results-dir to be on a filesystem mounted at the same path on "
+            "every host in --hosts (e.g. NFS/Lustre/GPFS); otherwise rank "
+            "result files written on remote nodes are invisible to the "
+            "controller's aggregation step. Mount a shared filesystem and "
+            "re-run, or run on a single host."
+        )
+
     def _aggregate_option_results(
         self,
         option: int,
@@ -547,6 +654,20 @@ class KVCacheBenchmark(Benchmark):
             all_avg_throughput.append(sum(trial_avg_throughput))
             all_storage_throughput.append(sum(trial_storage_throughput))
             all_p95_latency.append(max(trial_p95_latency) if trial_p95_latency else 0.0)
+        if missing_files:
+            hosts = getattr(self.args, 'hosts', None) or []
+            multi_host = any(not _is_localhost(h.split(':')[0]) for h in hosts)
+            if multi_host:
+                # Defense-in-depth — _probe_results_dir_shared should already
+                # have failed the run before we get here. Surface the same
+                # hint anyway in case the probe was skipped or missed an edge
+                # case (e.g. partial mount on a subset of nodes).
+                self.logger.warning(
+                    f"Option {option}: {len(missing_files)} rank result "
+                    "file(s) missing. In multi-host runs this typically "
+                    "means --results-dir is not on a filesystem visible at "
+                    "the same path on every host in --hosts (see issue #521)."
+                )
         return {
             'option': option,
             'aggregated_read_bandwidth_gbps': fmean(all_read_bw) if all_read_bw else 0.0,

--- a/mlpstorage_py/cli/kvcache_args.py
+++ b/mlpstorage_py/cli/kvcache_args.py
@@ -48,7 +48,10 @@ KVCACHE_HELP_MESSAGES = {
         "'latency' optimizes for response time, 'throughput' for requests/second."
     ),
     'kvcache_run': (
-        "Run the MLPerf KV Cache benchmark sequence (options 1, 2, and 3 via mlperf_wrapper.py)."
+        "Run the MLPerf KV Cache benchmark sequence (options 1, 2, and 3 via mlperf_wrapper.py). "
+        "Multi-host runs (--hosts with more than one host) REQUIRE --results-dir to be on a "
+        "filesystem mounted at the same path on every host (e.g. NFS/Lustre/GPFS); rank result "
+        "JSONs are written on the node where each rank lands and aggregated on the controller."
     ),
     'kvcache_datasize': (
         "Calculate memory requirements for KV cache based on model and user count."

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -1480,3 +1480,137 @@ class TestExecuteRunHonorsNumProcesses:
             rc = bm._execute_run()
         assert rc == 1
         mock_exec.assert_not_called()
+
+
+class TestProbeResultsDirShared:
+    """Tests for KVCacheBenchmark._probe_results_dir_shared.
+
+    Issue #521: kvcache must fail fast when --results-dir is not visible at
+    the same path on every host in --hosts. Otherwise rank result files
+    written on remote nodes are invisible to the controller's aggregation.
+    """
+
+    def test_localhost_only_is_noop(self, tmp_path):
+        """All-localhost runs cannot exhibit the bug; probe must not spawn mpi."""
+        bm = _make_run_benchmark(tmp_path)
+        with patch.object(bm, '_execute_command') as mock_exec:
+            bm._probe_results_dir_shared(['localhost'])
+        mock_exec.assert_not_called()
+
+    def test_single_host_is_noop(self, tmp_path):
+        """A single-host run (even non-localhost) cannot scatter results."""
+        bm = _make_run_benchmark(tmp_path)
+        with patch.object(bm, '_execute_command') as mock_exec:
+            bm._probe_results_dir_shared(['h1'])
+        mock_exec.assert_not_called()
+
+    def test_passes_when_all_hosts_write_sentinel(self, tmp_path):
+        """Shared FS: each host writes its sentinel; probe returns cleanly."""
+        bm = _make_run_benchmark(tmp_path)
+
+        def fake_execute(cmd, **kwargs):
+            # Simulate every host successfully landing its sentinel in the
+            # probe dir (which is what a shared FS would produce).
+            probe_dir = Path(bm.run_result_output) / '.fs_probe'
+            assert probe_dir.exists(), "probe dir should be pre-created"
+            # Extract probe_id from the embedded inline script in the command.
+            import re
+            m = re.search(r"'([0-9a-f]{12})__rank'", cmd)
+            assert m is not None, f"probe_id not found in cmd: {cmd}"
+            probe_id = m.group(1)
+            for rank, host in enumerate(['h1', 'h2', 'h3']):
+                marker = probe_dir / f"{probe_id}__rank{rank}__{host}.ok"
+                marker.write_text(host)
+            return ('', '', 0)
+
+        with patch.object(bm, '_execute_command', side_effect=fake_execute):
+            bm._probe_results_dir_shared(['h1', 'h2', 'h3'])
+
+    def test_raises_when_remote_hosts_miss_sentinel(self, tmp_path):
+        """Non-shared FS: only the controller's sentinel is visible; fail."""
+        bm = _make_run_benchmark(tmp_path)
+
+        def fake_execute(cmd, **kwargs):
+            import re
+            probe_dir = Path(bm.run_result_output) / '.fs_probe'
+            m = re.search(r"'([0-9a-f]{12})__rank'", cmd)
+            probe_id = m.group(1)
+            # Only one host out of three landed a sentinel — the other two
+            # wrote to their own local FS (invisible to the controller).
+            (probe_dir / f"{probe_id}__rank0__h1.ok").write_text('h1')
+            return ('', '', 0)
+
+        with patch.object(bm, '_execute_command', side_effect=fake_execute):
+            with pytest.raises(RuntimeError) as excinfo:
+                bm._probe_results_dir_shared(['h1', 'h2', 'h3'])
+        msg = str(excinfo.value)
+        assert 'not visible on every host' in msg
+        assert 'shared' in msg.lower() or 'NFS' in msg
+        # Hostnames the user passed must surface in the diagnostic.
+        assert 'h2' in msg and 'h3' in msg
+
+    def test_strips_slot_suffixes_before_probing(self, tmp_path):
+        """--hosts 'h1:4 h2:4' should probe 2 unique hosts, not 8."""
+        bm = _make_run_benchmark(tmp_path)
+        captured = {}
+
+        def fake_execute(cmd, **kwargs):
+            captured['cmd'] = cmd
+            # Land sentinels for both unique hosts.
+            import re
+            probe_dir = Path(bm.run_result_output) / '.fs_probe'
+            m = re.search(r"'([0-9a-f]{12})__rank'", cmd)
+            probe_id = m.group(1)
+            (probe_dir / f"{probe_id}__rank0__h1.ok").write_text('h1')
+            (probe_dir / f"{probe_id}__rank1__h2.ok").write_text('h2')
+            return ('', '', 0)
+
+        with patch.object(bm, '_execute_command', side_effect=fake_execute):
+            bm._probe_results_dir_shared(['h1:4', 'h2:4'])
+
+        # 1 rank per unique host, with :1 slot pinning in the host arg.
+        assert '-n 2 ' in captured['cmd']
+        assert '-host h1:1,h2:1' in captured['cmd']
+
+    def test_execute_run_invokes_probe_for_multi_host(self, tmp_path):
+        """_execute_run should call the probe when --hosts has remote entries."""
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.trials = 1
+        bm.args.inter_option_delay = 0
+        bm.args.num_processes = 2
+        bm.args.npernode = 1  # consistent with num_processes=2 across 2 hosts
+        bm.args.hosts = ['h1', 'h2']
+        agg = {
+            'option': 1, 'aggregated_read_bandwidth_gbps': 0.0,
+            'aggregated_write_bandwidth_gbps': 0.0,
+            'aggregated_avg_throughput_tokens_per_sec': 0.0,
+            'aggregated_storage_throughput_tokens_per_sec': 0.0,
+            'aggregated_p95_latency_ms': 0.0,
+            'rank_count': 2, 'trial_count': 1,
+            'partial_failure': False, 'missing_files': [], 'cpu_tier_ranks': [],
+        }
+        with patch.object(bm, '_probe_results_dir_shared') as mock_probe, \
+             patch.object(bm, '_execute_command', return_value=('', '', 0)), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results', return_value=agg), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'):
+            bm._execute_run()
+        mock_probe.assert_called_once_with(['h1', 'h2'])
+
+    def test_execute_run_skips_probe_in_what_if_mode(self, tmp_path):
+        """--what-if must not spawn mpirun probes (no execution at all)."""
+        bm = _make_run_benchmark(tmp_path, what_if=True)
+        bm.args.trials = 1
+        bm.args.inter_option_delay = 0
+        bm.args.num_processes = 2
+        bm.args.npernode = 1
+        bm.args.hosts = ['h1', 'h2']
+        with patch.object(bm, '_probe_results_dir_shared') as mock_probe, \
+             patch.object(bm, '_execute_command', return_value=('', '', 0)), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results'), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'):
+            bm._execute_run()
+        mock_probe.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds a proactive shared-FS probe to the kvcache benchmark: before launching any workload, each unique host in `--hosts` drops a sentinel file inside `--results-dir` via a one-rank-per-host `mpirun`. The controller then verifies it can see every sentinel locally. If any are missing, the run fails fast with a diagnostic that names the shared-FS requirement, lists which hosts wrote, and points at the remediation.
- Aggregation logs the same hint as a fallback when `partial_failure=True` in a multi-host run, in case the probe is bypassed or misses an edge case (e.g. a partial mount on a subset of nodes).
- `kvcache run --help` now documents the shared-FS requirement explicitly.

## Why

Per #521, multi-host kvcache runs write `kvcache_results_*.json` on whichever node each rank lands on, but `_aggregate_option_results()` globs them locally on the controller. Without a filesystem mounted at the same path on every host in `--hosts`, remote-host result files are invisible to aggregation and the run silently records `partial_failure` after the option loop has already run for many minutes.

This is the "Option C" fix from the issue — document and detect the requirement, fail closed early — chosen because it is the cheapest path to making the failure mode actionable. A future PR can add Option A (gather remote rank dirs back to the controller) for clusters without shared storage.

## On meeting the shared-FS requirement

The shared filesystem used for `--results-dir` **must not be the system-under-test**. The kvcache benchmark measures the SUT under load; if the result-aggregation FS is the same storage that's being benchmarked, every per-rank JSON write (and the cluster-collector / metadata writes alongside them) lands on the SUT and perturbs the scores being measured. This requirement is therefore not a request for additional benchmark-grade infrastructure — a plain NFS export from the controller to every host in `--hosts`, mounted at the same path, is sufficient and is what most submitters already have in place for logs and configs.

The probe pattern follows the existing `mlpstorage_py/cluster_collector.py` approach of executing a small script via `mpirun -host h1:1,h2:1,... -n N --map-by node`. Sentinel files are tagged with `OMPI_COMM_WORLD_RANK` / `PMI_RANK` and the rank's resolved hostname so the failure message can name which hosts couldn't reach the directory.

The probe is a no-op for single-host and all-localhost runs (cannot exhibit the bug) and is skipped under `--what-if`.

## Test plan

- [x] `uv run pytest tests/unit` — 1604 passed, 4 skipped, 0 failed
- [x] `uv run pytest tests/unit/test_benchmarks_kvcache.py` — 87 passed (7 new in `TestProbeResultsDirShared`)
- [x] `uv run pytest tests/unit/test_cli_kvcache.py` — 60 passed (covers the updated help string parsing)
- [x] New test cases:
  - localhost-only short-circuits (no mpirun invoked)
  - single-host short-circuits
  - all sentinels present → returns cleanly
  - missing sentinels → raises `RuntimeError` with hostnames + remediation
  - `--hosts h1:4 h2:4` strips slots → probes 2 unique hosts with `:1`
  - `_execute_run` wires the probe in for multi-host
  - `--what-if` bypasses the probe

Closes #521