### PR TITLE
fix(#566,#569): CAP-02 shared-FS probe works on FUSE; preserve scp basename

### DIFF
--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -2516,8 +2516,12 @@ if __name__ == '__main__':
 # per benchmark instance from `_pre_execution_gate`, after the CAP-01
 # capacity check; rank 0 creates a per-run-uuid-suffixed sentinel file in the
 # dataset destination, every rank `os.stat`s it, the MPI gather collects
-# (st_dev, st_ino) tuples to rank 0, rank 0 enforces cardinality exactly 1
-# (or fails fast with each hostname's reported tuple), unlinks in a finally
+# (st_dev, st_ino) tuples to rank 0, rank 0 enforces st_ino cardinality
+# exactly 1 (or fails fast with each hostname's reported tuple — st_dev is
+# still reported in the diagnostic since it can help operators triage
+# mismatched mounts, but it is NOT used in the equality check because
+# FUSE / distributed FS mount device ids legitimately differ per node),
+# unlinks in a finally
 # block, sleeps 5.0s for storage quiesce (D-49), and all ranks reach a final
 # MPI_Barrier so the measured workload starts simultaneously.
 #
@@ -2780,9 +2784,17 @@ def main():
                     "message": _build_per_rank_message(all_payloads),
                 }
             else:
+                # NOTE: st_dev is intentionally excluded. It is the kernel's
+                # per-mount device id, assigned per-node, and legitimately
+                # differs across hosts on FUSE / distributed filesystems
+                # (DAOS DFuse, NFS, Lustre, GPFS, BeeGFS, ...) even when
+                # every rank stats the same shared sentinel. st_ino is the
+                # cross-host identity signal: if all ranks see the same
+                # inode for rank 0's unique sentinel, the data-dir is
+                # genuinely shared. See issue #566.
                 ids = set()
                 for p in all_payloads:
-                    ids.add((p.get("st_dev"), p.get("st_ino")))
+                    ids.add(p.get("st_ino"))
                 if len(ids) != 1:
                     status = "fail"
                     rank0_failure_summary = {
@@ -3045,8 +3057,8 @@ class MPIClusterCollector:
         Args:
             script_local_path: Path to the collector script on the launch host.
             remote_dir: Absolute directory to create on each remote host; the
-                script will be placed at ``remote_dir/mlps_collector.py``. The
-                same absolute path is used on every node so the ``mpirun``
+                script will be placed at ``remote_dir/<basename(script_local_path)>``.
+                The same absolute path is used on every node so the ``mpirun``
                 command line is identical everywhere.
             hosts: Remote hostnames to stage to. Callers should pass the result
                 of :meth:`_remote_hosts_needing_staging` to avoid SSHing to the
@@ -3071,9 +3083,13 @@ class MPIClusterCollector:
                 if r.returncode != 0:
                     return host, f"ssh mkdir failed: {r.stderr.strip() or r.stdout.strip()}"
 
+                # Preserve the local script's basename on the remote so
+                # callers staging a non-default name (e.g. the CAP-02 probe
+                # which uses `mlps_cap02_probe.py`) get the file at the path
+                # they expect to invoke. See issue #569.
                 scp_cmd = [
                     "scp", *ssh_common, script_local_path,
-                    f"{target}:{remote_dir}/mlps_collector.py",
+                    f"{target}:{remote_dir}/{os.path.basename(script_local_path)}",
                 ]
                 r = subprocess.run(
                     scp_cmd, capture_output=True, text=True,

--- a/tests/unit/test_cluster_collector.py
+++ b/tests/unit/test_cluster_collector.py
@@ -3602,6 +3602,162 @@ class TestSharedFsProbeNonRank0Silence:
             )
 
 
+class TestStageScriptPreservesBasename:
+    """Regression for issue #569: the SSH/SCP staging helper must place the
+    script at ``remote_dir/<basename(script_local_path)>``, NOT at the
+    hardcoded ``remote_dir/mlps_collector.py``.
+
+    The CAP-02 shared-FS probe stages a script named ``mlps_cap02_probe.py``
+    via the same helper. Pre-fix, the file landed remotely as
+    ``mlps_collector.py`` while the launcher pointed ``mpirun`` at
+    ``mlps_cap02_probe.py`` — the probe failed remotely with ENOENT and
+    the symptoms were visible in the field as a CAP-02 staging hang.
+
+    This test mocks subprocess.run and asserts the scp destination path
+    uses the local script's basename verbatim.
+    """
+
+    def test_scp_destination_uses_local_basename(self, tmp_path):
+        from mlpstorage_py.cluster_collector import MPIClusterCollector
+
+        local_script = tmp_path / "mlps_cap02_probe.py"
+        local_script.write_text("# probe\n")
+
+        captured_scp_targets = []
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd and cmd[0] == "scp":
+                captured_scp_targets.append(cmd[-1])
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        coll = MPIClusterCollector(
+            hosts=["remote-host"],
+            mpi_bin="mpirun",
+            logger=MagicMock(),
+            results_dir=str(tmp_path),
+        )
+
+        with patch(
+            "mlpstorage_py.cluster_collector.subprocess.run",
+            side_effect=fake_run,
+        ):
+            coll._stage_script_on_remote_hosts(
+                script_local_path=str(local_script),
+                remote_dir="/tmp/staging",
+                hosts=["remote-host"],
+            )
+
+        assert len(captured_scp_targets) == 1, (
+            f"expected exactly one scp call; got {captured_scp_targets!r}"
+        )
+        target = captured_scp_targets[0]
+        assert target.endswith("/mlps_cap02_probe.py"), (
+            "Issue #569: scp destination must preserve the local basename "
+            "(mlps_cap02_probe.py), not the hardcoded mlps_collector.py. "
+            f"Got: {target!r}"
+        )
+        assert "mlps_collector.py" not in target, (
+            f"scp destination must NOT collapse to mlps_collector.py; got: {target!r}"
+        )
+
+
+class TestSharedFsProbeIgnoresStDevAcrossHosts:
+    """Regression for issue #566: the CAP-02 probe must NOT include st_dev
+    in the cross-host identity check.
+
+    st_dev is the kernel's per-mount device id. On FUSE / distributed
+    filesystems (DAOS DFuse, NFS, Lustre, GPFS, BeeGFS, ...) the same
+    shared mount gets a different st_dev on every node because each node
+    runs its own mount instance. st_ino IS identical cluster-wide because
+    it is derived from the underlying object/inode identity.
+
+    Pre-fix behavior (the bug): rank 0 gathered (st_dev, st_ino) tuples
+    from every rank and rejected the run unless all tuples were identical,
+    which made CAP-02 unsatisfiable on FUSE — blocking every multi-host
+    DAOS / NFS / Lustre run.
+
+    Post-fix behavior (locked by this test): rank 0 must succeed (status
+    "ok", no failure_summary) when every rank reports the same st_ino,
+    even with mismatched st_dev values.
+    """
+
+    def test_same_st_ino_different_st_dev_succeeds(self, tmp_path, monkeypatch):
+        import contextlib
+        import io
+        import json
+        import re
+        import sys
+        from unittest.mock import MagicMock
+
+        # Build the exact bad-tuple-good-inode shape from the issue:
+        #   host=R2-06 rank=0 st_dev=46 st_ino=281482956119445
+        #   host=R2-05 rank=1 st_dev=47 st_ino=281482956119445  (different st_dev)
+        fake_comm = MagicMock()
+        fake_comm.Get_rank.return_value = 0
+        fake_comm.Get_size.return_value = 2
+        fake_comm.gather.return_value = [
+            {"hostname": "R2-06", "rank": 0, "failure": None,
+             "st_dev": 46, "st_ino": 281482956119445},
+            {"hostname": "R2-05", "rank": 1, "failure": None,
+             "st_dev": 47, "st_ino": 281482956119445},
+        ]
+        fake_comm.bcast.side_effect = lambda v, root=0: v
+        fake_comm.Barrier.return_value = None
+
+        fake_mpi_module = MagicMock()
+        fake_mpi_module.COMM_WORLD = fake_comm
+        fake_mpi4py_pkg = MagicMock()
+        fake_mpi4py_pkg.MPI = fake_mpi_module
+        monkeypatch.setitem(sys.modules, "mpi4py", fake_mpi4py_pkg)
+        monkeypatch.setitem(sys.modules, "mpi4py.MPI", fake_mpi_module)
+
+        monkeypatch.setattr(
+            sys, "argv",
+            ["probe", str(tmp_path), "fuse-st-dev-mismatch-uuid"],
+        )
+
+        import time as _time
+        monkeypatch.setattr(_time, "sleep", lambda *_a, **_kw: None)
+
+        from mlpstorage_py.cluster_collector import SHARED_FS_PROBE_SCRIPT
+
+        captured = io.StringIO()
+        exit_code = None
+        with contextlib.redirect_stdout(captured):
+            try:
+                exec(SHARED_FS_PROBE_SCRIPT, {"__name__": "__main__"})
+            except SystemExit as se:
+                exit_code = se.code
+
+        stdout_content = captured.getvalue()
+        m = re.search(
+            r"__CAP02_RESULT_BEGIN__\s*\n(.*?)\n.*?__CAP02_RESULT_END__",
+            stdout_content,
+            re.DOTALL,
+        )
+        assert m is not None, (
+            "rank 0 must always emit framed payload on stdout; "
+            f"got: {stdout_content!r}"
+        )
+        payload = json.loads(m.group(1).strip())
+
+        assert payload["status"] == "ok", (
+            "Issue #566: same st_ino with different st_dev must be treated as "
+            "shared FS (FUSE / DAOS / NFS / Lustre all assign st_dev per-node). "
+            f"Got payload: {payload!r}"
+        )
+        assert payload["failure_summary"] is None, (
+            f"failure_summary must be None on success; got: {payload['failure_summary']!r}"
+        )
+        assert exit_code in (0, None), (
+            f"probe must sys.exit(0) on ok status; got exit_code={exit_code!r}"
+        )
+
+
 class TestTagOutputRegexParsesOpenMpi4xPrefix:
     """HARDEN-04 regression guard: the CAP-02 launcher's tag-strip regex
     must consume the OpenMPI 4.x --tag-output prefix format


### PR DESCRIPTION
## Summary

Two tightly coupled fixes that together unblock all multi-host runs on FUSE / distributed filesystems (DAOS, NFS, Lustre, GPFS, BeeGFS, ...). Both surfaced from field reports against `6553c0e`.

- **`mlpstorage_py/cluster_collector.py:2785`** — Drop `st_dev` from the CAP-02 cross-host equality check; compare `st_ino` only. `st_dev` is the kernel's per-mount device id, assigned per-node, so the same shared mount legitimately reports different `st_dev` values on each host. `st_ino` is the cross-host identity signal: if every rank stats rank-0's unique sentinel and sees the same inode, the data-dir is shared. `st_dev` is still surfaced in the failure diagnostic so operators can triage genuinely mismatched mounts.
- **`mlpstorage_py/cluster_collector.py:3076`** — The SSH/SCP staging helper hardcoded the remote destination filename to `mlps_collector.py`. The CAP-02 probe stages a different file (`mlps_cap02_probe.py`), so the script landed at the wrong remote path while `mpirun` pointed at the expected one. Use `basename(script_local_path)` so callers that stage a non-default name reach their script remotely.

Both fixes are required to reach the CAP-02 success path on FUSE in practice — without #569's basename fix the probe never runs remotely; without #566's `st_dev` fix it always fails when it does.

Resolves #566.
Resolves #569.

## Field evidence (from the issues)

```
host=R2-06 rank=0 st_dev=46 st_ino=281482956119445
host=R2-05 rank=1 st_dev=47 st_ino=281482956119445   ← st_dev differs, st_ino IDENTICAL
```

Same pattern reported independently on a 64-node Soperator / Slurm cluster against shared NFS-style mounts.

## Test plan

- [x] Added `TestSharedFsProbeIgnoresStDevAcrossHosts` — exec's the actual `SHARED_FS_PROBE_SCRIPT` with mocked MPI gather returning identical `st_ino` and mismatched `st_dev`; asserts `status="ok"` and `failure_summary=None`. This is the FUSE / DAOS field case from #566.
- [x] Added `TestStageScriptPreservesBasename` — mocks `subprocess.run`; asserts the scp destination ends with the local script basename (`mlps_cap02_probe.py`), not the hardcoded `mlps_collector.py`.
- [x] Existing `TestCardinalityGreaterThanOneFails` still passes — mismatched `st_ino` (the real "wrong mount" case) still hard-fails CAP-02.
- [x] Full unit suite: `uv run pytest tests/unit -q` → 2288 passed.
- [ ] On-cluster: multi-host DAOS DFuse datasize / run reproducer from #566 should now reach the workload (verified by reporter on the patched version; this PR brings the same patches into `main`).