### PR TITLE
MERGE ALL EARLIER PRs FIRST -- chore: bump dlio-benchmark to DLIO #39; version 3.0.25 -> 3.0.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.25"
+version = "3.0.26"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -129,6 +129,9 @@ torchaudio = [{ index = "pytorch-cpu" }]
 # Pinned to a specific commit for reproducibility; bump by updating `rev` and
 # re-running `uv lock --upgrade-package dlio-benchmark`.
 # Commit history (most recent first):
+#   - DLIO PR #39 fix for storage #567: O_DIRECT path triggers on
+#     uri_scheme=direct so direct_fs (--o-direct) reaches s3dlio instead of
+#     crashing buffered open() with a direct:// URI
 #   - DLIO PR #38 fix for storage #538: wire DIRECT_FS for --o-direct local
 #     O_DIRECT I/O (merged form supersedes the pre-merge pin from 3.0.23)
 #   - DLIO PR #37: restrict default `pytest` to checkin suite; full suite must
@@ -142,7 +145,7 @@ torchaudio = [{ index = "pytorch-cpu" }]
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
 #   - DLIO PR #21 fix for storage #391 part 1 (TorchIterableDatasetSimple gating)
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "252a54b18d113541e1e8e24832921fac0a7f2b96" }
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "f16fe43f657360e80f56fd3e9826b167620866e7" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=252a54b18d113541e1e8e24832921fac0a7f2b96#252a54b18d113541e1e8e24832921fac0a7f2b96" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=f16fe43f657360e80f56fd3e9826b167620866e7#f16fe43f657360e80f56fd3e9826b167620866e7" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.25"
+version = "3.0.26"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=252a54b18d113541e1e8e24832921fac0a7f2b96" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=252a54b18d113541e1e8e24832921fac0a7f2b96" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=f16fe43f657360e80f56fd3e9826b167620866e7" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=f16fe43f657360e80f56fd3e9826b167620866e7" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary

Bump `dlio-benchmark` pin to pick up [DLIO PR #39](https://github.com/mlcommons/DLIO_local_changes/pull/39) (merged `f16fe43`), which resolves #567, and roll the project version 3.0.25 → 3.0.26.

- **DLIO pin:** `252a54b1` → `f16fe43f`. The fix in #39 broadens the `_LocalFSIterableMixin` O_DIRECT gate so it triggers on either `storage_options.uri_scheme == "direct"` (canonical signal — what `direct_fs` validation produces) or the legacy `storage_options.storage_library == "direct"`. Before the fix the two halves of DLIO required different `storage_library` values and `--o-direct` for local NPZ / NPY / JPEG always crashed in the warmup batch with `FileNotFoundError: 'direct:///mnt/…/foo.npz'`.
- **Net effect for mlpstorage:** `--o-direct` for UNet3D / ResNet / any local NPZ-NPY-JPEG workload now reaches the s3dlio O_DIRECT engine instead of feeding `direct://` URIs to plain `open()`.
- **`uv.lock`:** regenerated via `uv lock --upgrade-package dlio-benchmark`. Same 108 packages resolve; only the `dlio-benchmark` source SHA moves.
- **Pin-history comment** at `pyproject.toml:131-148` updated with a new line for DLIO #39 / storage #567 (most-recent-first ordering).

## Test plan

- [x] `uv run pytest tests/unit -q` → **2290 passed**. No regressions.
- [x] `test_version_matches_pyproject` and `test_dist_name_matches_pyproject` pass at the new version.
- [x] `uv lock` resolves cleanly with no other dependency churn.
- [ ] On-cluster: reporter's `mlcommons/storage#567` reproducer (`mlpstorage … training unet3d run file --o-direct …`) should now train past warmup. Worth confirming on the lab cluster before tagging a release.

## Closes / fixes (downstream)

- Closes #567 — fix lives in DLIO #39; this PR is the downstream pin bump that makes 3.0.26 carry the fix.

## Notes

- This is a clean version bump on top of `main` (currently includes the recent #568 CAP-01 object-mode fix).
- Independent from the still-open #577 (CAP-02 / scp staging fixes for #566 + #569) — #577 will rebase cleanly onto `main` regardless of merge order.
