### PR TITLE
THIS ONE LAST: test+ci: fast-lane perf fixes, slow markers, run all 4 suites in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,29 @@ jobs:
         sudo apt-get install -y libopenmpi-dev openmpi-common openmpi-bin 
 
     - name: Install package and test dependencies
-      run: uv sync # Automatically creates the environment and locks dependencies
+      run: uv sync --extra test
 
-    # 4. Heavy Lifting (Runs only if linting passed)
-    - name: Run unit tests
-      run: uv run pytest # Runs your tests safely inside the managed environment
+    - name: Install subpackages (vdb_benchmark, kv_cache_benchmark)
+      # These have their own pyproject.toml and tests; install editable so
+      # their imports resolve and their `test` extras are available.
+      run: |
+        uv pip install -e ./vdb_benchmark
+        uv pip install -e ./kv_cache_benchmark
+
+    # 4. Run the four test suites separately.
+    # We can't collect them together: `tests/` and `vdb_benchmark/tests/`
+    # both have a top-level package named `tests` whose conftest.py modules
+    # collide under pytest's rootdir-relative import (ImportPathMismatchError).
+    # Each suite's pyproject defines its own `slow` marker and `-m 'not slow'`
+    # default, so subprocess-level invocation is correct.
+    - name: Run root test suite (tests/)
+      run: uv run pytest tests
+
+    - name: Run mlpstorage_py test suite
+      run: uv run pytest mlpstorage_py/tests
+
+    - name: Run vdb_benchmark test suite
+      run: uv run pytest vdb_benchmark/tests
+
+    - name: Run kv_cache_benchmark test suite
+      run: uv run pytest kv_cache_benchmark/tests

--- a/kv_cache_benchmark/pyproject.toml
+++ b/kv_cache_benchmark/pyproject.toml
@@ -110,4 +110,7 @@ ignore_missing_imports = true
 testpaths = ["tests", "."]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -m 'not slow'"
+markers = [
+    "slow: tests that take >5s (e.g., large GPU-overflow allocations, profiling). Excluded from the default suite; opt in with `pytest -m slow` (or `pytest -m ''` to run everything).",
+]

--- a/kv_cache_benchmark/tests/test_kv_cache.py
+++ b/kv_cache_benchmark/tests/test_kv_cache.py
@@ -1102,6 +1102,7 @@ class TestMultiTierCacheWithGPU:
         assert success is True
         assert location == 'gpu'
     
+    @pytest.mark.slow
     def test_gpu_overflow_to_cpu(self, multi_tier_cache_with_gpu):
         """When GPU is full, should overflow to CPU."""
         # Fill GPU with large allocations
@@ -3899,6 +3900,7 @@ class TestVisualizeUserRequestFlow:
 class TestBottleneckProfiling:
     """Profile bottleneck detection in the KV cache benchmark."""
 
+    @pytest.mark.slow
     def test_profile_allocate_vs_access_overhead(self):
         """Profile allocate vs access operations to identify bottleneck ratios."""
         import time as time_mod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.23"
+version = "3.0.25"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/integration/test_canonical_layout_end_to_end.py
+++ b/tests/integration/test_canonical_layout_end_to_end.py
@@ -402,6 +402,7 @@ class TestInitThenRunFullCliDispatch:
     runs on any dev box (does not require DLIO/openmpi).
     """
 
+    @pytest.mark.slow
     def test_init_then_closed_datagen_no_env_var(self, tmp_path, monkeypatch):
         """RED today: the second invocation raises ConfigurationError E101
         even though `mlpstorage init` wrote a valid sentinel.

--- a/tests/unit/test_cluster_collector.py
+++ b/tests/unit/test_cluster_collector.py
@@ -3554,6 +3554,11 @@ class TestSharedFsProbeNonRank0Silence:
             ["probe", str(tmp_path), "silence-test-uuid"],
         )
 
+        # The probe's rank-0 D-49 quiesce path sleeps 5s; neutralize for the
+        # unit test (we're only locking the stdout marker contract).
+        import time as _time
+        monkeypatch.setattr(_time, "sleep", lambda *_a, **_kw: None)
+
         from mlpstorage_py.cluster_collector import SHARED_FS_PROBE_SCRIPT
 
         captured = io.StringIO()

--- a/tests/unit/test_shared_fs_probe.py
+++ b/tests/unit/test_shared_fs_probe.py
@@ -618,15 +618,21 @@ class TestPitfall4BcastStatusPreventsProceed:
         saved_argv = sys.argv
         saved_mpi4py = sys.modules.get("mpi4py")
         saved_mpi = sys.modules.get("mpi4py.MPI")
+        # The probe's rank-0 D-49 quiesce path sleeps 5s; neutralize for the
+        # unit test (we're only locking call ordering, not timing).
+        import time as _time
+        saved_sleep = _time.sleep
         try:
             sys.modules["mpi4py"] = fake_mpi4py
             sys.modules["mpi4py.MPI"] = _FakeMPI()
+            _time.sleep = lambda *_a, **_kw: None
             sys.argv = ["<probe>", str(tmp_path), "test-uuid", out_file]
             namespace = {"__name__": "__main__"}
             # The heredoc body calls sys.exit at the end; trap it.
             with pytest.raises(SystemExit):
                 exec(SHARED_FS_PROBE_SCRIPT, namespace)
         finally:
+            _time.sleep = saved_sleep
             sys.argv = saved_argv
             if saved_mpi4py is not None:
                 sys.modules["mpi4py"] = saved_mpi4py

--- a/tests/unit/test_validation_helpers.py
+++ b/tests/unit/test_validation_helpers.py
@@ -155,7 +155,11 @@ class TestValidateBenchmarkEnvironment:
         mock_logger = MagicMock()
 
         with pytest.raises(DependencyError) as exc_info:
-            validate_benchmark_environment(args, logger=mock_logger)
+            # skip_remote_checks: hosts=['node1','node2'] would otherwise
+            # trigger a real SSH probe to nonexistent hosts (~20s of
+            # connect timeouts); this test only asserts that multiple
+            # errors accumulate, which the MPI+DLIO mocks already cover.
+            validate_benchmark_environment(args, logger=mock_logger, skip_remote_checks=True)
 
         # First error should be raised (MPI)
         assert "MPI not found" in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.23"
+version = "3.0.25"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
## Summary
Speeds up the default test run by ~104s and closes a CI coverage gap that left three sibling test trees unexecuted.

- **test perf** (commit 1): three tests in the fast lane were silently eating ~30s of unintended waits. Fixed the root cause — they remain in the fast lane.
  - `test_collects_multiple_errors` was hitting a real SSH connect timeout (~20s) because the test passes `hosts=['node1','node2']` and `validate_benchmark_environment` runs SSH probes unless `skip_remote_checks=True`.
  - Two mocked-MPI tests (`test_bcast_precedes_barrier_in_executed_heredoc_with_mocked_mpi4py`, `test_rank0_emits_markers_and_non_rank0_silent[0]`) were execing the probe script in-process; rank 0 hits `time.sleep(5.0)`. Patched `time.sleep` for the duration of the exec.
- **slow markers** (commit 2): mark three genuinely-slow tests `@pytest.mark.slow`. Also declares the `slow` marker in `kv_cache_benchmark/pyproject.toml` (the root suite already has one).
  - `test_init_then_closed_datagen_no_env_var` — ~17.5s full in-process CLI dispatcher.
  - `test_gpu_overflow_to_cpu` — ~32s, 100×10K-token allocations.
  - `test_profile_allocate_vs_access_overhead` — ~5.8s profiling test.
- **CI coverage** (commit 3): the previous workflow ran `uv run pytest`, which only picked up `testpaths=['tests']` from the root pyproject. Three other test trees (`mlpstorage_py/tests`, `vdb_benchmark/tests`, `kv_cache_benchmark/tests`) never executed in CI — exactly the kind of gap PRs #551–#560 had to fix by hand. Each suite now runs in its own step (collecting `tests/` and `vdb_benchmark/tests/` together hits `ImportPathMismatchError` because both define a top-level `tests` package).
- **version bump** (commit 4): 3.0.23 → 3.0.25 and uv.lock regen. PR #550 takes 3.0.24, so this PR claims the next slot.

### Local results (all 11 in-flight PRs + this PR's changes)
| Suite | Before | After |
|---|---|---|
| `tests/` | 86s, 2380 passed, 12 deselected | **39s, 2379 passed, 13 deselected** |
| `mlpstorage_py/tests/` | 3.98s, 778 passed | unchanged |
| `vdb_benchmark/tests/` | 0.86s, 136 passed | unchanged |
| `kv_cache_benchmark/tests/` | 155s, 240 passed | **98s, 238 passed, 2 deselected** |

Total: **3531 passed, 15 deselected (slow), 1 xfailed, 0 failed** in ~142s.

## Test plan
- [ ] CI runs all four suites green on this PR.
- [ ] Confirm `pytest -m slow` on the root suite picks up the 13 deselected tests (12 pre-existing + the newly-marked integration test).
- [ ] Confirm `pytest -m slow` on `kv_cache_benchmark/tests` picks up the 2 newly-marked tests.
- [ ] After PR #550 merges, rebase and resolve the trivial `pyproject.toml` version conflict (3.0.24 → 3.0.25).

## Notes
- The four 5.3s `test_shared_fs_probe_real_mpi.py::TestSharedFsProbeRealMpi::*` tests stay in the fast lane intentionally — MPI is a sensitive area for bugs and these exercise real `mpirun`.
- Stacked behind PRs #550–#560. The version bump will need a one-line rebase after #550 lands.