### PR TITLE
PALS mpiexec for cluster collector + CAP-02 probe (ALCF; follow-up to #549)

### DIFF
--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -2975,21 +2975,22 @@ class MPIClusterCollector:
         # Build host string with 1 slot per host (we only need one process per node)
         host_slots = [f"{host}:1" for host in unique_hosts]
 
-        # Select MPI binary
-        if self.mpi_bin == MPIRUN:
-            mpi_executable = MPI_RUN_BIN
-        elif self.mpi_bin == MPIEXEC:
-            mpi_executable = MPI_EXEC_BIN
+        # Select MPI binary + launcher-family flags (one process per node).
+        if self.mpi_bin == MPIEXEC:
+            # HPE Cray PALS mpiexec (ALCF Crux/Polaris/Aurora): use --ppn and a
+            # bare comma-separated --hosts list with --cpu-bind. PALS rejects the
+            # OpenMPI flags (-host h:slots, --bind-to, --map-by,
+            # --allow-run-as-root). Mirrors utils.generate_mpi_prefix_cmd (#549).
+            cmd = (
+                f"{MPI_EXEC_BIN} -n {num_hosts} --ppn 1"
+                f" --hosts {','.join(unique_hosts)} --cpu-bind none"
+            )
         else:
-            mpi_executable = self.mpi_bin
-
-        cmd = f"{mpi_executable} -n {num_hosts} -host {','.join(host_slots)}"
-
-        # Add common flags
-        cmd += " --bind-to none --map-by node"
-
-        if self.allow_run_as_root:
-            cmd += " --allow-run-as-root"
+            mpi_executable = MPI_RUN_BIN if self.mpi_bin == MPIRUN else self.mpi_bin
+            cmd = f"{mpi_executable} -n {num_hosts} -host {','.join(host_slots)}"
+            cmd += " --bind-to none --map-by node"
+            if self.allow_run_as_root:
+                cmd += " --allow-run-as-root"
 
         # Add the Python script and output path
         cmd += f" python3 {script_path} {output_path}"
@@ -3471,33 +3472,41 @@ def run_shared_fs_probe(destination, hosts, run_uuid, logger,
                 code=ErrorCode.FS_INVALID_STRUCTURE,
             )
 
-    # ---- Build the mpirun command.
-    if mpi_bin == MPIRUN:
-        mpi_executable = MPI_RUN_BIN
-    elif mpi_bin == MPIEXEC:
-        mpi_executable = MPI_EXEC_BIN
-    else:
-        mpi_executable = mpi_bin
-
+    # ---- Build the launcher command (one process per host).
     n = len(unique_hosts)
-    host_slots = ",".join("{0}:1".format(h) for h in unique_hosts)
-    cmd_parts = [
-        mpi_executable,
-        "-n", str(n),
-        "-host", host_slots,
-        "--bind-to", "none",
-        "--map-by", "node",
-        # HARDEN-02 D-55.1: --tag-output gives PRRTE per-line atomicity and
-        # prefixes each forwarded line with [rank,jobid]<channel>: (OpenMPI 4.x
-        # format; verified on 4.1.6 per HARDEN-04 — channel is <stdout>,
-        # <stderr>, or <stddiag>, sometimes with a trailing colon). The launcher's
-        # marker regex tolerates the prefix; the post-extract _strip_tag_output_prefix()
-        # consumes both the bracketed identifier AND the optional <channel>: marker.
-        # Must appear BEFORE --allow-run-as-root per OpenMPI's accepted arg ordering.
-        "--tag-output",
-    ]
-    if allow_run_as_root:
-        cmd_parts.append("--allow-run-as-root")
+    if mpi_bin == MPIEXEC:
+        # HPE Cray PALS mpiexec (ALCF Crux/Polaris/Aurora): --ppn + bare --hosts
+        # + --cpu-bind. PALS rejects OpenMPI's -host h:slots / --bind-to /
+        # --map-by / --tag-output / --allow-run-as-root. There is no tag-output
+        # prefix to strip; rank-0's stdout markers are parsed verbatim below.
+        # Mirrors utils.generate_mpi_prefix_cmd (#549).
+        cmd_parts = [
+            MPI_EXEC_BIN,
+            "-n", str(n),
+            "--ppn", "1",
+            "--hosts", ",".join(unique_hosts),
+            "--cpu-bind", "none",
+        ]
+    else:
+        mpi_executable = MPI_RUN_BIN if mpi_bin == MPIRUN else mpi_bin
+        host_slots = ",".join("{0}:1".format(h) for h in unique_hosts)
+        cmd_parts = [
+            mpi_executable,
+            "-n", str(n),
+            "-host", host_slots,
+            "--bind-to", "none",
+            "--map-by", "node",
+            # HARDEN-02 D-55.1: --tag-output gives PRRTE per-line atomicity and
+            # prefixes each forwarded line with [rank,jobid]<channel>: (OpenMPI 4.x
+            # format; verified on 4.1.6 per HARDEN-04 — channel is <stdout>,
+            # <stderr>, or <stddiag>, sometimes with a trailing colon). The launcher's
+            # marker regex tolerates the prefix; the post-extract _strip_tag_output_prefix()
+            # consumes both the bracketed identifier AND the optional <channel>: marker.
+            # Must appear BEFORE --allow-run-as-root per OpenMPI's accepted arg ordering.
+            "--tag-output",
+        ]
+        if allow_run_as_root:
+            cmd_parts.append("--allow-run-as-root")
     cmd_parts += [
         "python3",
         remote_script_path,

--- a/tests/unit/test_shared_fs_probe.py
+++ b/tests/unit/test_shared_fs_probe.py
@@ -45,6 +45,7 @@ from mlpstorage_py.cluster_collector import (
     SHARED_FS_PROBE_SCRIPT,
     run_shared_fs_probe,
 )
+from mlpstorage_py.config import MPIRUN, MPIEXEC
 from mlpstorage_py.errors import ErrorCode, FileSystemError
 
 
@@ -782,3 +783,69 @@ class TestQuiesceTimingD49:
             "(making the quiesce useless because the barrier already "
             "released). Pattern: {0}".format(pattern)
         )
+
+
+# =============================================================================
+# TestLauncherFlags — CAP-02 probe argv is launcher-family correct
+# (#549 follow-up: HPE Cray PALS mpiexec support for ALCF Crux/Polaris/Aurora)
+# =============================================================================
+
+
+class TestLauncherFlags:
+    """The probe must emit PALS-native flags for mpiexec, OpenMPI flags for mpirun."""
+
+    def _capture_probe_cmd(self, mpi_bin, tmp_path):
+        captured = {}
+
+        def _side_effect(cmd_str, **kwargs):
+            captured["cmd"] = cmd_str
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            result.stdout = (
+                "__CAP02_RESULT_BEGIN__\n"
+                + json.dumps(_OK_PAYLOAD_TWO_HOSTS, separators=(",", ":"))
+                + "\n__CAP02_RESULT_END__\n"
+            )
+            return result
+
+        logger = MagicMock()
+        with patch(
+            "mlpstorage_py.cluster_collector.subprocess.run",
+            side_effect=_side_effect,
+        ), patch(
+            "mlpstorage_py.cluster_collector.MPIClusterCollector"
+        ) as mock_coll_cls:
+            mock_coll = mock_coll_cls.return_value
+            mock_coll._stage_script_on_remote_hosts.return_value = {
+                "h1": None, "h2": None
+            }
+            run_shared_fs_probe(
+                destination=str(tmp_path),
+                hosts=["h1", "h2"],
+                run_uuid="test-uuid",
+                logger=logger,
+                mpi_bin=mpi_bin,
+            )
+        return captured.get("cmd", "")
+
+    def test_mpiexec_emits_pals_flags(self, tmp_path):
+        cmd = self._capture_probe_cmd(MPIEXEC, tmp_path)
+        # PALS-native
+        assert "--ppn 1" in cmd
+        assert "--hosts h1,h2" in cmd
+        assert "--cpu-bind none" in cmd
+        # OpenMPI-only flags PALS cannot parse must be absent
+        assert "--map-by" not in cmd
+        assert "--bind-to" not in cmd
+        assert "--tag-output" not in cmd
+        assert "--allow-run-as-root" not in cmd
+        assert "-host " not in cmd  # PALS uses --hosts, not OpenMPI -host
+
+    def test_mpirun_unchanged(self, tmp_path):
+        cmd = self._capture_probe_cmd(MPIRUN, tmp_path)
+        assert "-host h1:1,h2:1" in cmd
+        assert "--bind-to none" in cmd
+        assert "--map-by node" in cmd
+        assert "--tag-output" in cmd
+        assert "--ppn" not in cmd


### PR DESCRIPTION
## Follow-up to #549 — PALS `mpiexec` in the cluster collector & CAP-02 probe

#549 fixed `utils.generate_mpi_prefix_cmd()` (the DLIO/benchmark launcher). But `mlpstorage_py/cluster_collector.py` builds its **own** launcher command lines in two places that still emit **OpenMPI-only** flags regardless of `--mpi-bin`:

1. `MPIClusterCollector._generate_mpi_command` — the per-host system-info gather (populates the system description in result metadata).
2. `run_shared_fs_probe` — the **CAP-02** shared-filesystem probe.

On HPE Cray **PALS** `mpiexec` (ALCF Crux/Polaris/Aurora) these flags (`-host h:slots`, `--bind-to`, `--map-by`, `--tag-output`, `--allow-run-as-root`) are rejected.

### Impact

- **Single-host runs:** harmless — the collector catches the failure and falls back to local-only collection (observed on Crux: PALS prints its usage, then `INFO: Falling back to local-only collection`).
- **Multi-host runs:** broken — e.g. `llama3-70b/405b/1t` checkpointing (8/64/128 nodes) and multi-node training. The cross-host gather fails (only node 0 captured) and the CAP-02 shared-FS probe can't launch.

### Fix

Branch both builders on launcher family, mirroring #549. For `mpiexec`, emit a PALS-native command (one process per host):

```
mpiexec -n N --ppn 1 --hosts h1,h2 --cpu-bind none python3 <script> ...
```

`mpirun` behaviour is unchanged (still `-host h:1,…`, `--bind-to none`, `--map-by node`, `--tag-output`, and `--allow-run-as-root` when requested). The PALS probe path omits `--tag-output`, so rank-0's `__CAP02_RESULT_BEGIN__/END__` stdout markers are parsed verbatim — there is no tag prefix to strip.

### Tests

`tests/unit/test_shared_fs_probe.py::TestLauncherFlags` captures the probe's generated argv and asserts:
- `mpiexec` → `--ppn 1`, `--hosts h1,h2`, `--cpu-bind none`; none of `--map-by`/`--bind-to`/`--tag-output`/`-host`.
- `mpirun` → unchanged (regression guard).

Verified on Crux (PALS 1.7.1, `cray-mpich/9.0.1`).
