### PR TITLE
feat(#507): add --o-direct flag for O_DIRECT local filesystem I/O

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -217,6 +217,39 @@ class DLIOBenchmark(Benchmark, abc.ABC):
             f'uri_scheme={uri_scheme}, force_path_style={is_http_scheme and bool(endpoint_url)})'
         )
 
+    def _apply_odirect_params(self, storage_root=None):
+        """When --o-direct is used, route I/O through s3dlio's O_DIRECT local filesystem mode.
+
+        Configures DLIO to use the direct:// URI scheme so s3dlio opens every
+        file with O_DIRECT, bypassing the OS page cache.  Works for ALL training
+        and checkpointing workloads regardless of data format — this is distinct
+        from reader.odirect which is the legacy NPY/NPZ-only path.
+
+        storage_root is the filesystem directory that becomes the s3dlio "bucket"
+        root.  For training it is --data-dir; for checkpointing it is
+        --checkpoint-folder.  The full URI of a file is:
+            direct://<storage_root>/<relative-path>
+            e.g. direct:///mnt/data/unet3d/train/img_000000_of_007200.npz
+
+        This method is a no-op when --o-direct was not passed.  Incompatibility
+        with --object is enforced at CLI-validation time, not here.
+        See mlcommons/storage#507.
+        """
+        if not getattr(self.args, 'o_direct', False):
+            return
+        if 'storage.storage_type' not in self.params_dict:
+            self.params_dict['storage.storage_type'] = 's3'
+        if 'storage.storage_options.storage_library' not in self.params_dict:
+            self.params_dict['storage.storage_options.storage_library'] = 's3dlio'
+        if 'storage.storage_options.uri_scheme' not in self.params_dict:
+            self.params_dict['storage.storage_options.uri_scheme'] = 'direct'
+        if storage_root is not None and 'storage.storage_root' not in self.params_dict:
+            self.params_dict['storage.storage_root'] = storage_root.rstrip('/')
+        self.logger.info(
+            '--o-direct: routing I/O through s3dlio direct:// (O_DIRECT, bypasses page cache); '
+            f'storage_root={storage_root!r}'
+        )
+
     @staticmethod
     def _compute_validation_interval(num_files: int) -> int:
         """Return a validation-sample interval scaled to dataset size.
@@ -400,6 +433,10 @@ class TrainingBenchmark(DLIOBenchmark):
         # Inject object storage params before add_datadir_param (which reads storage_type
         # from params_dict to decide whether to create local directories).
         self._apply_object_storage_params()
+        # For --o-direct: switch to s3dlio direct:// mode after object-storage check
+        # (object-storage already sets storage_type=s3; the two are mutually exclusive
+        # and rejected at CLI-validation time, so only one branch can be active here).
+        self._apply_odirect_params(storage_root=getattr(self.args, 'data_dir', None))
         # Enable skip_listing for all storage types (file and object).  Must be
         # called after _apply_object_storage_params so combined_params is final.
         self._apply_skip_listing_params()
@@ -415,12 +452,27 @@ class TrainingBenchmark(DLIOBenchmark):
         self.logger.verboser(f'Instantiated the Training Benchmark...')
 
     def add_datadir_param(self):
-        self.params_dict['dataset.data_folder'] = self.args.data_dir
-        # Detect object storage: if storage.storage_type is not 'local' (or unset),
-        # data_folder is an S3/object-store key prefix — never a local filesystem path.
+        # Detect storage mode set by _apply_object_storage_params or _apply_odirect_params.
         storage_type = self.params_dict.get('storage.storage_type', 'local')
         is_object_storage = storage_type != 'local'
 
+        # For --o-direct: storage_root is already set to data_dir; data_folder must
+        # be the model-relative path so URIs don't double-include data_dir.
+        # URI = direct://<storage_root>/<data_folder>/train/<file>
+        #       = direct:///<data_dir>/<model>/train/<file>
+        if getattr(self.args, 'o_direct', False) and is_object_storage:
+            if any(self.args.data_dir.rstrip('/').endswith(m) for m in MODELS):
+                # data_dir already includes the model name; data_folder is empty (root of storage_root)
+                self.params_dict['dataset.data_folder'] = ''
+            else:
+                self.params_dict['dataset.data_folder'] = self.args.model
+            self.logger.debug(
+                f'--o-direct: dataset.data_folder={self.params_dict["dataset.data_folder"]!r} '
+                f'(relative to storage_root={self.params_dict.get("storage.storage_root")!r})'
+            )
+            return
+
+        self.params_dict['dataset.data_folder'] = self.args.data_dir
         if not any([self.args.data_dir.endswith(m) for m in MODELS]):
             # Append the model name to the data dir path
             self.params_dict['dataset.data_folder'] = os.path.join(self.args.data_dir, self.args.model)
@@ -555,6 +607,8 @@ class CheckpointingBenchmark(DLIOBenchmark):
         self.config_file = f'{self.config_name}.yaml'
         self.params_dict, self.yaml_params, self.combined_params = self.process_dlio_params(self.config_file)
         self._apply_object_storage_params()
+        # For --o-direct: checkpoint_folder is the s3dlio "bucket" root.
+        self._apply_odirect_params(storage_root=getattr(self.args, 'checkpoint_folder', None))
         self.verify_benchmark()
         self.add_checkpoint_params()
         self.logger.status(f'Instantiated the Checkpointing Benchmark...')
@@ -571,7 +625,13 @@ class CheckpointingBenchmark(DLIOBenchmark):
         self.params_dict['checkpoint.num_checkpoints_read'] = self.args.num_checkpoints_read
         self.params_dict['checkpoint.num_checkpoints_write'] = self.args.num_checkpoints_write
         if self.args.checkpoint_folder:
-            self.params_dict['checkpoint.checkpoint_folder'] = os.path.join(self.args.checkpoint_folder, self.args.model)
+            if getattr(self.args, 'o_direct', False) and self.params_dict.get('storage.storage_type') == 's3':
+                # In direct:// mode: storage_root = checkpoint_folder (set by _apply_odirect_params).
+                # DLIO's checkpoint_folder param is the model-relative subdirectory within storage_root.
+                # URI = direct://<checkpoint_folder>/<model>/checkpoint_file
+                self.params_dict['checkpoint.checkpoint_folder'] = self.args.model
+            else:
+                self.params_dict['checkpoint.checkpoint_folder'] = os.path.join(self.args.checkpoint_folder, self.args.model)
 
 
     def add_workflow_to_cmd(self, cmd) -> str:

--- a/mlpstorage_py/cli/checkpointing_args.py
+++ b/mlpstorage_py/cli/checkpointing_args.py
@@ -112,6 +112,23 @@ def _add_checkpointing_core_args(parser, command):
     if command in ("run", "configview"):
         add_storage_type_arguments(parser, required=True)
 
+    # --o-direct: available for run and configview (not datasize).
+    # Routes all checkpoint I/O through s3dlio's direct:// URI scheme with
+    # O_DIRECT, bypassing the OS page cache.  Incompatible with --object.
+    # See mlcommons/storage#507.
+    if command in ("run", "configview"):
+        parser.add_argument(
+            '--o-direct',
+            action='store_true',
+            default=False,
+            dest='o_direct',
+            help=(
+                "Route all checkpoint I/O through s3dlio's O_DIRECT local "
+                "filesystem mode (direct:// URI scheme), bypassing the OS "
+                "page cache.  Incompatible with --object."
+            ),
+        )
+
     # Checkpoint folder required for run only
     if command == "run":
         parser.add_argument(
@@ -199,6 +216,15 @@ def validate_checkpointing_arguments(args):
             error_messages.append(
                 "CLOSED submissions cannot set both --num-checkpoints-write=0 and "
                 "--num-checkpoints-read=0 in the same invocation."
+            )
+
+    if getattr(args, 'o_direct', False):
+        protocol = getattr(args, 'data_access_protocol', None)
+        if protocol == 'object':
+            error_messages.append(
+                "--o-direct is incompatible with --object. "
+                "O_DIRECT mode reads from the local filesystem via s3dlio's "
+                "direct:// URI scheme; it cannot be combined with an S3 endpoint."
             )
 
     if error_messages:

--- a/mlpstorage_py/cli/training_args.py
+++ b/mlpstorage_py/cli/training_args.py
@@ -199,6 +199,28 @@ def _add_training_core_args(parser, command, accel_choices):
             ),
         )
 
+    # --o-direct: available for datagen, run, and configview (not datasize).
+    # Routes all training I/O through s3dlio's direct:// URI scheme, opening
+    # every file with O_DIRECT so reads bypass the OS page cache entirely.
+    # Works for ALL training workloads regardless of data format — this is
+    # independent of reader.odirect, which is the legacy NPY/NPZ-only path.
+    # Incompatible with --object (O_DIRECT targets local filesystem only).
+    # See mlcommons/storage#507.
+    if command != 'datasize':
+        parser.add_argument(
+            '--o-direct',
+            action='store_true',
+            default=False,
+            dest='o_direct',
+            help=(
+                "Route all training I/O through s3dlio's O_DIRECT local "
+                "filesystem mode (direct:// URI scheme), bypassing the OS "
+                "page cache.  Works for every training workload regardless "
+                "of data format.  Incompatible with --object (O_DIRECT "
+                "targets the local filesystem only)."
+            ),
+        )
+
     # --params is allowed in CLOSED mode for the parameters listed in
     # TrainingRunRulesChecker.CLOSED_ALLOWED_PARAMS (e.g. dataset.num_files_train,
     # dataset.num_subfolders_train). Register it in the core args so closed
@@ -271,6 +293,16 @@ def validate_training_arguments(args):
             f"ERROR: --data-dir is required for training {command} with object storage.\n"
             "  Specify --data-dir <key-prefix-or-URI> on the command line, or set\n"
             "  'data_dir:' in the file passed via --config-file.",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_CODE.INVALID_ARGUMENTS)
+
+    if getattr(args, 'o_direct', False) and protocol == 'object':
+        print(
+            "ERROR: --o-direct is incompatible with --object.\n"
+            "  --o-direct routes I/O through s3dlio's direct:// URI scheme, which\n"
+            "  reads from the local filesystem with O_DIRECT — not from an S3 endpoint.\n"
+            "  Use --file with --o-direct, or use --object without --o-direct.",
             file=sys.stderr,
         )
         sys.exit(EXIT_CODE.INVALID_ARGUMENTS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.20"
+version = "3.0.21"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/unit/test_dlio_odirect.py
+++ b/tests/unit/test_dlio_odirect.py
@@ -1,0 +1,257 @@
+"""
+Tests for --o-direct CLI flag and _apply_odirect_params() (mlcommons/storage#507).
+
+--o-direct routes all training (and checkpointing) I/O through s3dlio's
+direct:// URI scheme so every file is opened with O_DIRECT, bypassing the
+OS page cache.  It works for ALL workloads — not model-specific.
+
+URI layout:
+    storage_root = --data-dir (e.g. /mnt/data)
+    data_folder  = model name relative to storage_root (e.g. unet3d)
+    File URI     = direct://<storage_root>/<data_folder>/train/<file>
+               i.e. direct:///mnt/data/unet3d/train/img_000000_of_007200.npz
+"""
+
+import sys
+import os
+from argparse import Namespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import importlib.util as _ilu
+for _dep in ('pyarrow', 'pyarrow.ipc', 'dotenv'):
+    if _ilu.find_spec(_dep) is None and _dep not in sys.modules:
+        sys.modules[_dep] = MagicMock()
+
+from mlpstorage_py.benchmarks.dlio import DLIOBenchmark
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_obj(o_direct=True, data_dir='/mnt/data', params_dict=None):
+    """Minimal stand-in for DLIOBenchmark 'self' for unit-testing the method."""
+    obj = MagicMock(spec=['args', 'params_dict', 'logger'])
+    obj.args = Namespace(o_direct=o_direct, data_dir=data_dir)
+    obj.params_dict = params_dict if params_dict is not None else {}
+    obj.logger = MagicMock()
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# _apply_odirect_params: no-op when flag absent
+# ---------------------------------------------------------------------------
+
+class TestApplyOdirectParamsNoOp:
+    def test_noop_when_flag_false(self):
+        obj = _make_obj(o_direct=False)
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data')
+        assert obj.params_dict == {}
+        obj.logger.info.assert_not_called()
+
+    def test_noop_when_flag_missing(self):
+        obj = _make_obj()
+        del obj.args.o_direct  # simulate attr not present
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data')
+        assert obj.params_dict == {}
+
+
+# ---------------------------------------------------------------------------
+# _apply_odirect_params: correct param injection
+# ---------------------------------------------------------------------------
+
+class TestApplyOdirectParamsInjection:
+    def test_sets_storage_type_s3(self):
+        obj = _make_obj()
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data')
+        assert obj.params_dict['storage.storage_type'] == 's3'
+
+    def test_sets_storage_library_s3dlio(self):
+        obj = _make_obj()
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data')
+        assert obj.params_dict['storage.storage_options.storage_library'] == 's3dlio'
+
+    def test_sets_uri_scheme_direct(self):
+        obj = _make_obj()
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data')
+        assert obj.params_dict['storage.storage_options.uri_scheme'] == 'direct'
+
+    def test_sets_storage_root_to_data_dir(self):
+        obj = _make_obj(data_dir='/mnt/data')
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data')
+        assert obj.params_dict['storage.storage_root'] == '/mnt/data'
+
+    def test_strips_trailing_slash_from_storage_root(self):
+        obj = _make_obj()
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data/')
+        assert obj.params_dict['storage.storage_root'] == '/mnt/data'
+
+    def test_storage_root_none_skips_storage_root_param(self):
+        obj = _make_obj()
+        DLIOBenchmark._apply_odirect_params(obj, storage_root=None)
+        assert 'storage.storage_root' not in obj.params_dict
+
+    def test_logs_info(self):
+        obj = _make_obj()
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data')
+        obj.logger.info.assert_called_once()
+        msg = obj.logger.info.call_args[0][0]
+        assert 'direct://' in msg
+        assert 'O_DIRECT' in msg
+
+
+# ---------------------------------------------------------------------------
+# _apply_odirect_params: respects existing user-supplied params
+# ---------------------------------------------------------------------------
+
+class TestApplyOdirectParamsNoOverride:
+    def test_does_not_override_existing_storage_type(self):
+        obj = _make_obj(params_dict={'storage.storage_type': 'custom'})
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data')
+        assert obj.params_dict['storage.storage_type'] == 'custom'
+
+    def test_does_not_override_existing_uri_scheme(self):
+        obj = _make_obj(params_dict={'storage.storage_options.uri_scheme': 'file'})
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data')
+        assert obj.params_dict['storage.storage_options.uri_scheme'] == 'file'
+
+    def test_does_not_override_existing_storage_root(self):
+        obj = _make_obj(params_dict={'storage.storage_root': '/already/set'})
+        DLIOBenchmark._apply_odirect_params(obj, storage_root='/mnt/data')
+        assert obj.params_dict['storage.storage_root'] == '/already/set'
+
+
+# ---------------------------------------------------------------------------
+# URI construction sanity check
+# ---------------------------------------------------------------------------
+
+class TestOdirectUriConstruction:
+    """Verify the URI pattern produced by get_uri() with direct:// scheme."""
+
+    def test_triple_slash_uri_for_absolute_path(self):
+        """storage_root=/mnt/data + data_folder=unet3d → direct:///mnt/data/unet3d/..."""
+        scheme = 'direct'
+        storage_root = '/mnt/data'
+        rel_path = 'unet3d/train/img_000000_of_007200.npz'
+        # Mirrors obj_store_lib.get_uri() logic:
+        uri = f"{scheme}://{storage_root}/{rel_path.lstrip('/')}"
+        assert uri == 'direct:///mnt/data/unet3d/train/img_000000_of_007200.npz'
+
+    def test_empty_data_folder_joins_to_train_correctly(self):
+        """When data_folder='', os.path.join('', 'train', file) still works."""
+        data_folder = ''
+        joined = os.path.join(data_folder, 'train', 'file.npz')
+        assert joined == 'train/file.npz'
+
+        scheme = 'direct'
+        storage_root = '/mnt/data/unet3d'
+        uri = f"{scheme}://{storage_root}/{joined.lstrip('/')}"
+        assert uri == 'direct:///mnt/data/unet3d/train/file.npz'
+
+
+# ---------------------------------------------------------------------------
+# CLI validation: --o-direct + --object rejection
+# ---------------------------------------------------------------------------
+
+class TestOdirectObjectRejection:
+    """validate_training_arguments() must reject --o-direct + --object."""
+
+    def test_training_rejects_odirect_plus_object(self, capsys):
+        from mlpstorage_py.cli.training_args import validate_training_arguments
+        from mlpstorage_py.config import EXIT_CODE
+        args = Namespace(
+            command='run',
+            data_access_protocol='object',
+            data_dir='s3://bucket/prefix',
+            o_direct=True,
+        )
+        with pytest.raises(SystemExit) as exc:
+            validate_training_arguments(args)
+        assert exc.value.code == EXIT_CODE.INVALID_ARGUMENTS
+        captured = capsys.readouterr()
+        assert '--o-direct' in captured.err
+        assert '--object' in captured.err
+
+    def test_training_allows_odirect_plus_file(self):
+        from mlpstorage_py.cli.training_args import validate_training_arguments
+        args = Namespace(
+            command='run',
+            data_access_protocol='file',
+            data_dir='/mnt/data',
+            o_direct=True,
+        )
+        # Must not raise
+        validate_training_arguments(args)
+
+    def test_training_allows_object_without_odirect(self):
+        from mlpstorage_py.cli.training_args import validate_training_arguments
+        args = Namespace(
+            command='run',
+            data_access_protocol='object',
+            data_dir='s3://bucket/prefix',
+            o_direct=False,
+        )
+        validate_training_arguments(args)
+
+    def test_checkpointing_rejects_odirect_plus_object(self, capsys):
+        from mlpstorage_py.cli.checkpointing_args import validate_checkpointing_arguments
+        from mlpstorage_py.config import LLM_MODELS, EXIT_CODE
+        args = Namespace(
+            model=LLM_MODELS[0],
+            num_checkpoints_read=10,
+            num_checkpoints_write=10,
+            data_access_protocol='object',
+            o_direct=True,
+            mode='open',
+        )
+        with pytest.raises(SystemExit) as exc:
+            validate_checkpointing_arguments(args)
+        assert exc.value.code == EXIT_CODE.INVALID_ARGUMENTS
+        captured = capsys.readouterr()
+        assert '--o-direct' in captured.out or '--o-direct' in captured.err
+
+
+# ---------------------------------------------------------------------------
+# add_datadir_param: data_folder is model-relative in direct:// mode
+# ---------------------------------------------------------------------------
+
+class TestAddDatadirParamOdirect:
+    """Training benchmark's add_datadir_param() sets data_folder relative to storage_root."""
+
+    def _make_training_obj(self, data_dir, model, o_direct=True):
+        obj = MagicMock(spec=['args', 'params_dict', 'logger'])
+        obj.args = Namespace(
+            o_direct=o_direct,
+            data_dir=data_dir,
+            model=model,
+        )
+        obj.params_dict = {
+            'storage.storage_type': 's3',
+            'storage.storage_root': data_dir.rstrip('/'),
+        } if o_direct else {}
+        obj.logger = MagicMock()
+        return obj
+
+    def test_data_folder_is_model_name_when_data_dir_is_parent(self):
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+        obj = self._make_training_obj('/mnt/data', 'unet3d')
+        TrainingBenchmark.add_datadir_param(obj)
+        assert obj.params_dict['dataset.data_folder'] == 'unet3d'
+
+    def test_data_folder_is_empty_when_data_dir_includes_model(self):
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+        obj = self._make_training_obj('/mnt/data/unet3d', 'unet3d')
+        TrainingBenchmark.add_datadir_param(obj)
+        assert obj.params_dict['dataset.data_folder'] == ''
+
+    def test_normal_path_unchanged_without_odirect(self):
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+        obj = self._make_training_obj('/mnt/data', 'unet3d', o_direct=False)
+        # Normal path creates directories — use a tmp dir to avoid side effects
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            obj.args.data_dir = tmpdir
+            TrainingBenchmark.add_datadir_param(obj)
+        assert obj.params_dict['dataset.data_folder'] != 'unet3d'


### PR DESCRIPTION
## Summary

Closes #507.

- Adds `--o-direct` to all training subcommands (datagen, run, configview — not datasize) and checkpointing `run`/`configview`.
- Routes all I/O through s3dlio's `direct://` URI scheme, which opens every file with `O_DIRECT`, bypassing the OS page cache.
- Works for **ALL training workloads regardless of data format** — this is not model-specific. It is independent of the legacy `reader.odirect=True` path, which only works for NPY/NPZ (UNet3D).
- Incompatible with `--object` (O_DIRECT targets the local filesystem); validation rejects the combination with a clear error message.
- Depends on mlcommons/DLIO_local_changes#36 (preflight directory check for `direct://` scheme).

### URI layout

```
storage_root  = --data-dir          (e.g. /mnt/data)
data_folder   = <model>             (relative, e.g. unet3d)
File URI      = direct:///mnt/data/unet3d/train/img_000000_of_007200.npz
                        ^^^
                        triple slash: two for the scheme, one for the abs path
```

For checkpointing: `storage_root = --checkpoint-folder`, `checkpoint_folder = <model>` (relative).

### CLOSED policy

All params injected by `_apply_odirect_params()` (`storage.storage_type`, `storage.storage_root`, `storage.storage_options.storage_library`, `storage.storage_options.uri_scheme`) are already in `TOOL_INJECTED_PARAMS` — no allowlist changes required.

## Files changed

| File | Change |
|------|--------|
| `mlpstorage_py/cli/training_args.py` | `--o-direct` flag + `--object` rejection |
| `mlpstorage_py/cli/checkpointing_args.py` | same for checkpointing |
| `mlpstorage_py/benchmarks/dlio.py` | `_apply_odirect_params()`, `add_datadir_param()` and `add_checkpoint_params()` relative-path fixes |
| `tests/unit/test_dlio_odirect.py` | 21 new unit tests (new file) |
| `pyproject.toml` | version bump 3.0.20 → 3.0.21 |

## Test plan

- [ ] `pytest tests/unit/test_dlio_odirect.py -v` — 21 unit tests, all pass
- [ ] `pytest tests/unit/ -q` — full unit suite, 1626 passed (2 pre-existing failures in `test_version.py` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)