### PR TITLE
fix(#584): _is_object_storage recognises data_access_protocol=='object'

### DIFF
--- a/mlpstorage_py/validation_helpers.py
+++ b/mlpstorage_py/validation_helpers.py
@@ -165,6 +165,14 @@ def _validate_required_params(args) -> List[Exception]:
 
 def _is_object_storage(args) -> bool:
     """Return True if args indicate object/S3 storage (skip all filesystem checks)."""
+    # Canonical signal: the `object` positional sets data_access_protocol='object'.
+    # storage.storage_type=s3 is injected onto self.params_dict by
+    # DLIOBenchmark._apply_object_storage_params AFTER argument parsing, so it
+    # is not present in args.params at validation time for a bare `--object`
+    # invocation; data_access_protocol IS set at parse time and is what every
+    # other site (CAP-01 gate, dlio.py, run_summary, cli_parser) keys on. See #584.
+    if getattr(args, 'data_access_protocol', None) == 'object':
+        return True
     # Check params list for storage.storage_type=s3
     params = getattr(args, 'params', None) or []
     for p in params:

--- a/tests/unit/test_validation_helpers.py
+++ b/tests/unit/test_validation_helpers.py
@@ -21,6 +21,8 @@ from mlpstorage_py.validation_helpers import (
     _requires_mpi,
     _is_distributed_run,
     _requires_dlio,
+    _is_object_storage,
+    _validate_paths,
 )
 from mlpstorage_py.errors import DependencyError, MPIError, ConfigurationError
 
@@ -115,6 +117,163 @@ class TestRequiresDlio:
         """Should return False when program not set."""
         args = Namespace()
         assert _requires_dlio(args) is False
+
+
+class TestIsObjectStorage:
+    """Tests for _is_object_storage helper function.
+
+    Regression coverage for issue #584: the helper used to recognize object
+    mode only via ``--params storage.storage_type=s3`` or an ``s3://``-scheme
+    data path. It did NOT consult ``args.data_access_protocol == 'object'``
+    — the canonical signal set by the ``object`` positional. A bare
+    ``mlpstorage … run object --data-dir data/unet3d …`` therefore fell
+    through to local-filesystem checks and failed with ``[E401] Data
+    directory not found``, even though the run is genuinely object-mode.
+
+    Note on coverage scope: ``storage.storage_type=s3`` is injected into
+    ``DLIOBenchmark.params_dict`` by ``_apply_object_storage_params`` AFTER
+    argument parsing — it never reaches ``args.params`` for a bare
+    ``--object`` invocation, which is exactly why the
+    ``data_access_protocol`` gate is load-bearing.
+    """
+
+    def test_data_access_protocol_object_returns_true(self):
+        """#584 regression: bare ``object`` positional must be recognised."""
+        args = Namespace(data_access_protocol='object', params=[], data_dir='data/unet3d')
+        assert _is_object_storage(args) is True
+
+    def test_data_access_protocol_file_returns_false(self):
+        """File mode with a local data_dir must NOT be misclassified."""
+        args = Namespace(data_access_protocol='file', params=[], data_dir='/tmp/local')
+        assert _is_object_storage(args) is False
+
+    def test_data_access_protocol_missing_falls_through(self):
+        """No data_access_protocol attr → fall through to legacy signals."""
+        args = Namespace(params=[], data_dir='/tmp/local')
+        assert _is_object_storage(args) is False
+
+    def test_params_storage_type_s3_returns_true(self):
+        """Legacy signal still works: --params storage.storage_type=s3."""
+        args = Namespace(
+            data_access_protocol=None,
+            params=['storage.storage_type=s3'],
+            data_dir='/tmp/local',
+        )
+        assert _is_object_storage(args) is True
+
+    def test_params_storage_type_object_returns_true(self):
+        """Legacy signal also accepts storage.storage_type=object."""
+        args = Namespace(
+            data_access_protocol=None,
+            params=['storage.storage_type=object'],
+            data_dir='/tmp/local',
+        )
+        assert _is_object_storage(args) is True
+
+    def test_s3_uri_scheme_on_data_dir_returns_true(self):
+        """Legacy signal still works: s3:// scheme on data_dir."""
+        args = Namespace(
+            data_access_protocol=None,
+            params=[],
+            data_dir='s3://bucket/path',
+        )
+        assert _is_object_storage(args) is True
+
+    def test_s3_uri_scheme_on_checkpoint_folder_returns_true(self):
+        """Legacy signal still works: s3:// scheme on checkpoint_folder."""
+        args = Namespace(
+            data_access_protocol=None,
+            params=[],
+            checkpoint_folder='s3://bucket/checkpoints',
+        )
+        assert _is_object_storage(args) is True
+
+    def test_unrelated_params_returns_false(self):
+        """Unrelated --params entries must not flip the gate."""
+        args = Namespace(
+            data_access_protocol='file',
+            params=['dataset.num_files_train=1000', 'dataset.num_subfolders_train=5'],
+            data_dir='/tmp/local',
+        )
+        assert _is_object_storage(args) is False
+
+    def test_empty_args_returns_false(self):
+        """Defensive: missing every signal must not raise, must return False."""
+        args = Namespace()
+        assert _is_object_storage(args) is False
+
+
+class TestValidatePathsObjectStorageBypass:
+    """Integration coverage for the #584 fix: ``_validate_paths`` must
+    early-return for object-mode runs so a non-existent local data_dir
+    does NOT raise FS_PATH_NOT_FOUND.
+
+    Pre-fix: a bare ``--object --data-dir data/unet3d`` invocation reached
+    ``os.path.exists('data/unet3d')`` (the path is conceptually a bucket
+    key, not a local path) and validation raised E401. The fix routes the
+    canonical ``data_access_protocol == 'object'`` signal through
+    ``_is_object_storage`` so the early return at the top of
+    ``_validate_paths`` fires.
+    """
+
+    def test_object_mode_with_nonexistent_data_dir_returns_no_errors(self):
+        """The exact storage#584 reproducer config: ``object`` positional,
+        bare relative data_dir that doesn't exist on the local FS, no
+        ``--params`` injected. Pre-fix this returned an E401 error;
+        post-fix it must return an empty error list."""
+        args = Namespace(
+            command='run',
+            data_access_protocol='object',
+            params=[],
+            data_dir='data/unet3d',  # does not exist locally — it's a bucket key
+            checkpoint_folder=None,
+            results_dir=None,
+            config_file=None,
+        )
+        errors = _validate_paths(args)
+        assert errors == [], (
+            "Issue #584 regression: object-mode runs with a non-existent "
+            "local data_dir path must early-return from _validate_paths. "
+            f"Got errors: {errors!r}"
+        )
+
+    def test_file_mode_with_nonexistent_data_dir_still_errors(self):
+        """Guardrail: file mode still raises when data_dir is missing.
+        The fix must not silently broaden the bypass."""
+        args = Namespace(
+            command='run',
+            data_access_protocol='file',
+            params=[],
+            data_dir='/nonexistent/local/path/that/does/not/exist',
+            checkpoint_folder=None,
+            results_dir=None,
+            config_file=None,
+        )
+        errors = _validate_paths(args)
+        assert len(errors) >= 1, (
+            "File mode must still report missing data_dir; the object-mode "
+            "bypass must not leak. Got: %r" % errors
+        )
+        assert any("Data directory not found" in str(e) for e in errors)
+
+    def test_object_mode_skips_checkpoint_parent_check(self):
+        """The checkpoint parent-dir check at validation_helpers.py:215-223
+        is the second site the reporter mentions — it must also be bypassed
+        for object mode, since object-mode checkpoint paths are bucket keys."""
+        args = Namespace(
+            command='run',
+            data_access_protocol='object',
+            params=[],
+            data_dir=None,
+            checkpoint_folder='checkpoints/llama3-8b',  # bucket key, no local parent
+            results_dir=None,
+            config_file=None,
+        )
+        errors = _validate_paths(args)
+        assert errors == [], (
+            "Object-mode checkpoint paths are bucket keys; the local parent-dir "
+            "check must be bypassed. Got: %r" % errors
+        )
 
 
 class TestValidateBenchmarkEnvironment:


### PR DESCRIPTION
## Summary

Resolves #584.

`validation_helpers._is_object_storage(args)` decided object-vs-local using only two signals:

1. `--params storage.storage_type=s3` present in `args.params`
2. `s3://`-scheme prefix on `args.data_dir` / `args.checkpoint_folder`

It did **not** consult `args.data_access_protocol == 'object'` — the canonical signal set by the `object` positional, and the signal every other site already keys on (CAP-01 gate per #568/#579, `dlio.py`, `run_summary`, `cli_parser`, every CLI module).

For a bare `mlpstorage … run object --data-dir data/unet3d …`:

- `data_access_protocol='object'` is set at parse time ✓
- `storage.storage_type=s3` is **injected onto `DLIOBenchmark.params_dict` after** parsing (`mlpstorage_py/benchmarks/dlio.py:202-203`), so it never reaches `args.params` at validation time
- the bare `--data-dir` has no `s3://` scheme

`_is_object_storage` returned `False`, `_validate_paths` fell through to `os.path.exists()` on what is conceptually a bucket key, and the run died with `[E401] Data directory not found`. Only `--skip-validation` could unblock it, which also disables the MPI / SSH / DLIO checks — too broad.

## The fix

One line, additive — check `data_access_protocol` first, then fall through to the legacy signals. Every config that returned `True` before still does.

```python
def _is_object_storage(args) -> bool:
    if getattr(args, 'data_access_protocol', None) == 'object':
        return True
    # … existing legacy signals unchanged …
```

## Tests

12 new tests, all pass; full unit suite stays green.

**`TestIsObjectStorage`** (9 cases):
- canonical signal (`data_access_protocol='object'`) → `True` (the #584 regression lock)
- `data_access_protocol='file'` → `False` (must not misclassify file mode)
- missing `data_access_protocol` attr → falls through to legacy signals
- legacy `--params storage.storage_type=s3` → `True` (and `=object` variant)
- `s3://` on `data_dir` → `True`
- `s3://` on `checkpoint_folder` → `True`
- unrelated `--params` entries don't flip the gate
- empty `Namespace()` doesn't raise

**`TestValidatePathsObjectStorageBypass`** (3 cases — integration through `_validate_paths`):
- exact #584 reproducer config (`object` positional, bare relative `data_dir`, no `--params`) → no errors
- **guardrail:** file mode with a missing `data_dir` still errors (the bypass must not leak)
- checkpoint parent-dir check is also bypassed for object mode (the second site the reporter mentioned)

## Verification

- [x] `uv run pytest tests/unit/test_validation_helpers.py -v` → 46 passed (34 existing + 12 new).
- [x] `uv run pytest tests/unit -q` → **2303 passed**. No regressions.
- [ ] On-cluster: reporter's repro (`mlpstorage closed training unet3d run object --data-dir data/unet3d …`, no `--skip-validation`) should now pass environment validation.

## Notes

- **Independent of #581.** That PR refines a *different* `_is_object_storage` — `DLIOBenchmark._is_object_storage()` in `benchmarks/dlio.py`, scoped to the CAP-01 capacity gate with access to `params_dict`. Same name, different scope. They could converge into a shared helper eventually, but #584 is the user-facing CLI-validation bug and is solved in isolation here.
- Independent of #577 (CAP-02 / scp fixes for #566+#569) and #582 (DLIO #39 pin bump for #567). All three rebase cleanly regardless of merge order.
