### PR TITLE
test(submission_checker): refresh MD5_EXCLUDE_PREFIXES exact-membership tuple

### DIFF
--- a/mlpstorage_py/tests/test_config_reference_checksum.py
+++ b/mlpstorage_py/tests/test_config_reference_checksum.py
@@ -51,9 +51,22 @@ class TestConstantsImport:
             assert prefix in MD5_EXCLUDE_PREFIXES, f"Missing prefix: {prefix}"
 
     def test_md5_exclude_prefixes_exact_membership(self):
-        """MD5_EXCLUDE_PREFIXES must contain exactly the expected entries — no extras (D-13 locked set)."""
+        """MD5_EXCLUDE_PREFIXES must contain exactly the expected entries — no extras (D-13 locked set).
+
+        Kept in sync with constants.MD5_EXCLUDE_PREFIXES: when adding/removing
+        entries there, update the expected tuple here so the gate keeps catching
+        unintended drops as well as unintended additions.
+        """
         expected = (
             ".git/",
+            ".idea/",          # JetBrains IDE workspace
+            ".vscode/",        # VS Code workspace
+            ".claude/",        # Claude CLI runtime / settings
+            ".agent/",         # Agent runtime (per project .gitignore "Coding Agents")
+            ".agents/",        # Same, alternate name
+            ".roo/",           # Roo agent runtime
+            ".planning/",      # GSD planning artifacts (project-local)
+            ".gsd-tmp/",       # GSD code-fixer worktree (project-local)
             "__pycache__/",
             ".pytest_cache/",
             ".venv/",


### PR DESCRIPTION
## Summary
\`constants.MD5_EXCLUDE_PREFIXES\` (\`mlpstorage_py/submission_checker/constants.py:163-182\`) gained 8 new entries — \`.idea/\`, \`.vscode/\`, \`.claude/\`, \`.agent/\`, \`.agents/\`, \`.roo/\`, \`.planning/\`, \`.gsd-tmp/\` — to keep developer-tool and agent-runtime artifacts out of the code-tree MD5. The \`test_md5_exclude_prefixes_exact_membership\` gate still encoded the pre-change tuple and started failing.

Update the expected tuple to mirror production. The "exact membership" gate is intentionally brittle — it's there to catch *unintended drops* as well as *unintended additions* — so the right fix is the maintenance step the constants-bumping commits should have taken, not loosening the gate to subset semantics. Also added a one-line maintenance note on the test docstring so the next person who edits the production constant sees the contract.

## Test plan
- [x] \`uv run python -m pytest mlpstorage_py/tests/test_config_reference_checksum.py -v\` → 12 passed (was 11 passed + 1 failed)