### PR TITLE
Fix NameError for cache_stats in kv_cache _print_summary (#570)

### DIFF
--- a/kv_cache_benchmark/kv_cache/benchmark.py
+++ b/kv_cache_benchmark/kv_cache/benchmark.py
@@ -1505,13 +1505,14 @@ class IntegratedBenchmark:
         print(f"  A 200MiB block at 1GiB/s NVMe read = ~200 ms device latency.")
         print(f"  Compare latencies against block sizes, not against 4KiB page I/O.\n")
 
+        cache_stats = summary['cache_stats']
+
         """
         # Printing of pass/fail is not used in MLPerf 3.0
 
         PASS_SYMBOL = "[OK]"
         FAIL_SYMBOL = "[X]"
 
-        cache_stats = summary['cache_stats']
         if 'storage_health' in cache_stats:
             storage_health = cache_stats['storage_health']
             status = storage_health['overall_status']


### PR DESCRIPTION
## Summary
- Fixes #570: `NameError: name 'cache_stats' is not defined` raised on every call to `IntegratedBenchmark._print_summary()` in `kv_cache_benchmark/kv_cache/benchmark.py`.
- The `cache_stats = summary['cache_stats']` assignment was sitting inside the triple-quoted block comment added in #545 to disable the legacy "Storage Performance Assessment" output, so the variable was never bound when the subsequent sections (Cache Hit Rate, totals, tier distribution, bandwidths, per-tier latencies, cache-type breakdowns) tried to read it.
- Moves the assignment one line above the `"""` block so it runs unconditionally; no other behavior changes.

## Test plan
- [ ] Run `mlpstorage kvcache run ...` and confirm `_print_summary` prints the full `### STORAGE PERFORMANCE ###` section without raising `NameError`.