### PR TITLE
test(vdb): declare 'test' optional-deps extra (psutil, h5py, pyyaml, mpi4py)

### DIFF
--- a/vdb_benchmark/pyproject.toml
+++ b/vdb_benchmark/pyproject.toml
@@ -50,6 +50,14 @@ mpi = [
   "mpi4py>=4.0.0",
 ]
 
+test = [
+  "pytest>=7.0",
+  "pyyaml",
+  "h5py",
+  "psutil",
+  "mpi4py>=4.0.0",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/mlcommons/storage/tree/main/vdb_benchmark"
 "Bug Tracker" = "https://github.com/mlcommons/storage/issues"


### PR DESCRIPTION
## Summary
- 2 vdb_benchmark tests (\`test_compaction_with_resource_monitoring\`, \`test_memory_aware_loading\`) import \`psutil\` inside the test body and fail with \`ModuleNotFoundError\` when the venv lacks it; several other tests also need pytest / pyyaml / h5py / mpi4py.
- Declare a \`test\` optional-dependency group on \`vdb_benchmark\` so \`uv run --extra test python -m pytest\` is fully self-contained — same convention the main project already uses for its own \`test\` extra.
- Result: full vdb test suite goes from **134/136 → 136/136** passing.

## Test plan
- [x] \`cd vdb_benchmark && uv sync --extra test\` installs psutil + companions
- [x] \`uv run --extra test python -m pytest tests/tests/\` → 136 passed
- [x] The two previously-failing tests now pass individually

This is the first PR in a series of small, focused cleanups to bring the test suite to 0 failures + 0 unintentional skips.