### PR TITLE
test(benchmarks): populate orgname/systemname/mode/vdb_engine in VectorDB tests

### DIFF
--- a/mlpstorage_py/tests/test_benchmarks.py
+++ b/mlpstorage_py/tests/test_benchmarks.py
@@ -555,6 +555,14 @@ class TestVectorDBBenchmark:
             index_type='DISKANN',
             num_shards=1,
             vector_dtype='FLOAT_VECTOR',
+            # orgname is populated upstream by main._main_impl()'s
+            # orgname-resolution gate (from orgname.yaml written by
+            # `mlpstorage init`). Benchmark.__init__ asserts it's set.
+            # systemname / mode are likewise read by base.py during init.
+            orgname='test-org',
+            systemname='test-sys',
+            mode='whatif',
+            vdb_engine='milvus',
         )
 
         with patch.object(VectorDBBenchmark, 'verify_benchmark'):
@@ -586,6 +594,10 @@ class TestVectorDBBenchmark:
             index_type='HNSW',
             num_shards=2,
             vector_dtype='FLOAT_VECTOR',
+            orgname='test-org',
+            systemname='test-sys',
+            mode='whatif',
+            vdb_engine='milvus',
         )
 
         with patch.object(VectorDBBenchmark, 'verify_benchmark'):


### PR DESCRIPTION
## Summary
\`Benchmark.__init__\` now asserts \`args.orgname\` is populated upstream by main._main_impl()'s orgname-resolution gate (base.py:125-133), and \`_reserve_run_directory → generate_output_location\` additionally reads \`args.mode\`, \`args.systemname\`, and (for vector_database) \`args.vdb_engine\`.

The two \`TestVectorDBBenchmark\` tests built their \`SimpleNamespace\` without any of those, so each tripped \`ConfigurationError [E101]\` before reaching the behaviors under test (\`test_constructor_accepts_kwargs\` verifies the constructor's run_datetime/logger kwarg contract; \`test_datasize_does_not_require_pymilvus\` verifies that datasize skips the pymilvus dep check).

Populate realistic stand-in values on both Namespaces so the tests actually exercise their intended contracts. The added fields mirror what the orgname/systemname plumbing populates in production.

## Test plan
- [x] \`uv run python -m pytest mlpstorage_py/tests/test_benchmarks.py -q\` → 17 passed (was 15 passed + 2 failed)