### PR TITLE
chore: bump dlio-benchmark pin + version 3.0.20 -> 3.0.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.20"
+version = "3.0.21"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?branch=main#ae1247a6d430f50acc8552856462d75dd88b8b52" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?branch=main#b63fef4102cce46432e8f6a1ba6b655f79ff70f5" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.20"
+version = "3.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?branch=main#b63fef4102cce46432e8f6a1ba6b655f79ff70f5" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?branch=main#75d129b1ca3b659d2b5095a6fc320f4033a50b2e" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
Closes #466
Closes #472
Closes #504
Closes #528

## Summary

- `pyproject.toml`: `3.0.20` → `3.0.21`.
- `uv.lock`: regenerated via `uv lock --upgrade-package dlio-benchmark`; pin moves `ae1247a6` (DLIO PR #29 merge) → `75d129b1` (current DLIO main HEAD).

## What's in the DLIO bump

Five DLIO PRs have landed since the previous pin and are pulled in here:

| DLIO PR | mlcommons/storage issue | What it does |
|---|---|---|
| [#30](https://github.com/mlcommons/DLIO_local_changes/pull/30) | #504 | Propagate `dataset.skip_listing` through `LoadConfig` so the CLI / YAML override actually reaches the listing layer. |
| [#31](https://github.com/mlcommons/DLIO_local_changes/pull/31) | #504 | `data_generator` fast-fail in the async upload pipeline. On the first `put_data()` exception, stop submitting new uploads and re-raise promptly. Bounds `_futures` growth to `n_workers` after the first failure — kills the unbounded-list OOM regardless of trigger. |
| [#32](https://github.com/mlcommons/DLIO_local_changes/pull/32) | #472 | @russfellows' preflight in `ObjStoreLibStorage`: credentials check, s3torchconnector silent-route-to-AWS guard, per-library bucket reachability probe. |
| [#34](https://github.com/mlcommons/DLIO_local_changes/pull/34) | #528 | Wrap PyTorch shm-reap `RuntimeError` with an actionable banner pointing operators at `loginctl enable-linger` (primary fix) and `DLIO_TORCH_SHARING_STRATEGY=file_descriptor` + `ulimit -n` raise (fallback). Adds the `DLIO_TORCH_SHARING_STRATEGY` env-var hook so the fallback is actually usable. |
| [#35](https://github.com/mlcommons/DLIO_local_changes/pull/35) | #466 | Eliminate double-allocation OOM in flat-layout file listing. |

This release effectively resolves both directions of the storage#504 OOM (preflight surfaces config errors clearly; fast-fail bounds the OOM regardless of cause), wires up the operator-facing banner for storage#528, fixes skip_listing propagation for storage#504, and closes #466's flat-layout listing OOM.

## Test plan

- [x] `git diff` shows only the two pyproject.toml / uv.lock version lines + the dlio-benchmark SHA in uv.lock.
- [x] `uv lock --upgrade-package dlio-benchmark` clean — no dependency churn beyond dlio-benchmark and the editable mlpstorage entry.
- [ ] No mlpstorage code change in this PR — behavioral testing for the five DLIO PRs lives in their respective PRs / issues. Worth a smoke run on a real object-storage workload before merging, since #32 changes the `ObjStoreLibStorage.__init__` path and #31 changes the upload-failure path.

## Coordination

- Companion PR **mlcommons/storage#532** (still draft) updates the `systemd_ipc.py` startup advisory text to reference both #447 and #528 vectors and the new `DLIO_TORCH_SHARING_STRATEGY` fallback — pairs with DLIO #34 in this bump. Can be promoted out of draft once the team has eyes on this PR.
