### PR TITLE
fix(#583): bridge URI scheme between DLIO preflight (bare) and checkpoint writer (qualified)

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -7,6 +7,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 from mlpstorage_py.benchmarks.base import Benchmark
+from mlpstorage_py.checkpointing.storage_writers import CHECKPOINT_URI_SCHEME_ENV
 from mlpstorage_py.config import (CONFIGS_ROOT_DIR, BENCHMARK_TYPES, EXEC_TYPE, MPIRUN, MLPSTORAGE_BIN_NAME,
                                LLM_ALLOWED_VALUES, LLM_SUBSET_PROCS, EXIT_CODE, MODELS, HYDRA_OUTPUT_SUBDIR,
                                LLM_SIZE_BY_RANK)
@@ -900,7 +901,26 @@ class CheckpointingBenchmark(DLIOBenchmark):
             # For direct:// / file:// schemes, ObjStoreLibStorage._preflight validates
             # that namespace as a local directory — so it must be an absolute path,
             # not relative to storage.storage_root. See issue #536.
-            self.params_dict['checkpoint.checkpoint_folder'] = os.path.join(self.args.checkpoint_folder, self.args.model)
+            folder = self.args.checkpoint_folder
+            storage_type = self.params_dict.get('storage.storage_type', 'local')
+            if storage_type in DLIOBenchmark._OBJECT_STORAGE_TYPES:
+                # Issue #583: mirror the #459 storage_root fix — DLIO's
+                # ObjStoreLibStorage._preflight prepends the scheme itself,
+                # so feeding it s3://bucket/... produces s3://s3://bucket/...
+                # Strip the scheme and stash it in an env var so the
+                # streaming-checkpoint writer (forked from DLIO, inherits
+                # env) can reconstruct the qualified URI at dispatch time.
+                normalized = DLIOBenchmark._strip_uri_scheme(folder)
+                if normalized != folder:
+                    scheme = urlparse(folder).scheme
+                    os.environ[CHECKPOINT_URI_SCHEME_ENV] = scheme
+                    self.logger.debug(
+                        f'Normalized checkpoint_folder: {folder!r} -> {normalized!r}; '
+                        f'set {CHECKPOINT_URI_SCHEME_ENV}={scheme!r} for the '
+                        'streaming-writer subprocess (issue #583).'
+                    )
+                folder = normalized
+            self.params_dict['checkpoint.checkpoint_folder'] = os.path.join(folder, self.args.model)
 
 
     def add_workflow_to_cmd(self, cmd) -> str:

--- a/mlpstorage_py/checkpointing/storage_writers/__init__.py
+++ b/mlpstorage_py/checkpointing/storage_writers/__init__.py
@@ -12,6 +12,8 @@ Use StorageWriterFactory.create() to automatically select the appropriate
 backend based on URI scheme or explicit backend name.
 """
 
+import os
+
 from .base import StorageWriter
 from .file_writer import FileStorageWriter
 from .s3dlio_writer import S3DLIOStorageWriter
@@ -19,9 +21,35 @@ from .s3dlio_writer import S3DLIOStorageWriter
 from typing import Optional, Any
 
 
+CHECKPOINT_URI_SCHEME_ENV = 'MLPSTORAGE_CHECKPOINT_URI_SCHEME'
+
+
+def _normalize_checkpoint_uri(uri: str) -> str:
+    """Reconstruct an object-storage URI when mlpstorage stripped the scheme.
+
+    Issue #583: ``CheckpointingBenchmark.add_checkpoint_params`` strips the
+    URI scheme from ``checkpoint_folder`` so DLIO's
+    ``ObjStoreLibStorage._preflight`` (which prepends the scheme itself,
+    the #392 / #459 pattern) doesn't produce ``s3://s3://…``. The writer
+    process — forked from DLIO, inheriting env — reads
+    ``MLPSTORAGE_CHECKPOINT_URI_SCHEME`` to put the scheme back before
+    dispatch. Without this bridge the writer would silently fall back to
+    the local FileStorageWriter on a scheme-less path, a data integrity
+    failure rather than a loud one.
+
+    No-op when the URI already has a scheme OR the env var is unset/empty.
+    """
+    if '://' in uri:
+        return uri
+    scheme = os.environ.get(CHECKPOINT_URI_SCHEME_ENV)
+    if not scheme:
+        return uri
+    return f'{scheme}://{uri}'
+
+
 class StorageWriterFactory:
     """Factory for creating storage writer instances based on URI or explicit backend."""
-    
+
     @staticmethod
     def create(
         uri_or_path: str,
@@ -60,6 +88,11 @@ class StorageWriterFactory:
             ...     use_direct_io=True
             ... )
         """
+        # Issue #583: reconstruct the URI scheme mlpstorage stripped to
+        # work around the DLIO preflight double-prefix bug. No-op if the
+        # URI already has a scheme or the env hint isn't set.
+        uri_or_path = _normalize_checkpoint_uri(uri_or_path)
+
         # Explicit backend selection
         if backend:
             if backend == 'file':

--- a/mlpstorage_py/checkpointing/storage_writers/s3dlio_writer.py
+++ b/mlpstorage_py/checkpointing/storage_writers/s3dlio_writer.py
@@ -76,7 +76,14 @@ class S3DLIOStorageWriter(StorageWriter):
             raise ImportError(
                 "s3dlio not available. Install with: pip install s3dlio"
             )
-        
+
+        # Issue #583: reconstruct the URI scheme if mlpstorage stripped it
+        # in CheckpointingBenchmark.add_checkpoint_params to dodge the
+        # DLIO ObjStoreLibStorage preflight double-prefix bug. Caller-
+        # supplied scheme-qualified URIs pass through unchanged.
+        from . import _normalize_checkpoint_uri
+        uri = _normalize_checkpoint_uri(uri)
+
         self.uri = uri
         self.chunk_size = chunk_size
         self.part_size = part_size

--- a/tests/unit/test_checkpoint_writer_scheme.py
+++ b/tests/unit/test_checkpoint_writer_scheme.py
@@ -1,0 +1,211 @@
+"""Tests for issue #583 — object-mode checkpoint writer URI reconstruction.
+
+When mlpstorage strips the URI scheme from ``checkpoint.checkpoint_folder``
+to avoid DLIO's ``ObjStoreLibStorage._preflight`` double-prefix bug
+(``s3://s3://…``, the #392-class failure mode that #459 fixed for
+``storage_root``), the checkpoint writer subprocess later receives a
+scheme-less path it cannot dispatch. The writer needs the scheme back.
+
+The bridge is ``MLPSTORAGE_CHECKPOINT_URI_SCHEME`` — an env var
+``CheckpointingBenchmark.add_checkpoint_params`` sets in the parent
+mlpstorage process when (and only when) it strips a scheme. DLIO and
+its forked writer subprocess inherit the env, and
+``_normalize_checkpoint_uri`` reconstructs the qualified URI right before
+the s3dlio/factory dispatch.
+
+These tests lock the helper and the two call sites (factory +
+``S3DLIOStorageWriter.__init__``) so a refactor that drops the
+reconstruction step would surface immediately rather than at a real S3
+write attempt.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub heavy deps so the module can be collected when s3dlio/pyarrow are
+# absent from the dev env (same defensive pattern used in
+# tests/unit/test_dlio_object_storage.py).
+import importlib.util as _ilu
+for _dep in ('pyarrow', 'pyarrow.ipc', 'dotenv'):
+    if _dep in sys.modules:
+        continue
+    try:
+        _spec = _ilu.find_spec(_dep)
+    except (ModuleNotFoundError, ValueError):
+        _spec = None
+    if _spec is None:
+        sys.modules[_dep] = MagicMock()
+
+
+CHECKPOINT_URI_SCHEME_ENV = 'MLPSTORAGE_CHECKPOINT_URI_SCHEME'
+
+
+# =============================================================================
+# _normalize_checkpoint_uri — the helper itself
+# =============================================================================
+
+
+class TestNormalizeCheckpointURI:
+    """``_normalize_checkpoint_uri`` is the single point of reconstruction.
+
+    Returns input unchanged when the URI already has a scheme OR when the
+    env var is unset. Prepends ``{scheme}://`` only when both conditions
+    hold (scheme-less URI AND env var set).
+    """
+
+    def test_returns_unchanged_when_uri_has_scheme(self, monkeypatch):
+        from mlpstorage_py.checkpointing.storage_writers import (
+            _normalize_checkpoint_uri,
+        )
+        monkeypatch.setenv(CHECKPOINT_URI_SCHEME_ENV, 's3')
+        assert _normalize_checkpoint_uri('s3://bucket/path') == 's3://bucket/path'
+        assert _normalize_checkpoint_uri('file:///local/path') == 'file:///local/path'
+        assert _normalize_checkpoint_uri('direct:///mnt/x') == 'direct:///mnt/x'
+
+    def test_returns_unchanged_when_env_unset(self, monkeypatch):
+        """Bare path + no env hint → caller's existing dispatch decides
+        (e.g. file backend default). MUST NOT prepend a default scheme."""
+        from mlpstorage_py.checkpointing.storage_writers import (
+            _normalize_checkpoint_uri,
+        )
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        assert _normalize_checkpoint_uri('/local/abs/path') == '/local/abs/path'
+        assert _normalize_checkpoint_uri('bucket/relative') == 'bucket/relative'
+
+    def test_prepends_scheme_for_bare_path_when_env_set(self, monkeypatch):
+        """The bug-fix path: mlpstorage stripped the scheme, set the env,
+        DLIO subprocess inherited it, writer reconstructs."""
+        from mlpstorage_py.checkpointing.storage_writers import (
+            _normalize_checkpoint_uri,
+        )
+        monkeypatch.setenv(CHECKPOINT_URI_SCHEME_ENV, 's3')
+        assert (
+            _normalize_checkpoint_uri('bucket/ckpt/llama3-8b/global_epoch1_step1/file.pt')
+            == 's3://bucket/ckpt/llama3-8b/global_epoch1_step1/file.pt'
+        )
+
+    def test_supports_az_scheme(self, monkeypatch):
+        from mlpstorage_py.checkpointing.storage_writers import (
+            _normalize_checkpoint_uri,
+        )
+        monkeypatch.setenv(CHECKPOINT_URI_SCHEME_ENV, 'az')
+        assert _normalize_checkpoint_uri('container/path') == 'az://container/path'
+
+    def test_supports_gs_scheme(self, monkeypatch):
+        from mlpstorage_py.checkpointing.storage_writers import (
+            _normalize_checkpoint_uri,
+        )
+        monkeypatch.setenv(CHECKPOINT_URI_SCHEME_ENV, 'gs')
+        assert _normalize_checkpoint_uri('bucket/path') == 'gs://bucket/path'
+
+    def test_empty_env_value_is_treated_as_unset(self, monkeypatch):
+        """Defensive: an empty string env value (rare but possible) must
+        not produce ``://path`` — treat it the same as unset."""
+        from mlpstorage_py.checkpointing.storage_writers import (
+            _normalize_checkpoint_uri,
+        )
+        monkeypatch.setenv(CHECKPOINT_URI_SCHEME_ENV, '')
+        assert _normalize_checkpoint_uri('bucket/path') == 'bucket/path'
+
+
+# =============================================================================
+# StorageWriterFactory.create — picks up normalization
+# =============================================================================
+
+
+class TestStorageWriterFactoryNormalization:
+    """The factory must run ``_normalize_checkpoint_uri`` BEFORE dispatch
+    so both the auto-detect branch (line 112+) and the explicit
+    ``backend='s3dlio'`` branch land on the correct writer for the
+    reconstructed scheme. Without normalization, a bare bucket path would
+    fall through to the default ``FileStorageWriter`` (line 148) and
+    silently write to the local filesystem instead of S3 — a data
+    integrity failure, not just a missing-feature failure.
+    """
+
+    def test_auto_detect_reconstructs_scheme_for_bare_path(self, monkeypatch):
+        monkeypatch.setenv(CHECKPOINT_URI_SCHEME_ENV, 's3')
+        from mlpstorage_py.checkpointing import storage_writers
+        with patch.object(storage_writers, 'S3DLIOStorageWriter') as mock_writer:
+            storage_writers.StorageWriterFactory.create('bucket/ckpt/file.pt')
+            mock_writer.assert_called_once()
+            args, _ = mock_writer.call_args
+            assert args[0] == 's3://bucket/ckpt/file.pt'
+
+    def test_explicit_s3dlio_backend_reconstructs_scheme(self, monkeypatch):
+        monkeypatch.setenv(CHECKPOINT_URI_SCHEME_ENV, 's3')
+        from mlpstorage_py.checkpointing import storage_writers
+        with patch.object(storage_writers, 'S3DLIOStorageWriter') as mock_writer:
+            storage_writers.StorageWriterFactory.create(
+                'bucket/ckpt/file.pt', backend='s3dlio'
+            )
+            mock_writer.assert_called_once()
+            args, _ = mock_writer.call_args
+            assert args[0] == 's3://bucket/ckpt/file.pt'
+
+    def test_no_env_var_bare_path_unchanged_falls_back_to_file(self, monkeypatch):
+        """Existing behavior preserved: no env var + bare path → file
+        backend. File-mode checkpoint runs that worked before #583 must
+        keep working."""
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        from mlpstorage_py.checkpointing import storage_writers
+        with patch.object(storage_writers, 'FileStorageWriter') as mock_writer:
+            storage_writers.StorageWriterFactory.create('/local/abs/path/file.pt')
+            mock_writer.assert_called_once()
+            args, kwargs = mock_writer.call_args
+            assert args[0] == '/local/abs/path/file.pt'
+
+    def test_scheme_qualified_uri_passes_through_unchanged_when_env_set(
+        self, monkeypatch
+    ):
+        """If the caller already gave a qualified URI, leave it alone —
+        even with env set. Belt-and-braces: env is a fallback, not an
+        override."""
+        monkeypatch.setenv(CHECKPOINT_URI_SCHEME_ENV, 's3')
+        from mlpstorage_py.checkpointing import storage_writers
+        with patch.object(storage_writers, 'S3DLIOStorageWriter') as mock_writer:
+            storage_writers.StorageWriterFactory.create('s3://bucket/file.pt')
+            mock_writer.assert_called_once()
+            args, _ = mock_writer.call_args
+            assert args[0] == 's3://bucket/file.pt'
+
+
+# =============================================================================
+# S3DLIOStorageWriter — picks up normalization
+# =============================================================================
+
+
+class TestS3DLIOStorageWriterNormalization:
+    """The writer __init__ must also normalize, because callers can
+    construct it directly (factory test above covers the factory path)."""
+
+    def test_writer_reconstructs_scheme_for_bare_path(self, monkeypatch):
+        monkeypatch.setenv(CHECKPOINT_URI_SCHEME_ENV, 's3')
+        from mlpstorage_py.checkpointing.storage_writers import s3dlio_writer
+        # Patch the s3dlio module attribute used by the writer; the writer
+        # imports it lazily inside __init__ via ``import s3dlio``.
+        fake = MagicMock()
+        fake.PyWriterOptions.return_value.with_buffer_size.return_value = MagicMock()
+        with patch.dict('sys.modules', {'s3dlio': fake}):
+            writer = s3dlio_writer.S3DLIOStorageWriter(
+                'bucket/ckpt/file.pt', use_multi_endpoint=False
+            )
+        assert writer.uri == 's3://bucket/ckpt/file.pt'
+
+    def test_writer_raises_unsupported_scheme_when_env_unset(self, monkeypatch):
+        """The original failure mode must remain reachable when no env
+        hint is provided — silently writing to the wrong backend would
+        be far worse than a loud error."""
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        from mlpstorage_py.checkpointing.storage_writers import s3dlio_writer
+        fake = MagicMock()
+        with patch.dict('sys.modules', {'s3dlio': fake}):
+            with pytest.raises(ValueError, match='Unsupported URI scheme'):
+                s3dlio_writer.S3DLIOStorageWriter(
+                    'bucket/ckpt/file.pt', use_multi_endpoint=False
+                )

--- a/tests/unit/test_dlio_object_storage.py
+++ b/tests/unit/test_dlio_object_storage.py
@@ -501,3 +501,153 @@ class TestProcessDlioParamsFullChain:
             obj.params_dict = params_dict
             DLIOBenchmark._apply_object_storage_params(obj)
         assert 'storage.storage_root' not in obj.params_dict
+
+
+# ---------------------------------------------------------------------------
+# Issue #583: checkpoint_folder scheme stripping + env-var bridge
+# ---------------------------------------------------------------------------
+
+CHECKPOINT_URI_SCHEME_ENV = 'MLPSTORAGE_CHECKPOINT_URI_SCHEME'
+
+
+def _make_checkpoint_obj(
+    checkpoint_folder,
+    model='llama3-8b',
+    storage_type='s3',
+    num_processes=8,
+):
+    """Stand-in for CheckpointingBenchmark 'self' when testing
+    add_checkpoint_params scheme handling. ``storage_type`` controls
+    whether the strip-and-set-env branch fires (object backends only)
+    so file-mode mismatches stay catchable by
+    ``_check_storage_scheme_consistency`` downstream."""
+    from mlpstorage_py.config import LLM_ALLOWED_VALUES
+    _, _, _, closed_gpus = LLM_ALLOWED_VALUES[model]
+    obj = MagicMock(spec=['args', 'params_dict', 'logger'])
+    obj.args = Namespace(
+        o_direct=False,
+        checkpoint_folder=checkpoint_folder,
+        model=model,
+        num_processes=num_processes,
+        num_checkpoints_read=10,
+        num_checkpoints_write=10,
+    )
+    obj.params_dict = {'storage.storage_type': storage_type}
+    obj.logger = MagicMock()
+    return obj
+
+
+class TestAddCheckpointParamsSchemeStripping:
+    """Issue #583: object-mode checkpointing must strip the URI scheme
+    from ``checkpoint_folder`` so DLIO's preflight (which prepends the
+    scheme itself) doesn't produce ``s3://s3://…``. The stripped scheme
+    is plumbed to the writer subprocess via env so it can reconstruct.
+
+    Mirrors the #459 fix for ``storage.storage_root`` but conditioned on
+    object-storage mode — leaving the strip out for ``local`` /
+    ``direct_fs`` preserves the existing
+    ``_check_storage_scheme_consistency`` guardrail (which catches
+    ``--file`` + ``--checkpoint-folder s3://…`` user mistakes).
+    """
+
+    def test_strips_s3_scheme_in_object_mode(self, monkeypatch):
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+        obj = _make_checkpoint_obj('s3://mybucket/ckpt', storage_type='s3')
+        CheckpointingBenchmark.add_checkpoint_params(obj)
+        assert (
+            obj.params_dict['checkpoint.checkpoint_folder']
+            == 'mybucket/ckpt/llama3-8b'
+        )
+
+    def test_strips_az_scheme_in_object_mode(self, monkeypatch):
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+        obj = _make_checkpoint_obj('az://container/ckpt', storage_type='s3')
+        CheckpointingBenchmark.add_checkpoint_params(obj)
+        assert (
+            obj.params_dict['checkpoint.checkpoint_folder']
+            == 'container/ckpt/llama3-8b'
+        )
+
+    def test_strips_gs_scheme_in_object_mode(self, monkeypatch):
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+        obj = _make_checkpoint_obj('gs://bucket/ckpt', storage_type='s3')
+        CheckpointingBenchmark.add_checkpoint_params(obj)
+        assert (
+            obj.params_dict['checkpoint.checkpoint_folder']
+            == 'bucket/ckpt/llama3-8b'
+        )
+
+    def test_no_strip_for_bare_path_in_object_mode(self, monkeypatch):
+        """If the operator already passed the bare form, behave the same
+        as before — no double-strip, no env clobber from an empty scheme."""
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+        obj = _make_checkpoint_obj('bucket/ckpt', storage_type='s3')
+        CheckpointingBenchmark.add_checkpoint_params(obj)
+        assert (
+            obj.params_dict['checkpoint.checkpoint_folder']
+            == 'bucket/ckpt/llama3-8b'
+        )
+        assert CHECKPOINT_URI_SCHEME_ENV not in os.environ
+
+    def test_no_strip_in_file_mode_preserves_consistency_guard(self, monkeypatch):
+        """``_check_storage_scheme_consistency`` is what catches the
+        ``--file --checkpoint-folder s3://…`` user mistake. If we strip
+        unconditionally, that guard sees a bare path and lets the
+        misconfiguration through. The strip must be conditioned on
+        object storage mode."""
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+        obj = _make_checkpoint_obj('s3://mybucket/ckpt', storage_type='local')
+        CheckpointingBenchmark.add_checkpoint_params(obj)
+        assert (
+            obj.params_dict['checkpoint.checkpoint_folder']
+            == 's3://mybucket/ckpt/llama3-8b'
+        )
+        assert CHECKPOINT_URI_SCHEME_ENV not in os.environ
+
+    def test_no_strip_for_direct_fs_odirect_mode(self, monkeypatch):
+        """--o-direct sets storage_type='direct_fs'; the namespace is a
+        local path — no preflight double-prefix problem to solve."""
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+        obj = _make_checkpoint_obj('/mnt/ckpts', storage_type='direct_fs')
+        CheckpointingBenchmark.add_checkpoint_params(obj)
+        assert (
+            obj.params_dict['checkpoint.checkpoint_folder']
+            == '/mnt/ckpts/llama3-8b'
+        )
+        assert CHECKPOINT_URI_SCHEME_ENV not in os.environ
+
+    def test_env_var_set_to_scheme_when_stripped(self, monkeypatch):
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+        obj = _make_checkpoint_obj('s3://mybucket/ckpt', storage_type='s3')
+        CheckpointingBenchmark.add_checkpoint_params(obj)
+        assert os.environ.get(CHECKPOINT_URI_SCHEME_ENV) == 's3'
+
+    def test_env_var_set_for_each_object_scheme(self, monkeypatch):
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+        for folder, scheme in (
+            ('s3://b/p', 's3'),
+            ('az://c/p', 'az'),
+            ('gs://b/p', 'gs'),
+        ):
+            monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+            obj = _make_checkpoint_obj(folder, storage_type='s3')
+            CheckpointingBenchmark.add_checkpoint_params(obj)
+            assert os.environ.get(CHECKPOINT_URI_SCHEME_ENV) == scheme, (
+                f'expected scheme {scheme!r} for {folder!r}'
+            )
+
+    def test_env_var_not_set_when_no_checkpoint_folder(self, monkeypatch):
+        monkeypatch.delenv(CHECKPOINT_URI_SCHEME_ENV, raising=False)
+        from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+        obj = _make_checkpoint_obj('', storage_type='s3')
+        # Empty folder → the ``if self.args.checkpoint_folder`` guard
+        # in add_checkpoint_params short-circuits, no strip, no env.
+        CheckpointingBenchmark.add_checkpoint_params(obj)
+        assert CHECKPOINT_URI_SCHEME_ENV not in os.environ


### PR DESCRIPTION
Fixes #583. Recreates @gaikwadabhishek's analysis as a CLA-clean implementation — credit for the bug report and root-cause writeup is his.

## The bug

`mlpstorage closed checkpointing run object --checkpoint-folder s3://…` cannot write to S3. Two consumers of `checkpoint_folder` want opposite forms:

- **DLIO preflight** (`ObjStoreLibStorage._preflight`) prepends the scheme itself (the #392 pattern), so it wants a **bare** bucket/prefix. Feeding it `s3://…` produces `s3://s3://…` and aborts.
- **mlpstorage's streaming-checkpoint writer** (`S3DLIOStorageWriter`) auto-dispatches by URI scheme, so it wants the **scheme-qualified** form. A bare path either lands silently on `FileStorageWriter` (writing to the local FS instead of S3 — data integrity failure) or raises `Unsupported URI scheme`.

Neither workaround works today — both shapes break one of the two consumers.

## The fix

Mirror the #459 storage_root fix for `checkpoint_folder`, plus a one-env-var bridge to the writer subprocess:

1. **`CheckpointingBenchmark.add_checkpoint_params`** — strip the URI scheme from `checkpoint_folder` so DLIO preflight gets a bare namespace. Set `MLPSTORAGE_CHECKPOINT_URI_SCHEME=<scheme>` in the parent env. Conditioned on `storage.storage_type in {'s3','s3_torch'}` so the file-mode mismatch guardrail in `_check_storage_scheme_consistency` (which catches `--file --checkpoint-folder s3://…` user mistakes) keeps working. `direct_fs` (`--o-direct`) is unaffected — its namespace is a local path.
2. **`storage_writers/_normalize_checkpoint_uri`** — new helper. If URI lacks a scheme AND env var is set, prepend `{scheme}://`. No-op otherwise.
3. **`StorageWriterFactory.create`** and **`S3DLIOStorageWriter.__init__`** — both call the helper before dispatch so the writer subprocess (forked from DLIO, inherits env) reconstructs the qualified URI cleanly.

## Test plan

- [x] RED commit (5d2b5cc) adds 21 tests across `tests/unit/test_dlio_object_storage.py` (10 new in `TestAddCheckpointParamsSchemeStripping`) and a new `tests/unit/test_checkpoint_writer_scheme.py` (11 tests: 6 for the helper, 4 for factory, 2 for writer init). 14 fail with `AttributeError` / `ImportError` / wrong dispatch; 7 pass (negative-case regression guards).
- [x] GREEN commit (22a99d4) makes all 21 pass. No regressions:
  - `tests/`: 2406 passed, 13 deselected
  - `mlpstorage_py/tests`: 780 passed, 1 xfailed
  - `vdb_benchmark/tests`: 144 passed
  - `kv_cache_benchmark/tests`: 238 passed
- [ ] On-cluster: reporter's repro (`mlpstorage closed checkpointing run object --checkpoint-folder s3://… --model llama3-8b …`) writes a full checkpoint to the bucket without `[E401]` or `Unsupported URI scheme`.

## Relationship to other open PRs

End-to-end object-mode checkpointing also requires:
- **#585** (`validation_helpers._is_object_storage` fix for #584) — without it the `[E401] Data directory not found` validation error fires before reaching this code path. Independent fix, different file.
- **#581** (CAP-01 object-storage skip refinement for #568) — uses the same `storage.storage_type` signal as this PR but inside `DLIOBenchmark._is_object_storage()`. This PR's inline check could refactor to call that helper once both land. Different functions in the same file; rebases cleanly either order.

All three rebase cleanly regardless of merge order; together they unblock object-mode runs end-to-end.

## Files

- `mlpstorage_py/benchmarks/dlio.py` — `add_checkpoint_params` scheme strip + env var; import for `CHECKPOINT_URI_SCHEME_ENV`.
- `mlpstorage_py/checkpointing/storage_writers/__init__.py` — new `_normalize_checkpoint_uri` helper + factory wiring; `CHECKPOINT_URI_SCHEME_ENV` constant.
- `mlpstorage_py/checkpointing/storage_writers/s3dlio_writer.py` — call the helper in `__init__`.
- `tests/unit/test_dlio_object_storage.py` — new `TestAddCheckpointParamsSchemeStripping` (10 tests).
- `tests/unit/test_checkpoint_writer_scheme.py` — new file (3 test classes, 11 tests).