### PR TITLE
fix(#537): populate kvcache metadata['parameters'] for reportgen + live verify

### DIFF
--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -740,6 +740,23 @@ class KVCacheBenchmark(Benchmark):
             'num_processes': self.num_processes,  # Include for distributed runs
         })
 
+        # Issue #537: KVCacheRunRulesChecker and reportgen read workload config
+        # from metadata['parameters']. KVCache has no DLIO combined_params, so
+        # the base class fills parameters with {} and every closed run lands as
+        # INVALID 'Missing model parameter'. Mirror the workload keys into
+        # parameters so both live verification and reportgen see the real run
+        # config instead of the run-checker's hard-coded defaults.
+        base_metadata['parameters'] = {
+            'model': self.model,
+            'num_users': self.num_users,
+            'duration': self.duration,
+            'gpu_mem_gb': self.gpu_mem_gb,
+            'cpu_mem_gb': self.cpu_mem_gb,
+            'cache_dir': self.cache_dir,
+            'generation_mode': self.generation_mode,
+            'performance_profile': self.performance_profile,
+        }
+
         # Add execution info for distributed runs
         exec_type = getattr(self.args, 'exec_type', None)
         if exec_type:

--- a/mlpstorage_py/rules/models.py
+++ b/mlpstorage_py/rules/models.py
@@ -665,6 +665,12 @@ class BenchmarkInstanceExtractor:
         """Extract BenchmarkRunData from a Benchmark instance."""
         if hasattr(benchmark, 'combined_params'):
             parameters = benchmark.combined_params
+        elif hasattr(benchmark, 'metadata'):
+            # Issue #537: non-DLIO benchmarks (e.g. kvcache, vectordb) lack
+            # combined_params but publish their workload config via the
+            # metadata property. Fall back to metadata['parameters'] so live
+            # run-checkers see the same dict reportgen reads on disk.
+            parameters = benchmark.metadata.get('parameters', {})
         else:
             parameters = {}
 

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -250,6 +250,35 @@ class TestKVCacheMetadata:
         assert 'generation_mode' in meta
         assert 'performance_profile' in meta
 
+    def test_metadata_parameters_populated_for_run_checker(self, base_args, mock_logger, tmp_path):
+        """Issue #537: KVCacheRunRulesChecker reads workload config from
+        metadata['parameters']. KVCache has no DLIO combined_params so the base
+        class falls back to {}, and reportgen then classifies every run INVALID
+        with 'Missing model parameter'. The kvcache metadata must populate
+        ['parameters'] with the workload config keys the checker consults."""
+        with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen, \
+             patch('mlpstorage_py.benchmarks.kvcache.KVCacheBenchmark._collect_cluster_information') as mock_cluster:
+            output_dir = str(tmp_path / "output")
+            mock_gen.return_value = output_dir
+            mock_cluster.return_value = None
+
+            from mlpstorage_py.benchmarks.kvcache import KVCacheBenchmark
+            bm = KVCacheBenchmark(base_args, logger=mock_logger, run_datetime="20250124_120000")
+            meta = bm.metadata
+
+        params = meta.get('parameters')
+        assert isinstance(params, dict) and params, \
+            "metadata['parameters'] must be a non-empty dict so reportgen can read workload config"
+
+        # Keys the KVCacheRunRulesChecker reads via self.benchmark_run.parameters.get(...)
+        assert params.get('model') == 'llama3.1-8b'
+        assert params.get('num_users') == 100
+        assert params.get('duration') == 60
+        assert params.get('gpu_mem_gb') == 16.0
+        assert params.get('cpu_mem_gb') == 32.0
+        assert params.get('generation_mode') == 'realistic'
+        assert params.get('performance_profile') == 'latency'
+
     def test_metadata_includes_distributed_info(self, base_args, mock_logger, tmp_path):
         """Verify metadata includes distributed execution info."""
         base_args.exec_type = EXEC_TYPE.MPI

--- a/tests/unit/test_rules_extractors.py
+++ b/tests/unit/test_rules_extractors.py
@@ -133,6 +133,37 @@ class TestBenchmarkInstanceExtractor:
 
         assert result.metrics is None
 
+    def test_extract_falls_back_to_metadata_parameters(self):
+        """Issue #537: KVCacheBenchmark (and any non-DLIO benchmark) lacks
+        combined_params, so the extractor's pre-fix behavior produces an empty
+        parameters dict. The live-verification run-checker then can't see the
+        workload config it was built to validate. When combined_params is
+        absent, fall back to benchmark.metadata['parameters'] so live and
+        on-disk reportgen paths agree."""
+        mock_benchmark = MagicMock(spec=['BENCHMARK_TYPE', 'args', 'run_datetime',
+                                         'params_dict', 'metadata'])
+        mock_benchmark.BENCHMARK_TYPE = BENCHMARK_TYPES.kv_cache
+        mock_benchmark.args.model = 'llama3.1-8b'
+        mock_benchmark.args.command = 'run'
+        mock_benchmark.args.num_processes = 4
+        mock_benchmark.run_datetime = '20260626_120000'
+        mock_benchmark.params_dict = {}
+        mock_benchmark.metadata = {
+            'parameters': {
+                'model': 'llama3.1-8b',
+                'num_users': 100,
+                'duration': 60,
+            },
+        }
+
+        result = BenchmarkInstanceExtractor.extract(mock_benchmark)
+
+        assert result.parameters == {
+            'model': 'llama3.1-8b',
+            'num_users': 100,
+            'duration': 60,
+        }
+
 
 class TestDLIOResultParser:
     """Tests for DLIOResultParser class."""


### PR DESCRIPTION
## Summary

Closes #537.

Every closed kvcache run lands in reportgen as \`INVALID: model: Missing model parameter\`. The KV Cache run-checker reads workload config from \`self.benchmark_run.parameters\`, but \`KVCacheBenchmark\` has no DLIO \`combined_params\` — \`Benchmark.metadata\` falls back to \`parameters = {}\`, and the kvcache override writes its workload keys at the top level instead. Both reportgen and live verification fail the same way; the non-\`model\` checks silently validate the run-checker's hard-coded defaults (\`num_users=100\`, \`duration=60s\`) instead of the real config.

## What changed

- **\`mlpstorage_py/benchmarks/kvcache.py\`** — \`KVCacheBenchmark.metadata\` now mirrors the workload config (\`model\`, \`num_users\`, \`duration\`, \`gpu_mem_gb\`, \`cpu_mem_gb\`, \`cache_dir\`, \`generation_mode\`, \`performance_profile\`) into \`base_metadata['parameters']\`. This is what reportgen's \`_from_metadata\` reads from the on-disk \`*_metadata.json\`.
- **\`mlpstorage_py/rules/models.py\`** — \`BenchmarkInstanceExtractor.extract\` falls back to \`benchmark.metadata['parameters']\` when \`combined_params\` is absent. This keeps the live-verification path consistent with the reportgen view and covers any future non-DLIO benchmark (vectordb included) that follows the same shape.

Two RED-first commits:
- \`14a990b\` — failing tests for both the kvcache metadata shape and the extractor fallback.
- \`342407c\` — fix; tests now GREEN.

## Test plan
- [x] \`uv run pytest tests/unit -q\` → 1630 passed, 4 skipped, 0 failed.
- [x] New test \`TestKVCacheMetadata::test_metadata_parameters_populated_for_run_checker\` asserts the seven workload keys land under \`metadata['parameters']\`.
- [x] New test \`TestBenchmarkInstanceExtractor::test_extract_falls_back_to_metadata_parameters\` asserts the live extractor reads from \`metadata['parameters']\` when \`combined_params\` is missing.
- [ ] Manual sanity check on a real closed kvcache run + \`mlpstorage reports reportgen\` to confirm the run classifies CLOSED/OPEN with metrics instead of \`INVALID\`.