### PR TITLE
fix(#538): fail-fast on storage_type vs data/checkpoint folder scheme mismatch

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -324,6 +324,137 @@ class DLIOBenchmark(Benchmark, abc.ABC):
         normalized = (parsed.netloc + parsed.path).rstrip('/')
         return normalized or parsed.netloc
 
+    # ── Issue #538: scheme-mismatch guardrail ────────────────────────────
+    # Recognized schemes. "Object" = anything DLIO routes through
+    # ObjStoreLibStorage; "local" = anything that resolves to a POSIX path.
+    _OBJECT_STORAGE_TYPES = frozenset({'s3', 's3_torch'})
+    _OBJECT_URI_SCHEMES = frozenset({'s3', 's3a', 'az', 'gs'})
+    _LOCAL_URI_SCHEMES = frozenset({'file', 'direct'})
+
+    def _check_storage_scheme_consistency(self):
+        """Fail fast on storage.storage_type vs data/checkpoint folder mismatch.
+
+        Issue #538: when ``storage.storage_type`` disagrees on scheme with
+        ``dataset.data_folder`` or ``checkpoint.checkpoint_folder``, DLIO's
+        ``StorageFactory.get_storage`` still picks the backend off the
+        global ``storage_type`` (not off the per-folder URI scheme) and
+        runs ``ObjStoreLibStorage._preflight()`` against the unrelated
+        folder. All MPI ranks then die at startup inside s3dlio with
+        either:
+
+            cannot reach bucket '/mnt/.../retinanet_checkpoints' via s3dlio
+            Bucket name cannot be empty in URI: s3://file:///mnt/.../...
+
+        The same failure shape exists for both the dataset path
+        (``datagen``/``run``) and the checkpoint path (any benchmark with
+        checkpointing enabled). The real fix lives in DLIO — parse each
+        folder's scheme in ``StorageFactory.get_storage`` rather than
+        routing off the global storage_type. Until that lands, refuse
+        mismatched combinations here so a 32-rank job doesn't spend a
+        minute spinning up only to crash in the preflight.
+
+        The check is intentionally narrow: bare relative prefixes (the
+        workload-YAML default, e.g. ``checkpoints/llama_8b``) are valid
+        under both backends and pass through.
+        """
+        command = getattr(self.args, 'command', None)
+        if command not in ('datagen', 'run', 'configview'):
+            return
+
+        storage_type = (
+            self.params_dict.get('storage.storage_type')
+            or (self.combined_params or {}).get('storage', {}).get('storage_type')
+            or 'local'
+        )
+        is_object_storage = storage_type in self._OBJECT_STORAGE_TYPES
+
+        # Always inspect the dataset path — DLIO's data StorageFactory is
+        # constructed for every command that touches data.
+        self._enforce_scheme_match(
+            param_key='dataset.data_folder',
+            yaml_path=('dataset', 'data_folder'),
+            storage_type=storage_type,
+            is_object_storage=is_object_storage,
+        )
+
+        # Inspect the checkpoint path only when checkpointing actually runs.
+        # CheckpointingBenchmark is always-on; TrainingBenchmark honors
+        # workflow.checkpoint (datagen never checkpoints).
+        if command == 'datagen':
+            return
+        checkpoint_on = self.BENCHMARK_TYPE == BENCHMARK_TYPES.checkpointing
+        if not checkpoint_on:
+            workflow = (self.combined_params or {}).get('workflow') or {}
+            checkpoint_on = bool(workflow.get('checkpoint', False))
+        if checkpoint_on:
+            self._enforce_scheme_match(
+                param_key='checkpoint.checkpoint_folder',
+                yaml_path=('checkpoint', 'checkpoint_folder'),
+                storage_type=storage_type,
+                is_object_storage=is_object_storage,
+            )
+
+    def _enforce_scheme_match(self, *, param_key, yaml_path, storage_type,
+                              is_object_storage):
+        """Raise if the resolved folder's scheme contradicts storage_type."""
+        folder = self.params_dict.get(param_key)
+        if folder is None:
+            node = self.combined_params or {}
+            for k in yaml_path:
+                node = (node or {}).get(k)
+                if node is None:
+                    break
+            folder = node
+        if not folder:
+            return
+        folder_str = str(folder).strip()
+        if not folder_str:
+            return
+
+        scheme = ''
+        if '://' in folder_str:
+            scheme = folder_str.split('://', 1)[0].lower()
+
+        looks_local = (
+            scheme in self._LOCAL_URI_SCHEMES
+            or (not scheme and folder_str.startswith('/'))
+        )
+        looks_object = scheme in self._OBJECT_URI_SCHEMES
+
+        if is_object_storage and looks_local:
+            detail = (
+                f"storage.storage_type={storage_type!r} selects object storage, "
+                f"but {param_key}={folder_str!r} is a local filesystem path or "
+                "file:// URI."
+            )
+            fix = (
+                f"  - point {param_key} at the object store "
+                "(e.g. s3://<bucket>/<prefix>), or\n"
+                "  - drop storage.storage_type=s3 / --object so data and "
+                "checkpoints use a local filesystem backend."
+            )
+        elif (not is_object_storage) and looks_object:
+            detail = (
+                f"storage.storage_type={storage_type!r} selects local storage, "
+                f"but {param_key}={folder_str!r} is an object-store URI."
+            )
+            fix = (
+                "  - set storage.storage_type=s3 (and the matching "
+                "storage_options) to target object storage, or\n"
+                f"  - point {param_key} at a local path."
+            )
+        else:
+            return
+
+        raise ValueError(
+            "Inconsistent storage configuration: " + detail + "\n"
+            "DLIO picks the storage backend from the global "
+            "storage.storage_type, then runs the obj_store_lib preflight "
+            f"against {param_key} using that backend. A mismatched scheme "
+            "crashes every MPI rank inside s3dlio at startup (see "
+            "mlcommons/storage#538). Either:\n" + fix
+        )
+
     def process_dlio_params(self, config_file):
         params_dict = dict() if not self.args.params else {k: v for k, v in (item.split("=") for item in self.args.params)}
 
@@ -452,6 +583,7 @@ class TrainingBenchmark(DLIOBenchmark):
             # The add_datadir_param would convert --data-dir to --dataset.data_folder which is invalid to
             # mlpstorage.
             self.add_datadir_param()
+        self._check_storage_scheme_consistency()
         self.logger.verboser(f'Instantiated the Training Benchmark...')
 
     def add_datadir_param(self):
@@ -686,6 +818,7 @@ class CheckpointingBenchmark(DLIOBenchmark):
         self._apply_odirect_params(storage_root=getattr(self.args, 'checkpoint_folder', None))
         self.verify_benchmark()
         self.add_checkpoint_params()
+        self._check_storage_scheme_consistency()
         self.logger.status(f'Instantiated the Checkpointing Benchmark...')
 
     def add_checkpoint_params(self):

--- a/tests/unit/test_dlio_checkpoint_storage_consistency.py
+++ b/tests/unit/test_dlio_checkpoint_storage_consistency.py
@@ -1,0 +1,332 @@
+"""
+Tests for DLIOBenchmark._check_storage_scheme_consistency().
+
+Guardrail behavior for issue #538: when ``storage.storage_type`` and a
+storage folder (``dataset.data_folder`` or ``checkpoint.checkpoint_folder``)
+disagree on scheme, DLIO crashes every MPI rank inside obj_store_lib's
+preflight (it picks the backend from storage_type and runs preflight
+against the unrelated folder URI). The guardrail must refuse the
+mismatch up front while letting valid combinations through.
+"""
+
+import sys
+from argparse import Namespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import importlib.util as _ilu
+for _dep in ('pyarrow', 'pyarrow.ipc', 'dotenv'):
+    if _ilu.find_spec(_dep) is None and _dep not in sys.modules:
+        sys.modules[_dep] = MagicMock()
+
+from mlpstorage_py.benchmarks.dlio import DLIOBenchmark
+from mlpstorage_py.config import BENCHMARK_TYPES
+
+
+def _make_mock_self(
+    *,
+    benchmark_type=BENCHMARK_TYPES.training,
+    command='run',
+    params_dict=None,
+    combined_params=None,
+):
+    obj = MagicMock(spec=[
+        'args', 'params_dict', 'combined_params', 'BENCHMARK_TYPE', 'logger',
+        '_enforce_scheme_match',
+        '_OBJECT_STORAGE_TYPES', '_OBJECT_URI_SCHEMES', '_LOCAL_URI_SCHEMES',
+    ])
+    obj.args = Namespace(command=command)
+    obj.params_dict = params_dict or {}
+    obj.combined_params = combined_params or {}
+    obj.BENCHMARK_TYPE = benchmark_type
+    obj.logger = MagicMock()
+    # Class constants — bound through so the unbound-method calls see them.
+    obj._OBJECT_STORAGE_TYPES = DLIOBenchmark._OBJECT_STORAGE_TYPES
+    obj._OBJECT_URI_SCHEMES = DLIOBenchmark._OBJECT_URI_SCHEMES
+    obj._LOCAL_URI_SCHEMES = DLIOBenchmark._LOCAL_URI_SCHEMES
+    # Bind the real _enforce_scheme_match so the top-level check exercises it.
+    obj._enforce_scheme_match = DLIOBenchmark._enforce_scheme_match.__get__(obj)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Skip paths — guardrail must be a no-op for these
+# ---------------------------------------------------------------------------
+
+class TestSkipPaths:
+
+    def test_noop_for_datasize_command(self):
+        obj = _make_mock_self(
+            command='datasize',
+            params_dict={
+                'storage.storage_type': 's3',
+                'checkpoint.checkpoint_folder': 'file:///mnt/x',
+                'dataset.data_folder': '/mnt/local/data',
+            },
+            combined_params={'workflow': {'checkpoint': True}},
+        )
+        DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+    def test_noop_when_training_workflow_checkpoint_disabled(self):
+        """Training without checkpointing: checkpoint folder is ignored."""
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            params_dict={
+                'storage.storage_type': 's3',
+                'checkpoint.checkpoint_folder': '/mnt/local/ckpts',
+                'dataset.data_folder': 'data/unet3d',
+            },
+            combined_params={'workflow': {'checkpoint': False}},
+        )
+        # No raise — dataset folder is a bare prefix, checkpoint check skipped.
+        DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+    def test_noop_for_bare_relative_prefix(self):
+        """Bare prefixes (workload-YAML defaults) are valid under both
+        backends and must pass."""
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            params_dict={
+                'storage.storage_type': 's3',
+                'checkpoint.checkpoint_folder': 'checkpoints/llama_8b',
+                'dataset.data_folder': 'data/llama_8b',
+            },
+        )
+        DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+
+# ---------------------------------------------------------------------------
+# Matching schemes — valid combinations must pass
+# ---------------------------------------------------------------------------
+
+class TestMatchingSchemes:
+
+    @pytest.mark.parametrize('storage_type,folder', [
+        ('s3',        's3://bucket/llama3-8b'),
+        ('s3_torch',  's3://bucket/llama3-8b'),
+        ('local',     '/mnt/local/ckpts/llama3-8b'),
+        ('local',     'file:///mnt/local/ckpts/llama3-8b'),
+        ('local',     'relative/path/llama_8b'),
+        # direct_fs is what _apply_odirect_params injects (mlcommons/storage#544).
+        # It is a local-filesystem backend; bare paths and direct:// URIs are valid.
+        ('direct_fs', '/mnt/local/ckpts/llama3-8b'),
+        ('direct_fs', 'direct:///mnt/local/ckpts/llama3-8b'),
+    ])
+    def test_matching_checkpoint_folder_passes(self, storage_type, folder):
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            params_dict={
+                'storage.storage_type': storage_type,
+                'checkpoint.checkpoint_folder': folder,
+            },
+        )
+        DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+    @pytest.mark.parametrize('storage_type,folder', [
+        ('s3',        's3://bucket/data/unet3d'),
+        ('local',     '/mnt/local/data/unet3d'),
+        ('local',     'file:///mnt/local/data/unet3d'),
+        ('direct_fs', '/mnt/local/data/unet3d'),
+        ('direct_fs', 'direct:///mnt/local/data/unet3d'),
+    ])
+    def test_matching_data_folder_passes(self, storage_type, folder):
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            params_dict={
+                'storage.storage_type': storage_type,
+                'dataset.data_folder': folder,
+            },
+            combined_params={'workflow': {'checkpoint': False}},
+        )
+        DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+
+# ---------------------------------------------------------------------------
+# Mismatch rejection — checkpoint folder (issue #538)
+# ---------------------------------------------------------------------------
+
+class TestCheckpointFolderMismatch:
+
+    def test_s3_storage_with_absolute_local_path_raises(self):
+        """Bare-path variant from issue #538."""
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            params_dict={
+                'storage.storage_type': 's3',
+                'checkpoint.checkpoint_folder': '/mnt/ecs/retinanet_checkpoints',
+                'dataset.data_folder': 'retinanet',
+            },
+            combined_params={'workflow': {'checkpoint': True}},
+        )
+        with pytest.raises(ValueError) as exc:
+            DLIOBenchmark._check_storage_scheme_consistency(obj)
+        msg = str(exc.value)
+        assert '/mnt/ecs/retinanet_checkpoints' in msg
+        assert 'checkpoint.checkpoint_folder' in msg
+        assert '#538' in msg
+
+    def test_s3_storage_with_file_uri_raises(self):
+        """file:// variant from issue #538 — what tripped s3dlio's bucket
+        parsing with `s3://file:///...`."""
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            params_dict={
+                'storage.storage_type': 's3',
+                'checkpoint.checkpoint_folder': 'file:///mnt/ecs/retinanet_checkpoints',
+                'dataset.data_folder': 'retinanet',
+            },
+            combined_params={'workflow': {'checkpoint': True}},
+        )
+        with pytest.raises(ValueError) as exc:
+            DLIOBenchmark._check_storage_scheme_consistency(obj)
+        assert 'file:///mnt/ecs/retinanet_checkpoints' in str(exc.value)
+
+    def test_local_storage_with_s3_uri_raises(self):
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            params_dict={
+                'storage.storage_type': 'local',
+                'checkpoint.checkpoint_folder': 's3://bucket/llama_8b',
+            },
+        )
+        with pytest.raises(ValueError) as exc:
+            DLIOBenchmark._check_storage_scheme_consistency(obj)
+        msg = str(exc.value)
+        assert 's3://bucket/llama_8b' in msg
+        assert 'local storage' in msg
+
+    def test_checkpointing_benchmark_ignores_workflow_flag(self):
+        """CheckpointingBenchmark always checkpoints — absence of
+        workflow.checkpoint must not disarm the guardrail."""
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            params_dict={
+                'storage.storage_type': 's3',
+                'checkpoint.checkpoint_folder': '/mnt/local/ckpts',
+            },
+            combined_params={},
+        )
+        with pytest.raises(ValueError):
+            DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+
+# ---------------------------------------------------------------------------
+# Mismatch rejection — dataset folder (same DLIO failure mode for data)
+# ---------------------------------------------------------------------------
+
+class TestDataFolderMismatch:
+
+    def test_s3_storage_with_absolute_local_data_path_raises(self):
+        """Same DLIO failure mode applies to dataset.data_folder: the data
+        StorageFactory also routes off storage_type and would run the
+        obj_store_lib preflight against the local path."""
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            command='run',
+            params_dict={
+                'storage.storage_type': 's3',
+                'dataset.data_folder': '/mnt/local/data/unet3d',
+            },
+            combined_params={'workflow': {'checkpoint': False}},
+        )
+        with pytest.raises(ValueError) as exc:
+            DLIOBenchmark._check_storage_scheme_consistency(obj)
+        msg = str(exc.value)
+        assert 'dataset.data_folder' in msg
+        assert '/mnt/local/data/unet3d' in msg
+
+    def test_s3_storage_with_file_uri_data_raises(self):
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            params_dict={
+                'storage.storage_type': 's3',
+                'dataset.data_folder': 'file:///mnt/local/data/unet3d',
+            },
+        )
+        with pytest.raises(ValueError):
+            DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+    def test_local_storage_with_s3_data_uri_raises(self):
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            params_dict={
+                'storage.storage_type': 'local',
+                'dataset.data_folder': 's3://bucket/unet3d',
+            },
+        )
+        with pytest.raises(ValueError) as exc:
+            DLIOBenchmark._check_storage_scheme_consistency(obj)
+        assert 's3://bucket/unet3d' in str(exc.value)
+
+    def test_datagen_command_still_checks_data_folder(self):
+        """datagen writes the data — same backend-selection mismatch applies."""
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            command='datagen',
+            params_dict={
+                'storage.storage_type': 's3',
+                'dataset.data_folder': '/mnt/local/data/unet3d',
+            },
+        )
+        with pytest.raises(ValueError):
+            DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+    def test_datagen_skips_checkpoint_folder_check(self):
+        """datagen never checkpoints — checkpoint_folder mismatch is irrelevant
+        and must not raise on its own."""
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            command='datagen',
+            params_dict={
+                'storage.storage_type': 's3',
+                'dataset.data_folder': 's3://bucket/unet3d',
+                'checkpoint.checkpoint_folder': '/mnt/local/ckpts',
+            },
+            combined_params={'workflow': {'checkpoint': True}},
+        )
+        DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+
+# ---------------------------------------------------------------------------
+# YAML-only values must still be inspected
+# ---------------------------------------------------------------------------
+
+class TestCombinedParamsFallback:
+
+    def test_storage_type_from_combined_params(self):
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            params_dict={
+                'checkpoint.checkpoint_folder': '/mnt/local/ckpts',
+            },
+            combined_params={
+                'workflow': {'checkpoint': True},
+                'storage': {'storage_type': 's3'},
+            },
+        )
+        with pytest.raises(ValueError):
+            DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+    def test_checkpoint_folder_from_combined_params(self):
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            params_dict={'storage.storage_type': 's3'},
+            combined_params={
+                'checkpoint': {'checkpoint_folder': 'file:///mnt/x/ckpts'},
+            },
+        )
+        with pytest.raises(ValueError):
+            DLIOBenchmark._check_storage_scheme_consistency(obj)
+
+    def test_data_folder_from_combined_params(self):
+        obj = _make_mock_self(
+            benchmark_type=BENCHMARK_TYPES.training,
+            params_dict={'storage.storage_type': 's3'},
+            combined_params={
+                'workflow': {'checkpoint': False},
+                'dataset': {'data_folder': '/mnt/local/data'},
+            },
+        )
+        with pytest.raises(ValueError):
+            DLIOBenchmark._check_storage_scheme_consistency(obj)


### PR DESCRIPTION
Fixes #538.

## Summary

When `storage.storage_type` and a storage folder (`dataset.data_folder` or `checkpoint.checkpoint_folder`) disagree on scheme, DLIO's `StorageFactory.get_storage` picks the backend off the global `storage_type` (not off the per-folder URI scheme) and runs `ObjStoreLibStorage._preflight()` against the unrelated folder. Every MPI rank dies at startup inside s3dlio with:

\`\`\`
cannot reach bucket '/mnt/.../retinanet_checkpoints' via s3dlio
Bucket name cannot be empty in URI: s3://file:///mnt/.../...
\`\`\`

PR #544 (Russ) fixed one path to this root cause: `--o-direct` was injecting `storage_type=s3` for a local-filesystem target. The issue reporter's actual reproducer is different — `--object` data plus `--params checkpoint.checkpoint_folder=file:///...` checkpoints — which #544 does not cover.

This PR closes the remaining mismatch surface:

- New `DLIOBenchmark._check_storage_scheme_consistency()` inspects the effective `storage.storage_type` and refuses inconsistent `dataset.data_folder` (datagen / run / configview) and `checkpoint.checkpoint_folder` (when checkpointing actually runs — always for `CheckpointingBenchmark`, conditional on `workflow.checkpoint` for `TrainingBenchmark`).
- Wired into `TrainingBenchmark.__init__` (after `add_datadir_param`) and `CheckpointingBenchmark.__init__` (after `add_checkpoint_params`) so the resolved values are final.
- Bare relative prefixes (the workload-YAML default, e.g. `checkpoints/llama_8b`) remain valid under both backends.
- `direct_fs` storage_type (PR #544's new injection) is treated as local — `direct://` URIs and bare paths pass cleanly.

The real fix belongs in DLIO (`StorageFactory.get_storage` should parse each folder's scheme rather than route off the global storage_type); this guardrail is the operator-facing fail-fast until that lands.

## Mismatch coverage matrix

| Combination | PR #544 | This PR |
|---|:---:|:---:|
| \`--o-direct\` alone (now requires \`file\`) | ✅ | n/a |
| \`--o-direct\` + \`object\` (rejected at CLI) | ✅ | n/a |
| \`object\` + \`--params checkpoint.checkpoint_folder=file:///…\` | ❌ | ✅ |
| \`object\` + \`--params checkpoint.checkpoint_folder=/local/…\` | ❌ | ✅ |
| \`--params storage.storage_type=s3\` + \`--data-dir /local/…\` | ❌ | ✅ |
| \`file\` + \`--params dataset.data_folder=s3://…\` | ❌ | ✅ |
| \`--params dataset.data_folder=file://…\` with s3 storage | ❌ | ✅ |

## New tests

25 unit tests in \`tests/unit/test_dlio_checkpoint_storage_consistency.py\`:

- Skip paths: \`datasize\` command, training with \`workflow.checkpoint=False\`, bare relative prefixes.
- Matching schemes: parametrized (\`s3\`, \`s3_torch\`, \`local\`, \`direct_fs\`) × (URI, absolute path, bare prefix) for both folder kinds.
- Checkpoint-folder mismatches: both #538 reproducer variants (bare path and \`file://\`), symmetric local→s3 case, and \`CheckpointingBenchmark\` ignores \`workflow.checkpoint\`.
- Data-folder mismatches: same shapes for \`datagen\` and \`run\`, plus \`datagen\` correctly skipping the checkpoint-folder check.
- YAML-only fallback: values declared in \`combined_params\` (workload YAML) instead of \`params_dict\` (CLI \`--params\`) are still inspected.

## Test plan

- [x] \`pytest tests/unit/test_dlio_checkpoint_storage_consistency.py\` — 25/25 pass
- [x] \`pytest tests/unit/test_dlio_odirect.py tests/unit/test_dlio_object_storage.py tests/unit/test_benchmarks_kvcache.py\` — 101/101 pass (no interaction regressions with PR #544's --o-direct work)