### PR TITLE
KVCache: Disable pass/fail printing

### DIFF
--- a/kv_cache_benchmark/kv_cache/benchmark.py
+++ b/kv_cache_benchmark/kv_cache/benchmark.py
@@ -1505,6 +1505,9 @@ class IntegratedBenchmark:
         print(f"  A 200MiB block at 1GiB/s NVMe read = ~200 ms device latency.")
         print(f"  Compare latencies against block sizes, not against 4KiB page I/O.\n")
 
+"""
+Printing of pass/fail is not used in MLPerf 3.0
+
         PASS_SYMBOL = "[OK]"
         FAIL_SYMBOL = "[X]"
 
@@ -1536,6 +1539,7 @@ class IntegratedBenchmark:
 
                 unit_suffix = unit if unit else ''
                 print(f"  {symbol} {criterion['name']}: {actual_str}{unit_suffix} (target: {target_str}{unit_suffix})")
+"""
 
         print(f"\n### OVERALL PERFORMANCE ###")
         print(f"Requests Completed: {summary['total_requests']}")


### PR DESCRIPTION
Disables the printing of PASS/FAIL results by the KV cache benchmark, as these are not used in the MLPerf 3.0 Benchmark, and this was causing confusion for submitters.