### PR TITLE
chore: bump dlio-benchmark pin to DLIO #36; version 3.0.21 -> 3.0.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.21"
+version = "3.0.22"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?branch=main#75d129b1ca3b659d2b5095a6fc320f4033a50b2e" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?branch=main#ca04069eb4c9787420298943b2bba7c55803d13b" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.21"
+version = "3.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
## Summary

- `pyproject.toml`: `3.0.21` → `3.0.22`.
- `uv.lock`: regenerated via `uv lock --upgrade-package dlio-benchmark`; pin moves `75d129b1` (DLIO PR #34 merge — last picked up by #533) → `ca04069e` (current DLIO main HEAD).

## What's in the DLIO bump

One DLIO PR landed since the previous pin:

| DLIO PR | What it does |
|---|---|
| [#36](https://github.com/mlcommons/DLIO_local_changes/pull/36) | Follow-up to DLIO #32 (@russfellows' `ObjStoreLibStorage` preflight, shipped in 3.0.21). The unconditional S3 credential + bucket-reachability checks would always fail for `direct://` / `file://` URI schemes — local-filesystem mode treats the "bucket" as a filesystem path, not an S3 bucket. #36 dispatches per scheme: for `direct://` / `file://` it verifies the path exists and is writable; for `s3://` it keeps the existing S3 preflight. |

This is a behavioural regression fix on top of 3.0.21, so worth landing promptly even though it's a single-PR bump.

## Test plan

- [x] `git diff` shows only the two pyproject.toml / uv.lock version lines + the dlio-benchmark SHA in uv.lock.
- [x] `uv lock --upgrade-package dlio-benchmark` clean — no dependency churn beyond dlio-benchmark and the editable mlpstorage entry.
- [ ] No mlpstorage code change in this PR — DLIO #36's behavioral test lives in DLIO. Worth a smoke run on a `direct://` or `file://` workload to confirm preflight doesn't fail at startup.