### PR TITLE
fix(#568): skip CAP-01 statvfs for object-mode DLIO runs

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -3,6 +3,7 @@ import os
 import os.path
 import pprint
 import sys
+from typing import Optional
 from urllib.parse import urlparse
 
 from mlpstorage_py.benchmarks.base import Benchmark
@@ -811,10 +812,18 @@ class TrainingBenchmark(DLIOBenchmark):
         )
         return int(total_disk_bytes)
 
-    def _capacity_gate_destination(self) -> str:
+    def _capacity_gate_destination(self) -> Optional[str]:
         """Return ``args.data_dir`` — the training dataset destination per
         REQUIREMENTS.md CAP-01.
+
+        Object-mode runs (data_access_protocol == 'object') target an
+        ``s3://`` URI; statvfs against a URI walks to filesystem root and
+        aborts with ``[E401] CAP-01: no valid parent``. Return None to
+        fire the A8 remote-backend escape hatch in ``_pre_execution_gate``.
+        See issue #568.
         """
+        if getattr(self.args, 'data_access_protocol', None) == 'object':
+            return None
         return self.args.data_dir
 
     def datasize(self):
@@ -965,6 +974,11 @@ class CheckpointingBenchmark(DLIOBenchmark):
         """
         cf = getattr(self.args, "checkpoint_folder", None)
         if not cf:
+            return None
+        # Object-mode runs target an s3:// URI; statvfs against a URI
+        # walks to filesystem root and aborts with [E401] CAP-01: no
+        # valid parent. A8 escape hatch — see issue #568.
+        if getattr(self.args, 'data_access_protocol', None) == 'object':
             return None
         return os.path.join(cf, self.args.model)
 

--- a/tests/unit/test_capacity_gate.py
+++ b/tests/unit/test_capacity_gate.py
@@ -40,7 +40,15 @@ import pytest
 # tests/unit/test_benchmarks_kvcache.py.
 import importlib.util as _ilu
 for _dep in ("pyarrow", "pyarrow.ipc", "psutil"):
-    if _ilu.find_spec(_dep) is None and _dep not in sys.modules:
+    if _dep in sys.modules:
+        continue
+    try:
+        _spec = _ilu.find_spec(_dep)
+    except (ModuleNotFoundError, ValueError):
+        # Parent already stubbed above (pyarrow → MagicMock), so find_spec
+        # for the submodule walks into the mock and raises. Treat as missing.
+        _spec = None
+    if _spec is None:
         sys.modules[_dep] = MagicMock()
 
 from mlpstorage_py.benchmarks.base import Benchmark
@@ -325,6 +333,35 @@ class TestTrainingBenchmarkRequiredBytes:
         bm.args = SimpleNamespace(data_dir="/data/foo")
         assert TrainingBenchmark._capacity_gate_destination(bm) == "/data/foo"
 
+    def test_destination_is_none_in_object_mode(self):
+        """Issue #568: CAP-01 must fire the A8 escape hatch when the
+        destination is an object-storage URI. statvfs on s3:// walks the
+        parent chain to the filesystem root and aborts with
+        ``[E401] CAP-01: no valid parent for s3://…``. ``data_access_protocol
+        == 'object'`` is the same signal _apply_object_storage_params keys on,
+        so returning None here mirrors the existing VectorDB/KVCache hatch.
+        """
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        bm = MagicMock(spec=TrainingBenchmark)
+        bm.args = SimpleNamespace(
+            data_dir="s3://mybucket/unet3d/data",
+            data_access_protocol="object",
+        )
+        assert TrainingBenchmark._capacity_gate_destination(bm) is None
+
+    def test_destination_is_data_dir_when_protocol_attribute_missing(self):
+        """Defensive: not every code path attaches data_access_protocol to
+        args (older test fixtures, internal callers). Absence must NOT be
+        interpreted as object mode — fall through to the existing local
+        statvfs path.
+        """
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        bm = MagicMock(spec=TrainingBenchmark)
+        bm.args = SimpleNamespace(data_dir="/data/foo")
+        assert TrainingBenchmark._capacity_gate_destination(bm) == "/data/foo"
+
     def test_datasize_invokes_pre_execution_gate_before_calculate_training_data_size(self):
         from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
 
@@ -501,6 +538,34 @@ class TestCheckpointingBenchmarkRequiredBytes:
         bm.args = SimpleNamespace(checkpoint_folder=None, model="llama3-8b")
         result = CheckpointingBenchmark._capacity_gate_destination(bm)
         assert result is None
+
+    def test_destination_is_none_in_object_mode(self):
+        """Issue #568: same A8 escape hatch as TrainingBenchmark — the
+        checkpoint_folder is an s3:// URI under `checkpointing run object`,
+        so the local statvfs would walk to root and abort with
+        ``[E401] CAP-01: no valid parent for s3://…``.
+        """
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+
+        bm = MagicMock(spec=CheckpointingBenchmark)
+        bm.args = SimpleNamespace(
+            checkpoint_folder="s3://mybucket/checkpoints",
+            model="llama3-8b",
+            data_access_protocol="object",
+        )
+        assert CheckpointingBenchmark._capacity_gate_destination(bm) is None
+
+    def test_destination_joined_when_protocol_attribute_missing(self):
+        """Defensive: absence of data_access_protocol must NOT be read as
+        object mode — fall through to the existing join behavior so file/
+        POSIX runs and older callers keep working.
+        """
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+
+        bm = MagicMock(spec=CheckpointingBenchmark)
+        bm.args = SimpleNamespace(checkpoint_folder="/cp", model="llama3-8b")
+        result = CheckpointingBenchmark._capacity_gate_destination(bm)
+        assert result == os.path.join("/cp", "llama3-8b")
 
 
 class TestVectorDBBenchmarkRequiredBytes:


### PR DESCRIPTION
## Summary
- Fixes #568. In `object` (S3) mode, the CAP-01 pre-execution capacity gate ran `os.statvfs()` against the `s3://…` destination; the parent-walk in `check_capacity_4field()` exhausted and aborted every training/checkpointing run with `[E401] CAP-01: cannot determine free space — no valid parent for s3://…`. `--skip-validation` did not help — CAP-01 lives in `_pre_execution_gate()`, separate from `validate_benchmark_environment()`.
- `TrainingBenchmark._capacity_gate_destination()` and `CheckpointingBenchmark._capacity_gate_destination()` now return `None` when `data_access_protocol == 'object'`, firing the existing A8 remote-backend escape hatch in `Benchmark._pre_execution_gate` (the same hatch VectorDB/KVCache already use). Logged as `CAP-01 skipped: destination not local`.
- File/POSIX runs unaffected: missing `data_access_protocol` attribute falls through to the existing `statvfs` path.
- Drive-by: the dep-stub block in `tests/unit/test_capacity_gate.py` raised `ModuleNotFoundError` from `find_spec("pyarrow.ipc")` after the parent `pyarrow` was stubbed with `MagicMock`, blocking collection. Wrapped the lookup so it degrades to "treat as missing."

## Test plan
- [x] RED commit: 4 new tests in `tests/unit/test_capacity_gate.py` (`test_destination_is_none_in_object_mode` + `test_destination_*_when_protocol_attribute_missing` × 2 benchmarks). 2 new tests fail on RED with the exact `s3://…` URI return.
- [x] GREEN commit: all 4 suites pass on the branch.
  - `tests/`: 2385 passed
  - `mlpstorage_py/tests`: 780 passed, 1 xfailed
  - `vdb_benchmark/tests`: 144 passed
  - `kv_cache_benchmark/tests`: 238 passed
- [ ] Reporter (@jadnov) re-runs the original repro on this branch and confirms training/checkpointing object-mode now proceeds past the gate.