### PR TITLE
test(code-image): refresh fixtures and assertions to md5-tree-v2

### DIFF
--- a/mlpstorage_py/tests/test_code_image.py
+++ b/mlpstorage_py/tests/test_code_image.py
@@ -260,7 +260,7 @@ class TestLoadCodeImage:
         img = load_code_image(image_parent / "code", mock_logger)
         assert img.path == image_parent / "code"
         assert len(img.hash) == 32
-        assert img.algorithm == "md5-tree-v1"
+        assert img.algorithm == "md5-tree-v2"
         assert img.mlpstorage_version == MLPSTORAGE_VERSION
 
     def test_load_missing_file_raises(self, tmp_path, mock_logger):
@@ -271,16 +271,19 @@ class TestLoadCodeImage:
 
         path = tmp_path / "img"
         path.mkdir()
-        
+
         with pytest.raises(MissingHashFile, match=".code-hash.json not found"):
             load_code_image(path, mock_logger)
 
     @pytest.mark.parametrize("payload, reason", [
         ({"bad": "json"}, "Missing required field"),
-        ({"hash": "a", "algorithm": "md5-tree-v1", "captured_at": "2026-01-01T00:00:00Z", "mlpstorage_version": "1", "git_sha": None}, "Invalid MD5 hash format"),
+        # algorithm must be the current production version (md5-tree-v2) so the
+        # specific field-validation path under test fires, not the unknown-
+        # algorithm short-circuit that runs first.
+        ({"hash": "a", "algorithm": "md5-tree-v2", "captured_at": "2026-01-01T00:00:00Z", "mlpstorage_version": "1", "git_sha": None}, "Invalid MD5 hash format"),
         ({"hash": "a"*32, "algorithm": "v2", "captured_at": "2026-01-01T00:00:00Z", "mlpstorage_version": "1", "git_sha": None}, "Unknown algorithm"),
-        ({"hash": "a"*32, "algorithm": "md5-tree-v1", "captured_at": "bad", "mlpstorage_version": "1", "git_sha": None}, "Invalid captured_at"),
-        ({"hash": "a"*32, "algorithm": "md5-tree-v1", "captured_at": "2026-01-01T00:00:00Z", "mlpstorage_version": "1", "git_sha": "bad"}, "Invalid git_sha"),
+        ({"hash": "a"*32, "algorithm": "md5-tree-v2", "captured_at": "bad", "mlpstorage_version": "1", "git_sha": None}, "Invalid captured_at"),
+        ({"hash": "a"*32, "algorithm": "md5-tree-v2", "captured_at": "2026-01-01T00:00:00Z", "mlpstorage_version": "1", "git_sha": "bad"}, "Invalid git_sha"),
     ])
     def test_load_malformed_json_raises(self, tmp_path, mock_logger, payload, reason):
         """D-15: MalformedHashFile raised for various invalid schemas."""
@@ -381,7 +384,7 @@ class TestCodeHashJsonSchema:
         
         payload = json.loads((image_parent / "code" / ".code-hash.json").read_text())
         
-        assert payload["algorithm"] == "md5-tree-v1"
+        assert payload["algorithm"] == "md5-tree-v2"
         assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", payload["captured_at"])
         assert payload["mlpstorage_version"] == MLPSTORAGE_VERSION
         assert re.fullmatch(r"[0-9a-f]{32}", payload["hash"])

--- a/mlpstorage_py/tests/test_submission_checker_structure.py
+++ b/mlpstorage_py/tests/test_submission_checker_structure.py
@@ -553,7 +553,7 @@ def _write_valid_hash_json(code_path, mock_logger, **overrides):
     digest = compute_code_tree_md5(str(code_path), mock_logger)
     payload = {
         "hash": digest,
-        "algorithm": "md5-tree-v1",
+        "algorithm": "md5-tree-v2",
         "captured_at": "2026-06-17T00:00:00Z",
         "mlpstorage_version": "3.0.9",
         "git_sha": None,


### PR DESCRIPTION
## Summary
Commit \`d8b8f0c\` (issue #505 fix) bumped the code-tree hash algorithm identifier from \`md5-tree-v1\` to \`md5-tree-v2\` in \`submission_checker.tools.code_image._ALGORITHM\` so stale pre-#512 captures surface as \`MalformedHashFile\`. Production rejects any other value as "Unknown algorithm" *before* checking other fields (code_image.py:470).

Two test files still encoded v1, producing 20 failures across them:

- \`test_code_image.py\`
  - \`test_load_happy_path\` asserted \`img.algorithm == "md5-tree-v1"\`
  - \`test_schema_invariants\` asserted \`payload["algorithm"] == "md5-tree-v1"\`
  - \`test_load_malformed_json_raises[Invalid MD5 hash format]\` payload's algorithm was \`md5-tree-v1\`, so production raised "Unknown algorithm" *first* and the test never reached the hash-format check it was meant to exercise. Same for \`[Invalid captured_at]\` and \`[Invalid git_sha]\`. All flipped to \`md5-tree-v2\` so the *intended* field-validation branch fires.
  - The \`[Unknown algorithm]\` parameter (algorithm=\`"v2"\`) is preserved — it IS testing the unknown-algorithm branch.

- \`test_submission_checker_structure.py\`
  - \`_write_valid_hash_json\` fixture wrote algorithm \`md5-tree-v1\`; every layered self-consistency test downstream depends on that fixture being valid. Flipping the one fixture string to \`md5-tree-v2\` unblocks all 15 failures in that file.

## Test plan
- [x] \`uv run python -m pytest mlpstorage_py/tests/test_code_image.py mlpstorage_py/tests/test_submission_checker_structure.py -q\` → 131 passed (was 116 passed + 20 failed)