### PR TITLE
Support HPE Cray PALS mpiexec launcher (ALCF Crux/Polaris/Aurora)

### DIFF
--- a/mlpstorage_py/utils.py
+++ b/mlpstorage_py/utils.py
@@ -570,10 +570,39 @@ def generate_mpi_prefix_cmd(
         logger.debug(f"Configured slots for hosts: {hosts}")
 
     # Build MPI command prefix
+    # ---- HPE Cray PALS mpiexec (ALCF Crux/Polaris/Aurora) ----
+    # PALS mpiexec uses `--ppn` and a bare comma-separated `--hosts` list, with
+    # `--cpu-bind` for affinity. It does NOT accept the OpenMPI flags this
+    # function emits for mpirun (`-host h:slots`, `--npernode`, `--bind-to`,
+    # `--map-by`, `--mca`, `--oversubscribe`, `--allow-run-as-root`), so build a
+    # PALS-native prefix and return early. Without this, `--mpi-bin mpiexec`
+    # produces an argv PALS cannot parse and every ALCF run fails to launch.
+    if mpi_cmd == MPIEXEC:
+        pals_hosts: List[str] = []
+        for host in hosts:
+            host_part = host.split(':')[0]
+            if host_part not in pals_hosts:
+                pals_hosts.append(host_part)
+        ranks_per_node = processes_per_node
+        if ranks_per_node is None:
+            # Ceil-divide so every node has enough slots for num_processes.
+            ranks_per_node = -(-num_processes // len(pals_hosts))
+        prefix = (
+            f"{MPI_EXEC_BIN} -n {num_processes}"
+            f" --ppn {ranks_per_node}"
+            f" --hosts {','.join(pals_hosts)}"
+        )
+        # PALS affinity flag is --cpu-bind (not OpenMPI's --bind-to/--map-by).
+        if not _mpi_params_contain_flag(params, "cpu-bind"):
+            prefix += " --cpu-bind none"
+        if params:
+            for param in params:
+                prefix += f" {param}"
+        return prefix
+
+    # ---- OpenMPI mpirun ----
     if mpi_cmd == MPIRUN:
         prefix = f"{MPI_RUN_BIN} -n {num_processes} -host {','.join(hosts)}"
-    elif mpi_cmd == MPIEXEC:
-        prefix = f"{MPI_EXEC_BIN} -n {num_processes} -host {','.join(hosts)}"
     else:
         raise ValueError(f"Unsupported MPI command: {mpi_cmd}")
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -472,7 +472,7 @@ class TestGenerateMpiPrefixCmd:
         assert '--map-by node' in result  # Multi-host uses node
 
     def test_mpiexec_command(self, mock_logger):
-        """mpiexec generates correct command prefix."""
+        """mpiexec (HPE Cray PALS) generates a PALS-native prefix."""
         result = generate_mpi_prefix_cmd(
             mpi_cmd=MPIEXEC,
             hosts=['host1'],
@@ -482,7 +482,48 @@ class TestGenerateMpiPrefixCmd:
             params=None,
             logger=mock_logger
         )
-        assert 'mpiexec' in result or '-n 4' in result
+        # PALS-native flags
+        assert 'mpiexec' in result
+        assert '-n 4' in result
+        assert '--ppn 4' in result
+        assert '--hosts host1' in result
+        assert '--cpu-bind' in result
+        # OpenMPI-only flags PALS cannot parse must be absent
+        assert '--npernode' not in result
+        assert '--bind-to' not in result
+        assert '--map-by' not in result
+        assert '-host ' not in result  # PALS uses --hosts, not OpenMPI -host
+
+    def test_mpiexec_multi_host_ppn(self, mock_logger):
+        """mpiexec spreads ranks per node via --ppn over a bare --hosts list."""
+        result = generate_mpi_prefix_cmd(
+            mpi_cmd=MPIEXEC,
+            hosts=['host1', 'host2'],
+            num_processes=8,
+            oversubscribe=False,
+            allow_run_as_root=False,
+            params=None,
+            logger=mock_logger,
+            processes_per_node=4
+        )
+        assert '-n 8' in result
+        assert '--ppn 4' in result
+        assert '--hosts host1,host2' in result
+        assert '--npernode' not in result and '--map-by' not in result
+
+    def test_mpiexec_user_cpu_bind_suppresses_default(self, mock_logger):
+        """A user-supplied --cpu-bind via params suppresses the injected default."""
+        result = generate_mpi_prefix_cmd(
+            mpi_cmd=MPIEXEC,
+            hosts=['host1'],
+            num_processes=4,
+            oversubscribe=False,
+            allow_run_as_root=False,
+            params=['--cpu-bind', 'depth'],
+            logger=mock_logger
+        )
+        assert result.count('--cpu-bind') == 1
+        assert 'depth' in result
 
     def test_oversubscribe_flag(self, mock_logger):
         """Oversubscribe flag is added when True."""


### PR DESCRIPTION
## Problem

`mlpstorage_py/utils.py::generate_mpi_prefix_cmd()` builds **OpenMPI-only** flags for *both* `mpirun` and `mpiexec`. On ALCF Cray EX systems (Crux/Polaris/Aurora) the launcher is **HPE Cray PALS `mpiexec`**, which rejects those flags, so `--mpi-bin mpiexec` produces an argv PALS cannot parse and every run fails to launch.

Reproduced on **Crux** (`/opt/cray/pals/1.7/bin/mpiexec` v1.7.1, `cray-mpich/9.0.1`, `cray-pals/1.7.1`) — the generated prefix is identical for both binaries:

```
[mpirun]  -> mpirun  -n 8 -host localhost:8 --npernode 8 --bind-to none --map-by socket
[mpiexec] -> mpiexec -n 8 -host localhost:8 --npernode 8 --bind-to none --map-by socket
```

PALS `mpiexec --help` accepts `-n/--np`, `--ppn`, `--cpu-bind`, `--depth`, `--hosts` (bare, comma-separated), `--hostfile` — but **not** `-host h:slots`, `--npernode`, `--bind-to`, `--map-by`, `--mca`, `--oversubscribe`, or `--allow-run-as-root`.

## Fix

Add a PALS-native branch for `mpiexec` in `generate_mpi_prefix_cmd()` that emits, e.g.:

```
mpiexec -n 8 --ppn 4 --hosts host1,host2 --cpu-bind none
```

- `--ppn` is taken from `processes_per_node`, or `ceil(num_processes / n_hosts)` when unset.
- `--hosts` is the bare, de-duplicated, comma-separated host list (no `:slots`).
- `--cpu-bind none` is injected as a safe default for an I/O benchmark, and suppressed if the user supplies `--cpu-bind` via `--mpi-params`.
- **`mpirun` behaviour is unchanged** (OpenMPI path untouched).

## Tests

`tests/unit/test_utils.py::TestGenerateMpiPrefixCmd` — strengthened the `mpiexec` test and added cases for: PALS flags present, OpenMPI flags absent, multi-host `--ppn`, and user `--cpu-bind` override. Existing `mpirun` tests act as a regression guard.

## Notes / follow-up

`mlpstorage_py/cluster_collector.py` (the CAP-02 shared-FS probe and MPI cluster-info collector) hardcodes the same OpenMPI flags (`--map-by node`, `--bind-to none`, `--allow-run-as-root`). Single-host runs skip those paths, but multi-host ALCF runs will need the same family-branch treatment — happy to follow up in a separate PR.