### PR TITLE
docs(systemd_ipc): expand advisory to cover both #447 and #528 shm vectors

### DIFF
--- a/mlpstorage_py/environment/systemd_ipc.py
+++ b/mlpstorage_py/environment/systemd_ipc.py
@@ -1,17 +1,28 @@
 """
 Detect whether systemd-logind will reap POSIX IPC objects out from under the
-benchmark, which causes the SemLock FileNotFoundError reported in #447.
+benchmark, which causes two independent shm-reap failures: the SemLock
+FileNotFoundError reported in #447 and the PyTorch tensor-storage
+"could not unlink the shared memory file /torch_*" RuntimeError reported
+in #528.
 
 systemd-logind defaults to `RemoveIPC=yes`, which removes /dev/shm/sem.*,
-SysV semaphores, and shared memory belonging to a user once that user has
-no remaining login sessions. mpirun launches that briefly detach from
-the controlling session, or Python's spawn-context multiprocessing that
-re-opens semaphores by name, can hit this window and crash with
-`FileNotFoundError: [Errno 2] No such file or directory` inside
-`SemLock._rebuild`.
+/dev/shm/torch_*, SysV semaphores, and shared memory belonging to a user
+once that user has no remaining login sessions. mpirun launches that
+briefly detach from the controlling session can hit this window and crash
+in one of two ways:
+  - `FileNotFoundError: [Errno 2]` inside multiprocessing.SemLock._rebuild
+    (#447 — mitigated by storage PR #460's multiprocessing_context=fork)
+  - `RuntimeError: could not unlink the shared memory file /torch_*`
+    inside a PyTorch DataLoader worker (#528 — INDEPENDENT of fork vs
+    spawn; the multiprocessing_context fix does not cover it)
 
 `loginctl enable-linger USER` keeps a user-level systemd manager alive
-regardless of login sessions, which suppresses the reap.
+regardless of login sessions, which suppresses the reap and covers both
+vectors. For users without privilege to enable linger, the #528 vector
+can additionally be sidestepped by setting
+`DLIO_TORCH_SHARING_STRATEGY=file_descriptor` before launching (switches
+PyTorch IPC to FD-passing so no /dev/shm/torch_* files are created); the
+#447 vector requires sysadmin escalation if linger is unavailable.
 
 This module only inspects host state — it never modifies it. The intended
 caller is `validate_benchmark_environment`, which logs the warning string
@@ -149,9 +160,26 @@ def check_removeipc_risk(
     return (
         "systemd-logind has RemoveIPC=yes (the distro default). When a "
         "benchmark spawns Python multiprocessing workers, the kernel can "
-        "reap their POSIX semaphores out from under them, producing "
-        "`FileNotFoundError: [Errno 2]` in multiprocessing/synchronize.py "
-        "(see issue #447). To prevent this, enable systemd user-linger:\n"
+        "reap two independent classes of user-owned /dev/shm files out "
+        "from under live ranks:\n"
+        "  - /dev/shm/sem.mp-*  -> FileNotFoundError in "
+        "multiprocessing/synchronize.py (issue #447)\n"
+        "  - /dev/shm/torch_*   -> 'could not unlink the shared memory "
+        "file' RuntimeError in PyTorch DataLoader workers (issue #528)\n"
+        "\n"
+        "PRIMARY FIX (covers BOTH vectors; persistent):\n"
         f"  sudo loginctl enable-linger {user_for_msg}\n"
-        "Alternatively, set `RemoveIPC=no` in /etc/systemd/logind.conf."
+        "  loginctl show-user "
+        f"{user_for_msg} --property=Linger   # should report Linger=yes\n"
+        "\n"
+        "FALLBACK if you cannot enable linger (HPC cluster, container, "
+        "hosted env), to be applied IN ADDITION TO any existing #447 fix:\n"
+        "  - Set DLIO_TORCH_SHARING_STRATEGY=file_descriptor before "
+        "launching (switches PyTorch IPC away from named shm so #528's "
+        "vector has nothing to reap).\n"
+        "  - Raise FD limits before launching mpirun "
+        "(`ulimit -n 65536`); file_descriptor strategy opens one FD per "
+        "shared tensor and the default ulimit -n=1024 is too low.\n"
+        "  - Or sysadmin-side: set `RemoveIPC=no` in "
+        "/etc/systemd/logind.conf."
     )


### PR DESCRIPTION
**Draft.** Companion to **mlcommons/DLIO_local_changes#34** — together they address the two-front problem in mlcommons/storage#528.

## Why

The existing RemoveIPC advisory in `mlpstorage_py/environment/systemd_ipc.py` only mentions the `/dev/shm/sem.mp-*` SemLock vector (#447). #528 (Wolfgang De Salvador) shows there's a SECOND, INDEPENDENT shm-reap vector against `/dev/shm/torch_*` (PyTorch tensor-storage IPC) that the `multiprocessing_context=fork` mitigation from PR #460 does NOT cover.

Operators who applied only the YAML half of #460's fix and ran multi-node on Ubuntu 22.04 / 24.04 with default `RemoveIPC=yes` still hit crashes — see #528's reproduction table (100% failure rate at 12 nodes). The startup advisory needs to surface the second vector explicitly and the fallback for users without `enable-linger` privilege.

## What changes (one file)

`mlpstorage_py/environment/systemd_ipc.py`:

- **Module docstring** updated to name both #447 and #528 with their distinct error strings.
- **`check_removeipc_risk()` return text** rewritten to:
  - List BOTH vectors explicitly.
  - Promote `sudo loginctl enable-linger $USER` as the primary fix (covers both) + include the verification command (`loginctl show-user $USER --property=Linger`).
  - Add a **FALLBACK** section for users without `enable-linger` privilege: `DLIO_TORCH_SHARING_STRATEGY=file_descriptor` + `ulimit -n 65536`, or sysadmin-side `RemoveIPC=no` in `/etc/systemd/logind.conf`.

The `DLIO_TORCH_SHARING_STRATEGY` knob mentioned in the fallback is implemented by **mlcommons/DLIO_local_changes#34**; both PRs need to land for the fallback advice to be actionable end-to-end.

## Test plan

- [x] `uv run pytest tests/unit/test_systemd_ipc.py -q` — all 25 tests pass. The existing assertions pin the `loginctl enable-linger <user>` substring, which is preserved by the new wording — no test updates needed.

## Why not auto-apply

Deliberate non-goal: this PR (and #34) do not silently flip the sharing strategy when `RemoveIPC=yes && Linger=no` is detected. Silent auto-magic breaks differently downstream (FD exhaustion at `ulimit -n=1024` produces cryptic errors) and removes operator visibility into what was tuned. The advisory + the #528 failure-time banner give the operator clear instructions; the operator runs the commands.

## References

- mlcommons/storage#528 (primary; Wolfgang's analysis)
- mlcommons/storage#447 (related — vector 1)
- mlcommons/storage PR #460 (mitigation that covers only vector 1)
- mlcommons/DLIO_local_changes#34 (companion: failure-time banner + env-var hook)