### PR TITLE
THIS ONE FIRST: chore: bump dlio-benchmark pin to DLIO #38 merged + #37; version 3.0.23 -> 3.0.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.23"
+version = "3.0.24"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -129,7 +129,10 @@ torchaudio = [{ index = "pytorch-cpu" }]
 # Pinned to a specific commit for reproducibility; bump by updating `rev` and
 # re-running `uv lock --upgrade-package dlio-benchmark`.
 # Commit history (most recent first):
-#   - DLIO PR #38 fix for storage #538: wire DIRECT_FS for --o-direct local O_DIRECT I/O
+#   - DLIO PR #38 fix for storage #538: wire DIRECT_FS for --o-direct local
+#     O_DIRECT I/O (merged form supersedes the pre-merge pin from 3.0.23)
+#   - DLIO PR #37: restrict default `pytest` to checkin suite; full suite must
+#     be invoked explicitly with `pytest tests/ -m full_suite`
 #   - DLIO PR #28 fix for storage #487: expose DLIO_DROP_CACHES_TIMEOUT,
 #     distinguish slow flush from sudo refusal
 #   - DLIO PR #27 fix for storage #466 #472: skip_listing, S3 object storage,
@@ -139,7 +142,7 @@ torchaudio = [{ index = "pytorch-cpu" }]
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
 #   - DLIO PR #21 fix for storage #391 part 1 (TorchIterableDatasetSimple gating)
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "17d982a3c7842355c25787c97f636a9f6a474caa" }
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "252a54b18d113541e1e8e24832921fac0a7f2b96" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=17d982a3c7842355c25787c97f636a9f6a474caa#17d982a3c7842355c25787c97f636a9f6a474caa" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=252a54b18d113541e1e8e24832921fac0a7f2b96#252a54b18d113541e1e8e24832921fac0a7f2b96" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.23"
+version = "3.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=17d982a3c7842355c25787c97f636a9f6a474caa" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=17d982a3c7842355c25787c97f636a9f6a474caa" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=252a54b18d113541e1e8e24832921fac0a7f2b96" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=252a54b18d113541e1e8e24832921fac0a7f2b96" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary

\`uv lock --upgrade-package dlio-benchmark\` moves the pin from \`17d982a3\` to \`252a54b1\`, picking up two DLIO commits.

## What changed

- **DLIO PR #37** — restricts default \`pytest\` to the checkin suite (~85 fast tests, <10 min). The full suite carries aspirational tests expected to fail and takes hours; it must now be invoked explicitly with \`pytest tests/ -m full_suite\`. No runtime impact on mlpstorage — pure DLIO test-infrastructure cleanup.
- **DLIO PR #38 (merged form)** — the previous 3.0.23 pin (\`17d982a3\`) tracked the unmerged tip of #38. Upstream main now has the merged commit (\`252a54b1\`) with the same DIRECT_FS routing for \`--o-direct\` local O_DIRECT I/O. Switching to the merged SHA keeps mlpstorage aligned with what other DLIO consumers see.

Version bumped 3.0.23 → 3.0.24.

## Test plan
- [x] \`uv lock --upgrade-package dlio-benchmark\` resolves cleanly.
- [x] \`uv run pytest tests/unit -q\` → 2257 passed.