### PR TITLE
fix(#575): CAP-01 deferral message + correct --data-dir layout docs

### DIFF
--- a/ManPage.md
+++ b/ManPage.md
@@ -237,21 +237,25 @@ After the first successful write, `mlpstorage` will never again modify `systemna
 
 ## DATA DIRECTORY (`--data-dir`)
 
-The data directory is the on-storage workspace for generated datasets and checkpoints. It is read by `run` and written by `datagen`. Its layout is determined by the underlying DLIO workload template plus any `--params` overrides, but the canonical structure produced by the bundled templates is:
+The data directory is the on-storage workspace for the generated **training** dataset. It is read by `run` and written by `datagen`. The internal layout follows the DLIO data-generator convention familiar to ML practitioners — a per-model root containing the standard `train` / `valid` / `test` split:
 
 ```
 <data-dir>/
-├── training/
-│   └── <model>/                    e.g. unet3d, retinanet
-│       └── <rank>/                 zero-padded process rank: 0000, 0001, ...
-│           └── <data files>        .npz / .hdf5 / .tfrecord depending on model
-└── checkpointing/
-    └── <model>/                    e.g. llama3-70b
-        └── <rank>/
-            └── <checkpoint shards> .safetensors / .pt
+└── <model>/                        e.g. unet3d, retinanet — auto-appended
+    ├── train/                      <data files> .npz / .npy / .jpeg /
+    │                               .hdf5 / .tfrecord depending on model
+    │                               and workload YAML
+    ├── valid/                      empty under v3.0 bundled workloads (see note)
+    └── test/                       empty under v3.0 bundled workloads (see note)
 ```
 
-The `data-dir` must live on the storage system under test. For closed training submissions, the generated dataset must total at least five times the client host memory (`--client-host-memory-in-gb`) to prevent the OS page cache from absorbing the workload; `datasize` exists specifically to compute and report this lower bound.
+The `<model>/` segment is appended by `datagen` if `--data-dir` does not already end in the model name; the `train/`, `valid/`, and `test/` subdirectories are created on the local filesystem before `datagen` runs. Each rank writes into the same `train/` directory using DLIO's `{prefix}_{idx:0N}_of_{total}.{format}` naming convention — no per-rank subdirectory. Object-storage modes (`object` positional) skip the local makedirs because the path is an S3 key prefix.
+
+> **Note on `valid/` and `test/`** — every bundled v3.0 training workload YAML sets `workflow.train: True` only, with no `evaluation` step and no `num_files_eval`. Both subdirectories are therefore created on disk but **not populated by `datagen` today**. They follow the conventional train/valid/test split used throughout the ML ecosystem (`valid/` for held-out evaluation files consumed during training, `test/` for a post-training generalization corpus) so the layout remains immediately recognizable and a future workload that enables `workflow.evaluation: True` writes into the path practitioners expect. Submitters can ignore the empty subdirectories; `mlpstorage validate` does not inspect `--data-dir` contents.
+
+Each `datagen` invocation should own its `--data-dir` — sharing a single `--data-dir` across multiple workloads or repeated runs is not supported. The `--data-dir` must live on the storage system under test. For closed training submissions, the generated dataset must total at least five times the client host memory (`--client-host-memory-in-gb`) to prevent the OS page cache from absorbing the workload; `datasize` exists specifically to compute and report this lower bound.
+
+Checkpointing benchmarks use a separate `--checkpoint-folder` (not `--data-dir`); its layout is `<checkpoint-folder>/<model>/…` where the contents under `<model>/` are managed by the DLIO checkpointing workload (shard counts, ranks, and shapes depend on the model and `--num-processes`).
 
 VectorDB does not use `--data-dir`; vectors are loaded directly into the database engine (Milvus) by `datagen`. KV-Cache does not use `--data-dir`; cache tiers reside in GPU/CPU memory and (optionally) `--cache-dir` on NVMe.
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -30,14 +30,14 @@ ansible-galaxy collection install -r collections/requirements.yml
 
 ## 🗂️ Preparing Mount Directories
 
-Before running benchmarks, **ensure dataset folders exist** on **every node**.
+Before running benchmarks, **ensure the `--data-dir` parent exists** on **every node**. `mlpstorage datagen` will create the per-workload internal structure (`<data-dir>/<model>/{train,valid,test}/`) on first use — you do not need to pre-create those subdirectories.
 
 ### Option 1: Local Directory
 
-Create local folders:
+Create the parent folder:
 
 ```bash
-mkdir -p /mnt/nfs/train /mnt/nfs/valid
+mkdir -p /mnt/nfs
 ```
 
 ### Option 2: NFS Mounted Directory

--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -818,11 +818,25 @@ class TrainingBenchmark(DLIOBenchmark):
                 cluster_info = self.accumulate_host_info(self.args)
                 self.cluster_information = cluster_info
             except AttributeError as exc:
-                self.logger.info(
-                    "CAP-01 deferred: unable to determine system memory "
-                    f"({exc}). Re-run with --client-host-memory-in-gb to "
-                    "enable the disk-capacity check."
-                )
+                # The --client-host-memory-in-gb flag is intentionally NOT
+                # registered for datagen (see cli/training_args.py around
+                # the "Memory argument — not for datagen" comment), so don't
+                # tell datagen users to "re-run with" a flag the parser will
+                # reject. See issue #575 (and the earlier confusion in #578).
+                command = getattr(self.args, 'command', None)
+                if command == 'datagen':
+                    self.logger.info(
+                        "CAP-01 skipped for datagen: the disk-capacity gate "
+                        "needs --client-host-memory-in-gb, which datagen does "
+                        "not accept by design. This notice is informational; "
+                        "the run will proceed."
+                    )
+                else:
+                    self.logger.info(
+                        "CAP-01 deferred: unable to determine system memory "
+                        f"({exc}). Re-run with --client-host-memory-in-gb to "
+                        "enable the disk-capacity check."
+                    )
                 return 0
         _, _, total_disk_bytes = calculate_training_data_size(
             self.args,

--- a/tests/unit/test_capacity_gate.py
+++ b/tests/unit/test_capacity_gate.py
@@ -484,6 +484,70 @@ class TestTrainingBenchmarkRequiredBytes:
             "Operator must be told CAP-01 was deferred — silent skip violates SC#6 intent."
         )
 
+    def test_deferral_message_is_datagen_aware_for_datagen_command(self):
+        """Issue #575 regression: --client-host-memory-in-gb is intentionally NOT
+        accepted by datagen (mlpstorage_py/cli/training_args.py — "Memory
+        argument — not for datagen"). The deferral notice must therefore NOT
+        tell a datagen user to "Re-run with --client-host-memory-in-gb" — the
+        parser would reject the re-run. Same confusion previously surfaced in
+        #578 and was only fixed for the gate itself, not the suggestion text.
+        """
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        bm = MagicMock(spec=TrainingBenchmark)
+        bm.args = SimpleNamespace(data_dir="/data", command="datagen")
+        try:
+            del bm.cluster_information
+        except AttributeError:
+            pass
+        bm.combined_params = {"dataset": {}, "reader": {}}
+        bm.logger = MagicMock()
+        bm.accumulate_host_info = MagicMock(side_effect=AttributeError(
+            "'Namespace' object has no attribute 'client_host_memory_in_gb'"
+        ))
+
+        result = TrainingBenchmark.required_bytes_for_capacity_gate(bm)
+
+        assert result == 0
+        assert bm.logger.info.called
+        logged = " ".join(str(c.args[0]) for c in bm.logger.info.call_args_list)
+        assert "datagen" in logged, (
+            "datagen-path deferral message must mention datagen so the operator "
+            f"understands why the gate was skipped. Got: {logged!r}"
+        )
+        assert "Re-run with --client-host-memory-in-gb" not in logged, (
+            "Issue #575: the deferral notice must NOT instruct datagen users to "
+            "re-run with --client-host-memory-in-gb — that flag is not registered "
+            f"on the datagen subparser. Got: {logged!r}"
+        )
+
+    def test_deferral_message_keeps_rerun_suggestion_for_non_datagen_commands(self):
+        """Guardrail for #575: the rewrite must not silently drop the
+        actionable suggestion for the run / datasize commands where
+        --client-host-memory-in-gb IS accepted."""
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        bm = MagicMock(spec=TrainingBenchmark)
+        bm.args = SimpleNamespace(data_dir="/data", command="run")
+        try:
+            del bm.cluster_information
+        except AttributeError:
+            pass
+        bm.combined_params = {"dataset": {}, "reader": {}}
+        bm.logger = MagicMock()
+        bm.accumulate_host_info = MagicMock(side_effect=AttributeError(
+            "'Namespace' object has no attribute 'client_host_memory_in_gb'"
+        ))
+
+        result = TrainingBenchmark.required_bytes_for_capacity_gate(bm)
+
+        assert result == 0
+        logged = " ".join(str(c.args[0]) for c in bm.logger.info.call_args_list)
+        assert "Re-run with --client-host-memory-in-gb" in logged, (
+            "run-path deferral message must retain the actionable re-run "
+            f"suggestion (the flag IS accepted by `run`). Got: {logged!r}"
+        )
+
 
 class TestCheckpointingBenchmarkRequiredBytes:
     """A7 destination join + sum(rank_gb) * GiB * num_checkpoints_write."""


### PR DESCRIPTION
## Summary

Fixes the two surviving issues from #575 — the primary CAP-02 staging bug was already addressed by #577 and is on `main` at 3.0.26, so the only things this PR touches are the loose ends.

### 1. CAP-01 deferred-message bug (the user-facing nuisance)

The deferral notice told `datagen` users to *"Re-run with `--client-host-memory-in-gb`"* — but `--client-host-memory-in-gb` is intentionally **not registered** on the `datagen` subparser (`mlpstorage_py/cli/training_args.py`, the "Memory argument — not for datagen" branch). The previous report of this confusion (#578) was closed citing a fix, but the merged fix was for the gate itself; the misleading suggestion text was never updated. Kevin tripped on it again here.

The notice now splits by command:

- `command == 'datagen'` → `"CAP-01 skipped for datagen: the disk-capacity gate needs --client-host-memory-in-gb, which datagen does not accept by design. This notice is informational; the run will proceed."`
- everything else (`run`, `datasize`) → retains the original *"Re-run with --client-host-memory-in-gb"* suggestion, since those subparsers DO accept the flag.

Two regression tests in `tests/unit/test_capacity_gate.py`:
- `test_deferral_message_is_datagen_aware_for_datagen_command` — locks the new behavior.
- `test_deferral_message_keeps_rerun_suggestion_for_non_datagen_commands` — guardrail so a future cleanup doesn't drop the actionable suggestion for `run` / `datasize`.

### 2. `--data-dir` docs realigned with the code

Two docs described a `--data-dir` internal structure that doesn't match the code:

- **`ManPage.md`** showed a rank-based `<data-dir>/training/<model>/<rank>/<files>` tree plus a parallel `checkpointing/` branch under `--data-dir`. The code actually produces `<data-dir>/<model>/{train,valid,test}/` with no rank subdir, and checkpointing has its own `--checkpoint-folder` flag — not a sibling under `--data-dir`.
- **`ansible/README.md`** instructed users to `mkdir -p /mnt/nfs/train /mnt/nfs/valid` — wrong level (no `<model>/`) AND redundant, because `mlpstorage` calls `os.makedirs()` for the internal structure itself.

The new ManPage text shows the actual on-disk tree:

```
<data-dir>/
└── <model>/                        e.g. unet3d, retinanet — auto-appended
    ├── train/                      data files (.npz / .npy / .jpeg / ...)
    ├── valid/                      empty under v3.0 bundled workloads (see note)
    └── test/                       empty under v3.0 bundled workloads (see note)
```

A note explains *why* `valid/` and `test/` are present but empty: every bundled v3.0 training workload YAML sets `workflow.train: True` only, with no `evaluation` step and no `num_files_eval` — DLIO defaults (`do_eval=False`, `num_files_eval=0`) leave the subdirs unused. The conventional ML train/valid/test split is preserved on disk because that's what AI practitioners expect to see, and because a future workload that flips `workflow.evaluation: True` will write into the path they'd expect.

Also surfaced explicitly: *"each `datagen` invocation should own its `--data-dir`"* — sharing one `--data-dir` across multiple workloads or repeated runs is not supported.

`ansible/README.md` now says `mkdir -p /mnt/nfs` plus a one-liner that `mlpstorage datagen` creates the per-workload internal structure (`<data-dir>/<model>/{train,valid,test}/`) on first use, so users don't need to pre-create those subdirectories.

### Deliberately NOT in this PR

- The dead `test/` makedirs at `mlpstorage_py/benchmarks/dlio.py:692-698` — could be removed unilaterally, deferred for a separate, intentional cleanup.
- The `<model>/` auto-append at `mlpstorage_py/benchmarks/dlio.py:684-690` — touching this is a cross-repo design conversation with DLIO's `data_generator.py:330-368` (which hardcodes `/train/` and `/valid/` paths regardless of the mlpstorage side).
- Any change to `<results-dir>` or other ManPage sections.
- `docs/OBJECT_STORAGE_TESTING.md:127` (`s3 ls .../retinanet/train/`) — already correct under the documented shape, no change needed.

## Test plan

- [x] `uv run pytest tests/unit -q` → **2335 passed** (+2 new regression tests, no regressions).
- [x] Both `test_deferral_message_*` tests assert the message split end-to-end.
- [ ] Kevin's reproducer on a 3.0.26+ build, no `--skip-validation`, multi-host. The primary CAP-02 failure is already fixed (PR #577 / commit `953247a`); this PR just removes the confusing secondary noise about `--client-host-memory-in-gb` and corrects the docs he flagged.

Resolves #575.
