### PR TITLE
fix(#571): bypass BenchmarkVerifier entirely in whatif mode

### DIFF
--- a/mlpstorage_py/benchmarks/base.py
+++ b/mlpstorage_py/benchmarks/base.py
@@ -896,18 +896,14 @@ class Benchmark(BenchmarkInterface, abc.ABC):
             May call sys.exit(1) if invalid and --allow-invalid-params not set.
         """
         self.logger.verboser(f'Verifying benchmark parameters: {self.args}')
-        if not self.benchmark_run_verifier:
-            self.benchmark_run_verifier = BenchmarkVerifier(self, logger=self.logger)
-
-        self.verification = self.benchmark_run_verifier.verify()
-        self.logger.verboser(f'Benchmark verification result: {self.verification}')
 
         # ``args.mode`` is the source of truth (post-PR #412 modal CLI:
         # closed|open|whatif as the first positional, argparse-enforced).
-        # The ``not closed_mode and not open_mode`` branch below is the
-        # explicit short-circuit for ``mode == 'whatif'``: whatif runs
-        # without verification by design. Do not delete it — whatif is a
-        # supported execution mode.
+        # whatif short-circuits BEFORE the verifier runs so checks like
+        # ``check_num_files_train`` don't log INVALID errors against runs
+        # that aren't subject to compliance (issue #571 Q3). ``self.verification``
+        # stays ``None`` for whatif and surfaces as ``"verification": null`` in
+        # the run metadata — which is accurate: no verification was performed.
         mode = self.args.mode
         closed_mode = (mode == 'closed')
         open_mode = (mode == 'open')
@@ -915,6 +911,13 @@ class Benchmark(BenchmarkInterface, abc.ABC):
         if not closed_mode and not open_mode:
             self.logger.warning(f'Running the benchmark without verification for open or closed configurations. These results are not valid for submission. Use closed or open as the first positional argument to specify a configuration.')
             return True
+
+        if not self.benchmark_run_verifier:
+            self.benchmark_run_verifier = BenchmarkVerifier(self, logger=self.logger)
+
+        self.verification = self.benchmark_run_verifier.verify()
+        self.logger.verboser(f'Benchmark verification result: {self.verification}')
+
         if not self.BENCHMARK_TYPE:
             raise ValueError(f'No benchmark specified. Unable to verify benchmark')
 

--- a/tests/unit/test_benchmarks_base.py
+++ b/tests/unit/test_benchmarks_base.py
@@ -402,6 +402,12 @@ class TestBenchmarkVerifyBenchmark:
     def test_returns_true_in_whatif_mode_without_verification(self, tmp_path):
         """`mode='whatif'` short-circuits verification with a warning and returns True.
 
+        Issue #571 Q3: whatif must NOT run the BenchmarkVerifier at all —
+        before the fix the verifier ran and emitted ERROR-level INVALID
+        lines for checks like ``check_num_files_train`` even though
+        ``verify_benchmark`` then returned True. Asserting the verifier
+        was never instantiated is what locks the bypass in place.
+
         Originally written as `test_returns_true_with_neither_flag_set`,
         which exercised the legacy `closed=False, open=False` bool case.
         Post-#412 the modal CLI is argparse-enforced so the only way to
@@ -440,6 +446,49 @@ class TestBenchmarkVerifyBenchmark:
             result = benchmark.verify_benchmark()
 
         assert result is True
+        mock_verifier_class.assert_not_called()
+        assert benchmark.verification is None
+
+    def test_whatif_bypasses_invalid_verification(self, tmp_path):
+        """Issue #571 Q3: a whatif run whose params would be INVALID under
+        closed/open rules must still proceed (return True) and must NOT
+        call sys.exit(1). Before the fix, the verifier ran first and
+        emitted ERROR-level INVALID lines; the mode short-circuit returned
+        True afterwards. After the fix, the verifier never runs in whatif
+        so the INVALID branch is unreachable.
+        """
+        args = Namespace(
+            mode='whatif',
+            dry_run=False,
+            orgname='Acme',
+            systemname='sys-v1',
+            debug=False,
+            verbose=False,
+            what_if=False,
+            stream_log_level='INFO',
+            results_dir=str(tmp_path),
+            model='unet3d',
+            command='run',
+            num_processes=8,
+            accelerator_type='h100',
+            closed=False,
+            open=False,
+            allow_invalid_params=False,
+        )
+
+        with patch('mlpstorage_py.benchmarks.base.generate_output_location') as mock_gen:
+            mock_gen.return_value = str(tmp_path / "output")
+            benchmark = ConcreteBenchmark(args, run_datetime="20250115_120000")
+
+        with patch('mlpstorage_py.benchmarks.base.BenchmarkVerifier') as mock_verifier_class:
+            mock_verifier = MagicMock()
+            mock_verifier.verify.return_value = PARAM_VALIDATION.INVALID
+            mock_verifier_class.return_value = mock_verifier
+
+            result = benchmark.verify_benchmark()
+
+        assert result is True
+        mock_verifier_class.assert_not_called()
 
 
 class TestBenchmarkRun:


### PR DESCRIPTION
## Summary

Closes Q3 of #571 — \"If I specify 'whatif' in the training command, should mlpstorage bypass the data size check? Currently, it does not.\"

`verify_benchmark` ran `BenchmarkVerifier.verify()` before checking `args.mode`, so whatif runs emitted ERROR-level `INVALID:` lines from `check_num_files_train` (and every other check) even though the mode short-circuit then returned `True` and the run proceeded. The existing comment in that function already said *\"whatif runs without verification by design\"* — the code didn't match.

This PR reorders `verify_benchmark` in `mlpstorage_py/benchmarks/base.py` so the whatif gate fires first. In whatif:

- `BenchmarkVerifier` is never instantiated — no INVALID error spam
- `self.verification` stays `None` and surfaces as `\"verification\": null` in the run metadata (accurate: no verification was performed)
- `verify_benchmark` returns `True` as before

closed/open behavior is unchanged.

Q1/Q2 from the issue are working-as-intended (math, not a bug) and were answered in https://github.com/mlcommons/storage/issues/571#issuecomment-4837042057. Q4 (datasize says 3500 vs. YAML default 7200) is tracked separately.

## Test plan
- [x] `uv run pytest tests/unit/test_benchmarks_base.py::TestBenchmarkVerifyBenchmark -v` — 7/7 pass, including the new `test_whatif_bypasses_invalid_verification`
- [x] Existing `test_returns_true_in_whatif_mode_without_verification` tightened with `mock_verifier_class.assert_not_called()` + `benchmark.verification is None`
- [x] Full unit suite: `uv run pytest tests/unit` → 2287 passed