### PR TITLE
chore(cli): point error messages at the positional 'file'/'object', not --file/--object

### DIFF
--- a/mlpstorage_py/cli/checkpointing_args.py
+++ b/mlpstorage_py/cli/checkpointing_args.py
@@ -122,8 +122,8 @@ def _add_checkpointing_core_args(parser, command):
 
     # --o-direct: available for run and configview (not datasize).
     # Routes all checkpoint I/O through s3dlio's direct:// URI scheme with
-    # O_DIRECT, bypassing the OS page cache.  Incompatible with --object.
-    # See mlcommons/storage#507.
+    # O_DIRECT, bypassing the OS page cache.  Requires the 'file'
+    # data-access protocol.  See mlcommons/storage#507.
     if command in ("run", "configview"):
         parser.add_argument(
             '--o-direct',
@@ -133,7 +133,7 @@ def _add_checkpointing_core_args(parser, command):
             help=(
                 "Route all checkpoint I/O through s3dlio's O_DIRECT local "
                 "filesystem mode (direct:// URI scheme), bypassing the OS "
-                "page cache.  Incompatible with --object."
+                "page cache.  Requires the 'file' data-access protocol."
             ),
         )
 
@@ -230,16 +230,18 @@ def validate_checkpointing_arguments(args):
         protocol = getattr(args, 'data_access_protocol', None)
         if protocol == 'object':
             error_messages.append(
-                "--o-direct is incompatible with --object. "
+                "--o-direct is incompatible with the 'object' data-access protocol. "
                 "O_DIRECT mode reads from the local filesystem via s3dlio's "
                 "direct:// URI scheme; it cannot be combined with an S3 endpoint. "
-                "Use --file --o-direct for O_DIRECT local I/O."
+                "Use the 'file' positional with --o-direct for O_DIRECT local I/O, "
+                "e.g. `mlpstorage <mode> checkpointing run file --o-direct`."
             )
         elif protocol != 'file':
             error_messages.append(
-                "--o-direct requires --file. "
+                "--o-direct requires the 'file' data-access protocol. "
                 "O_DIRECT mode routes I/O through s3dlio's direct:// URI scheme on the "
-                "local filesystem and must be combined with --file."
+                "local filesystem and must be combined with the 'file' positional, "
+                "e.g. `mlpstorage <mode> checkpointing run file --o-direct`."
             )
 
     if error_messages:

--- a/mlpstorage_py/cli/kvcache_args.py
+++ b/mlpstorage_py/cli/kvcache_args.py
@@ -419,7 +419,11 @@ def validate_kvcache_arguments(args):
     error_messages = []
 
     if hasattr(args, 'data_access_protocol') and args.data_access_protocol != 'file':
-        error_messages.append("KVCache only supports POSIX file storage, ie: --object= is not supported")
+        error_messages.append(
+            "KVCache only supports POSIX file storage; the 'object' data-access "
+            "protocol is not supported. Use the 'file' positional, "
+            "e.g. `mlpstorage <mode> kvcache run file ...`."
+        )
 
     if error_messages:
         for msg in error_messages:

--- a/mlpstorage_py/cli/training_args.py
+++ b/mlpstorage_py/cli/training_args.py
@@ -204,8 +204,8 @@ def _add_training_core_args(parser, command, accel_choices):
     # every file with O_DIRECT so reads bypass the OS page cache entirely.
     # Works for ALL training workloads regardless of data format — this is
     # independent of reader.odirect, which is the legacy NPY/NPZ-only path.
-    # Incompatible with --object (O_DIRECT targets local filesystem only).
-    # See mlcommons/storage#507.
+    # Requires the 'file' data-access protocol (O_DIRECT targets local
+    # filesystem only).  See mlcommons/storage#507.
     if command != 'datasize':
         parser.add_argument(
             '--o-direct',
@@ -216,8 +216,8 @@ def _add_training_core_args(parser, command, accel_choices):
                 "Route all training I/O through s3dlio's O_DIRECT local "
                 "filesystem mode (direct:// URI scheme), bypassing the OS "
                 "page cache.  Works for every training workload regardless "
-                "of data format.  Incompatible with --object (O_DIRECT "
-                "targets the local filesystem only)."
+                "of data format.  Requires the 'file' data-access protocol "
+                "(O_DIRECT targets the local filesystem only)."
             ),
         )
 
@@ -306,18 +306,19 @@ def validate_training_arguments(args):
     if getattr(args, 'o_direct', False) and protocol != 'file':
         if protocol == 'object':
             print(
-                "ERROR: --o-direct is incompatible with --object.\n"
+                "ERROR: --o-direct is incompatible with the 'object' data-access protocol.\n"
                 "  --o-direct routes I/O through s3dlio's direct:// URI scheme on the\n"
                 "  local filesystem — it cannot be combined with S3 object storage.\n"
-                "  Use --file --o-direct for O_DIRECT local I/O.",
+                "  Use the 'file' positional with --o-direct for O_DIRECT local I/O,\n"
+                "  e.g. `mlpstorage <mode> training <model> run file --o-direct`.",
                 file=sys.stderr,
             )
         else:
             print(
-                "ERROR: --o-direct requires --file.\n"
+                "ERROR: --o-direct requires the 'file' data-access protocol.\n"
                 "  --o-direct routes I/O through s3dlio's direct:// URI scheme on the\n"
-                "  local filesystem. It must be combined with --file.\n"
-                "  Use --file --o-direct for O_DIRECT local I/O.",
+                "  local filesystem. It must be combined with the 'file' positional,\n"
+                "  e.g. `mlpstorage <mode> training <model> run file --o-direct`.",
                 file=sys.stderr,
             )
         sys.exit(EXIT_CODE.INVALID_ARGUMENTS)

--- a/tests/unit/test_dlio_odirect.py
+++ b/tests/unit/test_dlio_odirect.py
@@ -172,15 +172,19 @@ class TestOdirectObjectRejection:
         assert exc.value.code == EXIT_CODE.INVALID_ARGUMENTS
         captured = capsys.readouterr()
         assert '--o-direct' in captured.err
-        assert '--object' in captured.err
+        # Error must name the 'object' positional protocol — NOT '--object'
+        # which is no longer a flag (see issue #376 and the cli_parser.py
+        # comment that documents the rename). The quoted-positional form
+        # is what the user actually types.
+        assert "'object'" in captured.err
 
     def test_training_rejects_odirect_without_file(self, capsys):
-        """--o-direct without --file must be rejected: --o-direct requires --file."""
+        """--o-direct without 'file' positional must be rejected."""
         from mlpstorage_py.cli.training_args import validate_training_arguments
         from mlpstorage_py.config import EXIT_CODE
         args = Namespace(
             command='run',
-            data_access_protocol=None,  # neither --file nor --object
+            data_access_protocol=None,  # neither 'file' nor 'object'
             data_dir='/mnt/data',
             o_direct=True,
         )
@@ -189,7 +193,8 @@ class TestOdirectObjectRejection:
         assert exc.value.code == EXIT_CODE.INVALID_ARGUMENTS
         captured = capsys.readouterr()
         assert '--o-direct' in captured.err
-        assert '--file' in captured.err
+        # Quoted-positional 'file' — not the no-longer-existing --file flag.
+        assert "'file'" in captured.err
 
     def test_training_allows_odirect_plus_file(self):
         from mlpstorage_py.cli.training_args import validate_training_arguments
@@ -213,14 +218,14 @@ class TestOdirectObjectRejection:
         validate_training_arguments(args)
 
     def test_checkpointing_rejects_odirect_without_file(self, capsys):
-        """--o-direct without --file must be rejected for checkpointing too."""
+        """--o-direct without 'file' positional must be rejected for checkpointing too."""
         from mlpstorage_py.cli.checkpointing_args import validate_checkpointing_arguments
         from mlpstorage_py.config import LLM_MODELS, EXIT_CODE
         args = Namespace(
             model=LLM_MODELS[0],
             num_checkpoints_read=10,
             num_checkpoints_write=10,
-            data_access_protocol=None,  # neither --file nor --object
+            data_access_protocol=None,  # neither 'file' nor 'object'
             o_direct=True,
             mode='open',
         )
@@ -230,7 +235,8 @@ class TestOdirectObjectRejection:
         combined = capsys.readouterr()
         output = combined.out + combined.err
         assert '--o-direct' in output
-        assert '--file' in output
+        # Quoted-positional 'file' — not the no-longer-existing --file flag.
+        assert "'file'" in output
 
     def test_checkpointing_rejects_odirect_plus_object(self, capsys):
         from mlpstorage_py.cli.checkpointing_args import validate_checkpointing_arguments


### PR DESCRIPTION
## Summary

The data-access protocol is a positional (`mlpstorage_py/cli/common_args.py:329` — `add_storage_type_arguments` registers it with `choices=['file', 'object']`). The old `--file` / `--object` flag form was removed when #376 was fixed.

Several user-facing error messages, help strings, and comments still tell users to type `--file --o-direct` or similar. A user who follows those hints types the suggested string and hits:

\`\`\`
argparse: error: unrecognized arguments: --file
\`\`\`

This PR fixes the user-visible wording in three CLI files and points operators at the actual positional with a copy-pasteable example command form.

## Changes

- `mlpstorage_py/cli/training_args.py` — `--o-direct` rejection messages (both branches) and the `--o-direct` argparse help text.
- `mlpstorage_py/cli/checkpointing_args.py` — same pair.
- `mlpstorage_py/cli/kvcache_args.py` — the "only POSIX file storage" rejection message.

Before / after examples:

\`\`\`
- ERROR: --o-direct is incompatible with --object.
-   ...
-   Use --file --o-direct for O_DIRECT local I/O.
+ ERROR: --o-direct is incompatible with the 'object' data-access protocol.
+   ...
+   Use the 'file' positional with --o-direct for O_DIRECT local I/O,
+   e.g. \`mlpstorage <mode> training <model> run file --o-direct\`.
\`\`\`

PR #544 introduced two of the affected `--o-direct` messages most recently; the rest pre-date #376. The flag form remains documented as historical context in `cli_parser.py` and the `test_issue_376_file_arg_conflict.py` test — those are intentional records of the removal and not changed here.

## Test updates

Test assertions in `tests/unit/test_dlio_odirect.py` that previously matched on the literal `--object` / `--file` substrings are updated to match the new quoted-positional form (`'object'` / `'file'`) so they verify the corrected wording.

## Test plan

- [x] \`pytest tests/unit/test_dlio_odirect.py\` — passes (3 assertion updates)
- [x] \`pytest tests/unit/test_dlio_odirect.py tests/unit/test_dlio_object_storage.py tests/unit/test_cli.py tests/unit/test_cli_kvcache.py tests/unit/test_benchmarks_kvcache.py tests/unit/test_help_behavior.py\` — 369/369 pass