### PR TITLE
feat(kvcache): expose tuning knobs in OPEN/whatif + plumb dead flags through to kv-cache.py

### DIFF
--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -301,6 +301,9 @@ class KVCacheBenchmark(Benchmark):
         if not getattr(self.args, 'what_if', False):
             self._probe_results_dir_shared(hosts)
 
+        # Global tuning knobs apply to all options identically; compute once.
+        global_kv_args = self._build_global_kvcache_args(is_closed)
+
         option_results = {}
         for option in [1, 2, 3]:
             option_kv_args = self._build_option_kvcache_args(option, is_closed)
@@ -312,6 +315,9 @@ class KVCacheBenchmark(Benchmark):
                 )
                 option_trial_dir.mkdir(parents=True, exist_ok=True)
 
+                # The wrapper's parse_known_args forwards anything after its own
+                # flags to kv-cache.py verbatim; both option_kv_args and
+                # global_kv_args land on kv-cache.py's argparse.
                 wrapper_cmd = (
                     f"{mpi_prefix} {sys.executable} {wrapper_path}"
                     f" --rank-output-base {option_trial_dir}"
@@ -319,6 +325,7 @@ class KVCacheBenchmark(Benchmark):
                     f" --seed-base {seed}"
                     f" --config {config_path}"
                     f" {' '.join(option_kv_args)}"
+                    f"{' ' + ' '.join(global_kv_args) if global_kv_args else ''}"
                 )
 
                 self.logger.status(f"Running option {option} trial {trial + 1}/{trials}...")
@@ -405,9 +412,9 @@ class KVCacheBenchmark(Benchmark):
         user input can reach kv-cache.py through this path because the CLOSED
         CLI does not expose the corresponding flags.
 
-        OPEN: user-set flags supersede WORKLOAD_PARAMS[option] one key at a
-        time. max-concurrent-allocs is not exposed by the OPEN CLI, so it
-        always comes from WORKLOAD_PARAMS.
+        OPEN/whatif: user-set flags supersede WORKLOAD_PARAMS[option] one key
+        at a time; unset keys fall back to the per-option WORKLOAD_PARAMS
+        default.
         """
         defaults = WORKLOAD_PARAMS[option]
         if is_closed:
@@ -435,7 +442,11 @@ class KVCacheBenchmark(Benchmark):
                     if getattr(self.args, 'cpu_mem_gb', None) is not None
                     else defaults['cpu-mem-gb']
                 ),
-                'max-concurrent-allocs': defaults['max-concurrent-allocs'],
+                'max-concurrent-allocs': (
+                    getattr(self.args, 'max_concurrent_allocs', None)
+                    if getattr(self.args, 'max_concurrent_allocs', None) is not None
+                    else defaults['max-concurrent-allocs']
+                ),
                 'generation-mode': (
                     getattr(self.args, 'generation_mode', None) or defaults['generation-mode']
                 ),
@@ -443,6 +454,45 @@ class KVCacheBenchmark(Benchmark):
         out = []
         for key, value in params.items():
             out.extend([f'--{key}', str(value)])
+        return out
+
+    def _build_global_kvcache_args(self, is_closed: bool) -> List[str]:
+        """Return the global (non-per-option) kv-cache.py CLI args.
+
+        These are tuning knobs that apply across all three options. They are
+        forwarded only in OPEN/whatif; CLOSED returns an empty list to preserve
+        the MLPerf-mandated invocation shape (per-option WORKLOAD_PARAMS only).
+
+        For `store_true` flags we emit the flag only when truthy. For value
+        flags we emit only when the user supplied something — that way the
+        kv-cache.py default applies if the user did not touch the knob, and
+        any value the user set propagates faithfully.
+        """
+        if is_closed:
+            return []
+
+        out: List[str] = []
+        # store_true flags — forward iff True.
+        for attr, flag in (
+            ('disable_multi_turn', '--disable-multi-turn'),
+            ('disable_prefix_caching', '--disable-prefix-caching'),
+            ('enable_rag', '--enable-rag'),
+            ('enable_autoscaling', '--enable-autoscaling'),
+            ('enable_latency_tracing', '--enable-latency-tracing'),
+        ):
+            if getattr(self.args, attr, False):
+                out.append(flag)
+
+        # Value flags — forward iff the user supplied a non-None value.
+        for attr, flag in (
+            ('rag_num_docs', '--rag-num-docs'),
+            ('autoscaler_mode', '--autoscaler-mode'),
+            ('performance_profile', '--performance-profile'),
+        ):
+            value = getattr(self.args, attr, None)
+            if value is not None:
+                out.extend([flag, str(value)])
+
         return out
 
     def _resolve_rank_layout(self, hosts):

--- a/mlpstorage_py/cli/kvcache_args.py
+++ b/mlpstorage_py/cli/kvcache_args.py
@@ -63,7 +63,19 @@ KVCACHE_HELP_MESSAGES = {
     'enable_autoscaling': "Enable autoscaling simulation for user load.",
     'autoscaler_mode': (
         "Autoscaler mode: 'qos' (quality of service based) or "
-        "'predictive' (load prediction based)."
+        "'capacity' (storage capacity based)."
+    ),
+    'max_concurrent_allocs': (
+        "Cap on concurrent in-flight cache allocations (semaphore size). "
+        "Bounds peak RAM: max_allocs * avg_context_tokens * bytes_per_token. "
+        "0 disables the cap. OPEN/whatif submissions only — per-option "
+        "values are MLPerf-mandated in CLOSED (16/16/4 for options 1/2/3)."
+    ),
+    'enable_latency_tracing': (
+        "Enable bpftrace block-layer device latency tracing during the run. "
+        "Requires sudo and bpftrace on every client host. Adds telemetry to "
+        "stdout/JSON/XLSX output without changing the benchmark result. "
+        "OPEN/whatif submissions only — disabled in CLOSED."
     ),
     'seed': (
         "Base random seed (default 42). Effective seed per rank = base + rank. "
@@ -180,7 +192,10 @@ def _add_kvcache_cache_arguments(parser, mode):
         help=KVCACHE_HELP_MESSAGES['cache_dir']
     )
     if mode == "closed":
-        # Set defaults for all open-gated attrs so namespace attrs always exist
+        # Set defaults for all open-gated attrs so namespace attrs always exist.
+        # The benchmark wrapper does NOT forward these to kv-cache.py in CLOSED
+        # (see KVCacheBenchmark._build_global_kvcache_args) — the values here
+        # only make hasattr(self.args, X) checks succeed inside the benchmark.
         cache_group.set_defaults(
             gpu_mem_gb=16.0,
             cpu_mem_gb=32.0,
@@ -199,6 +214,8 @@ def _add_kvcache_cache_arguments(parser, mode):
             inter_option_delay=20,
             allow_invalid_params=False,
             params='',
+            max_concurrent_allocs=None,
+            enable_latency_tracing=False,
         )
     else:
         # `--loops` is registered only on the run subparser (via
@@ -272,6 +289,12 @@ def _add_kvcache_open_args(parser):
         '--allow-invalid-params', '-aip',
         action='store_true',
         help="Allow parameters that would otherwise be flagged as invalid"
+    )
+    run_group.add_argument(
+        '--max-concurrent-allocs',
+        type=int,
+        default=None,
+        help=KVCACHE_HELP_MESSAGES['max_concurrent_allocs']
     )
 
 
@@ -369,9 +392,18 @@ def _add_kvcache_optional_features(parser, mode):
         )
         features_group.add_argument(
             '--autoscaler-mode',
-            choices=['qos', 'predictive'],
+            # Must mirror kv_cache.cli's --autoscaler-mode choices; the prior
+            # 'predictive' value did not exist in kv-cache.py and would have
+            # been rejected by its argparse if these flags were ever forwarded
+            # (which they were not — see the dead-flag fix in this same PR).
+            choices=['qos', 'capacity'],
             default='qos',
             help=KVCACHE_HELP_MESSAGES['autoscaler_mode']
+        )
+        features_group.add_argument(
+            '--enable-latency-tracing',
+            action='store_true',
+            help=KVCACHE_HELP_MESSAGES['enable_latency_tracing']
         )
 
 

--- a/mlpstorage_py/run_summary.py
+++ b/mlpstorage_py/run_summary.py
@@ -390,6 +390,7 @@ _KVCACHE_FIELDS_RUN: List[Tuple[str, str]] = [
     ("duration",                  'duration'),
     ("generation_mode",           'generation_mode'),
     ("performance_profile",       'performance_profile'),
+    ("max_concurrent_allocs",     'max_concurrent_allocs'),
     ("loops",                     'loops'),
 ]
 
@@ -400,6 +401,7 @@ _KVCACHE_FIELDS_FEATURES: List[Tuple[str, str]] = [
     ("rag_num_docs",              'rag_num_docs'),
     ("enable_autoscaling",        'enable_autoscaling'),
     ("autoscaler_mode",           'autoscaler_mode'),
+    ("enable_latency_tracing",    'enable_latency_tracing'),
 ]
 
 _KVCACHE_FIELDS_DISTRIBUTED: List[Tuple[str, str]] = [

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -1293,16 +1293,187 @@ class TestBuildOptionKvcacheArgs:
         assert out[out.index('--num-users') + 1] == str(WORKLOAD_PARAMS[2]['num-users'])
         assert out[out.index('--cpu-mem-gb') + 1] == str(WORKLOAD_PARAMS[2]['cpu-mem-gb'])
 
-    def test_max_concurrent_allocs_always_from_workload_params(self, tmp_path):
-        """max-concurrent-allocs is not user-exposed even in OPEN — it
-        always tracks the per-option WORKLOAD_PARAMS value."""
+    def test_max_concurrent_allocs_falls_back_to_workload_params_when_unset(self, tmp_path):
+        """When the user has not set --max-concurrent-allocs (args attr is
+        absent or None), both CLOSED and OPEN emit the per-option
+        WORKLOAD_PARAMS value."""
         from mlpstorage_py.benchmarks.kvcache import WORKLOAD_PARAMS
         bm = _make_run_benchmark(tmp_path)
+        # Ensure the attr is absent so the OPEN getattr-or-default lands on the
+        # WORKLOAD_PARAMS fallback path (mirrors a parser namespace where the
+        # user did not pass --max-concurrent-allocs).
+        if hasattr(bm.args, 'max_concurrent_allocs'):
+            delattr(bm.args, 'max_concurrent_allocs')
         out_open = bm._build_option_kvcache_args(3, is_closed=False)
         out_closed = bm._build_option_kvcache_args(3, is_closed=True)
         expected = str(WORKLOAD_PARAMS[3]['max-concurrent-allocs'])
         assert out_open[out_open.index('--max-concurrent-allocs') + 1] == expected
         assert out_closed[out_closed.index('--max-concurrent-allocs') + 1] == expected
+
+    def test_max_concurrent_allocs_user_value_overrides_in_open(self, tmp_path):
+        """In OPEN, a user-set --max-concurrent-allocs supersedes the
+        per-option WORKLOAD_PARAMS default — same precedence as
+        --num-users / --gpu-mem-gb / etc."""
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.max_concurrent_allocs = 8
+        out = bm._build_option_kvcache_args(3, is_closed=False)
+        # Option 3's WORKLOAD_PARAMS default is 4; user's 8 must win.
+        assert out[out.index('--max-concurrent-allocs') + 1] == '8'
+
+    def test_max_concurrent_allocs_zero_overrides_in_open(self, tmp_path):
+        """0 is a legal kv-cache.py value meaning 'no semaphore cap' — must
+        flow through, not be treated as falsy."""
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.max_concurrent_allocs = 0
+        out = bm._build_option_kvcache_args(1, is_closed=False)
+        # Option 1's WORKLOAD_PARAMS default is 16; user's 0 must win.
+        assert out[out.index('--max-concurrent-allocs') + 1] == '0'
+
+    def test_max_concurrent_allocs_ignored_in_closed_even_if_set(self, tmp_path):
+        """In CLOSED the user cannot override max-concurrent-allocs — the
+        per-option MLPerf-mandated value is emitted verbatim regardless of
+        what's on args. (Defense in depth: the CLI also doesn't register
+        --max-concurrent-allocs in CLOSED mode.)"""
+        from mlpstorage_py.benchmarks.kvcache import WORKLOAD_PARAMS
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.max_concurrent_allocs = 9999  # absurd, must be ignored
+        out = bm._build_option_kvcache_args(1, is_closed=True)
+        assert out[out.index('--max-concurrent-allocs') + 1] == str(
+            WORKLOAD_PARAMS[1]['max-concurrent-allocs']
+        )
+
+
+class TestBuildGlobalKvcacheArgs:
+    """Global (non-per-option) tuning knobs forwarded by
+    _build_global_kvcache_args.
+
+    CLOSED must return an empty list — the MLPerf-mandated invocation only
+    carries WORKLOAD_PARAMS keys and no optional features (verified against
+    the v3 KV Cache Proposal reference command in
+    kv_cache_benchmark/docs/MLperf_v3_KV_cache_proposal.md).
+
+    OPEN/whatif forward each user-supplied knob exactly once. store_true
+    flags are emitted iff truthy; value flags are emitted iff non-None.
+    """
+
+    def test_closed_returns_empty_list(self, tmp_path):
+        bm = _make_run_benchmark(tmp_path)
+        # Even if the args namespace carries values (the CLOSED set_defaults
+        # block pre-populates these), CLOSED must not forward them.
+        bm.args.enable_rag = True
+        bm.args.enable_autoscaling = True
+        bm.args.enable_latency_tracing = True
+        bm.args.autoscaler_mode = 'qos'
+        bm.args.rag_num_docs = 10
+        bm.args.performance_profile = 'throughput'
+        out = bm._build_global_kvcache_args(is_closed=True)
+        assert out == [], (
+            "CLOSED must forward zero global flags — MLPerf-mandated "
+            f"invocation only carries WORKLOAD_PARAMS. Got: {out!r}"
+        )
+
+    def test_open_with_no_user_flags_returns_empty(self, tmp_path):
+        """No store_true flag set, no value flag set → no forwarding.
+        kv-cache.py's own defaults apply for every untouched knob."""
+        bm = _make_run_benchmark(tmp_path)
+        # Strip every attribute the global builder consults so the namespace
+        # mirrors "user did not touch any optional-feature flag."
+        for attr in (
+            'disable_multi_turn', 'disable_prefix_caching', 'enable_rag',
+            'enable_autoscaling', 'enable_latency_tracing',
+            'rag_num_docs', 'autoscaler_mode', 'performance_profile',
+        ):
+            if hasattr(bm.args, attr):
+                delattr(bm.args, attr)
+        assert bm._build_global_kvcache_args(is_closed=False) == []
+
+    @pytest.mark.parametrize('attr,flag', [
+        ('disable_multi_turn', '--disable-multi-turn'),
+        ('disable_prefix_caching', '--disable-prefix-caching'),
+        ('enable_rag', '--enable-rag'),
+        ('enable_autoscaling', '--enable-autoscaling'),
+        ('enable_latency_tracing', '--enable-latency-tracing'),
+    ])
+    def test_open_store_true_flag_emits_flag(self, tmp_path, attr, flag):
+        """Each store_true flag must appear exactly once in the global argv
+        when truthy — including the two new flags (#594 sibling fix) and the
+        previously-dead ones (#498/#500 follow-up)."""
+        bm = _make_run_benchmark(tmp_path)
+        # Strip non-target attrs so the result is unambiguously about `attr`.
+        for other in (
+            'disable_multi_turn', 'disable_prefix_caching', 'enable_rag',
+            'enable_autoscaling', 'enable_latency_tracing',
+            'rag_num_docs', 'autoscaler_mode', 'performance_profile',
+        ):
+            if other != attr and hasattr(bm.args, other):
+                delattr(bm.args, other)
+        setattr(bm.args, attr, True)
+        out = bm._build_global_kvcache_args(is_closed=False)
+        assert out.count(flag) == 1, (
+            f"expected {flag!r} exactly once; got {out!r}"
+        )
+
+    @pytest.mark.parametrize('attr,flag', [
+        ('disable_multi_turn', '--disable-multi-turn'),
+        ('disable_prefix_caching', '--disable-prefix-caching'),
+        ('enable_rag', '--enable-rag'),
+        ('enable_autoscaling', '--enable-autoscaling'),
+        ('enable_latency_tracing', '--enable-latency-tracing'),
+    ])
+    def test_open_store_true_flag_false_does_not_emit(self, tmp_path, attr, flag):
+        """A store_true flag set to False must NOT appear — that's what
+        keeps kv-cache.py's own defaults intact for unset knobs."""
+        bm = _make_run_benchmark(tmp_path)
+        for other in (
+            'rag_num_docs', 'autoscaler_mode', 'performance_profile',
+        ):
+            if hasattr(bm.args, other):
+                delattr(bm.args, other)
+        for x in (
+            'disable_multi_turn', 'disable_prefix_caching', 'enable_rag',
+            'enable_autoscaling', 'enable_latency_tracing',
+        ):
+            setattr(bm.args, x, False)
+        out = bm._build_global_kvcache_args(is_closed=False)
+        assert flag not in out
+
+    @pytest.mark.parametrize('attr,flag,value', [
+        ('rag_num_docs', '--rag-num-docs', 25),
+        ('autoscaler_mode', '--autoscaler-mode', 'capacity'),
+        ('performance_profile', '--performance-profile', 'throughput'),
+    ])
+    def test_open_value_flag_emits_value(self, tmp_path, attr, flag, value):
+        bm = _make_run_benchmark(tmp_path)
+        for other in (
+            'disable_multi_turn', 'disable_prefix_caching', 'enable_rag',
+            'enable_autoscaling', 'enable_latency_tracing',
+            'rag_num_docs', 'autoscaler_mode', 'performance_profile',
+        ):
+            if other != attr and hasattr(bm.args, other):
+                delattr(bm.args, other)
+        setattr(bm.args, attr, value)
+        out = bm._build_global_kvcache_args(is_closed=False)
+        idx = out.index(flag)
+        assert out[idx + 1] == str(value)
+
+    @pytest.mark.parametrize('attr,flag', [
+        ('rag_num_docs', '--rag-num-docs'),
+        ('autoscaler_mode', '--autoscaler-mode'),
+        ('performance_profile', '--performance-profile'),
+    ])
+    def test_open_value_flag_none_does_not_emit(self, tmp_path, attr, flag):
+        """An explicitly-None value flag must not be forwarded."""
+        bm = _make_run_benchmark(tmp_path)
+        for other in (
+            'disable_multi_turn', 'disable_prefix_caching', 'enable_rag',
+            'enable_autoscaling', 'enable_latency_tracing',
+            'rag_num_docs', 'autoscaler_mode', 'performance_profile',
+        ):
+            if hasattr(bm.args, other):
+                delattr(bm.args, other)
+        setattr(bm.args, attr, None)
+        out = bm._build_global_kvcache_args(is_closed=False)
+        assert flag not in out
 
 
 class TestWrapperCommandForwardsPerOptionArgs:
@@ -1419,6 +1590,126 @@ class TestWrapperCommandForwardsPerOptionArgs:
         # And the wrapper-adjacent default must NOT also be present.
         assert 'kv_cache_benchmark/config.yaml' not in cmd0, \
             f"Default config path leaked into cmd alongside user override: {cmd0}"
+
+
+class TestWrapperCommandForwardsGlobalArgs:
+    """End-to-end checks that the wrapper command built by _execute_run
+    forwards the global tuning knobs (the new --enable-latency-tracing and
+    the previously-dead --enable-rag / --disable-multi-turn / etc.) in
+    OPEN/whatif but never in CLOSED."""
+
+    def _capture_first_cmd(self, bm):
+        agg = {
+            'option': 1, 'aggregated_read_bandwidth_gbps': 0.0,
+            'aggregated_write_bandwidth_gbps': 0.0,
+            'aggregated_avg_throughput_tokens_per_sec': 0.0,
+            'aggregated_storage_throughput_tokens_per_sec': 0.0,
+            'aggregated_p95_latency_ms': 0.0,
+            'rank_count': 1, 'trial_count': 1,
+            'partial_failure': False, 'missing_files': [], 'cpu_tier_ranks': [],
+        }
+        executed = []
+        def fake_execute(cmd, **kwargs):
+            executed.append(cmd)
+            return ('', '', 0)
+        with patch.object(bm, '_execute_command', side_effect=fake_execute), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results', return_value=agg), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'):
+            bm._execute_run()
+        return executed[0]
+
+    def test_open_enable_latency_tracing_reaches_wrapper(self, tmp_path):
+        """The end-to-end smoke test for the latency-tracing fix: setting
+        --enable-latency-tracing in OPEN must put `--enable-latency-tracing`
+        into the wrapper argv. Pre-fix this flag was unreachable from
+        mlpstorage at any mode."""
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.mode = 'open'
+        bm.args.trials = 1
+        bm.args.inter_option_delay = 0
+        bm.args.enable_latency_tracing = True
+        cmd0 = self._capture_first_cmd(bm)
+        assert '--enable-latency-tracing' in cmd0, (
+            f"--enable-latency-tracing missing from wrapper argv: {cmd0!r}"
+        )
+
+    def test_open_user_max_concurrent_allocs_reaches_wrapper(self, tmp_path):
+        """Setting --max-concurrent-allocs in OPEN must override the
+        per-option WORKLOAD_PARAMS default in the wrapper argv."""
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.mode = 'open'
+        bm.args.trials = 1
+        bm.args.inter_option_delay = 0
+        bm.args.max_concurrent_allocs = 32
+        cmd0 = self._capture_first_cmd(bm)
+        # Option 1's default is 16; the user's 32 must appear instead.
+        assert '--max-concurrent-allocs 32' in cmd0, cmd0
+        assert '--max-concurrent-allocs 16' not in cmd0, cmd0
+
+    def test_open_dead_optional_features_reach_wrapper(self, tmp_path):
+        """The previously-dead optional-feature flags (--enable-rag,
+        --disable-multi-turn, --enable-autoscaling, --rag-num-docs,
+        --autoscaler-mode, --performance-profile) must now propagate to
+        the wrapper argv in OPEN."""
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.mode = 'open'
+        bm.args.trials = 1
+        bm.args.inter_option_delay = 0
+        bm.args.disable_multi_turn = True
+        bm.args.disable_prefix_caching = True
+        bm.args.enable_rag = True
+        bm.args.enable_autoscaling = True
+        bm.args.rag_num_docs = 25
+        bm.args.autoscaler_mode = 'capacity'
+        bm.args.performance_profile = 'throughput'
+        cmd0 = self._capture_first_cmd(bm)
+        assert '--disable-multi-turn' in cmd0
+        assert '--disable-prefix-caching' in cmd0
+        assert '--enable-rag' in cmd0
+        assert '--enable-autoscaling' in cmd0
+        assert '--rag-num-docs 25' in cmd0
+        assert '--autoscaler-mode capacity' in cmd0
+        assert '--performance-profile throughput' in cmd0
+
+    def test_closed_does_not_forward_global_args_even_if_namespace_carries_them(
+        self, tmp_path,
+    ):
+        """The CLOSED set_defaults block in kvcache_args.py pre-populates
+        enable_rag=True / enable_autoscaling=True on the namespace, but the
+        CLOSED branch of _build_global_kvcache_args must drop them — the
+        MLPerf-mandated invocation only carries WORKLOAD_PARAMS keys.
+        Behaviour pre-fix: the dead flags were never forwarded; this test
+        locks that property under the new plumb-through code path."""
+        bm = _make_run_benchmark(tmp_path)
+        bm.args.mode = 'closed'
+        # The CLOSED set_defaults block sets these to True / non-None.
+        bm.args.enable_rag = True
+        bm.args.enable_autoscaling = True
+        bm.args.enable_latency_tracing = True
+        bm.args.disable_multi_turn = True
+        bm.args.autoscaler_mode = 'qos'
+        bm.args.rag_num_docs = 10
+        bm.args.performance_profile = 'throughput'
+        bm.args.max_concurrent_allocs = 999
+        cmd0 = self._capture_first_cmd(bm)
+        # None of the global / latency-tracing / dead-flag tokens may appear.
+        for token in (
+            '--enable-rag', '--enable-autoscaling', '--enable-latency-tracing',
+            '--disable-multi-turn', '--disable-prefix-caching',
+            '--autoscaler-mode', '--rag-num-docs', '--performance-profile',
+        ):
+            assert token not in cmd0, (
+                f"CLOSED forwarded {token!r} despite namespace value being "
+                f"pre-populated: {cmd0!r}"
+            )
+        # max-concurrent-allocs DOES appear (it's a WORKLOAD_PARAMS key) but
+        # must use the per-option mandated value, not the namespace override.
+        assert '--max-concurrent-allocs 16' in cmd0, (
+            f"CLOSED option-1 must emit MLPerf-mandated 16, not user 999: "
+            f"{cmd0!r}"
+        )
 
 
 class TestResolveRankLayout:

--- a/tests/unit/test_cli_kvcache.py
+++ b/tests/unit/test_cli_kvcache.py
@@ -313,8 +313,11 @@ class TestKVCacheOptionalFeatures:
         assert args.enable_autoscaling is True
 
     def test_autoscaler_mode_argument(self, parser):
-        """Run should accept --autoscaler-mode argument."""
-        for mode in ['qos', 'predictive']:
+        """Run should accept --autoscaler-mode argument. Choices must match
+        kv_cache.cli upstream (qos | capacity) — the prior 'predictive' value
+        did not exist downstream and would have been rejected by kv-cache.py
+        once the flag was actually plumbed through the wrapper."""
+        for mode in ['qos', 'capacity']:
             args = parser.parse_args(self.BASE_RUN_ARGS + ['--autoscaler-mode', mode])
             assert args.autoscaler_mode == mode
 
@@ -451,3 +454,156 @@ class TestKVCacheClosedModePerformanceProfile:
         with pytest.raises(SystemExit):
             closed_parser.parse_args(['run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
                                       '--performance-profile', 'latency'])
+
+
+class TestKVCacheMaxConcurrentAllocs:
+    """OPEN/whatif expose --max-concurrent-allocs as an int tuning knob;
+    CLOSED rejects it (per-option value is MLPerf-mandated from
+    WORKLOAD_PARAMS)."""
+
+    @pytest.fixture
+    def open_parser(self):
+        parser = argparse.ArgumentParser()
+        add_kvcache_arguments(parser, 'open')
+        return parser
+
+    @pytest.fixture
+    def whatif_parser(self):
+        parser = argparse.ArgumentParser()
+        add_kvcache_arguments(parser, 'whatif')
+        return parser
+
+    @pytest.fixture
+    def closed_parser(self):
+        parser = argparse.ArgumentParser()
+        add_kvcache_arguments(parser, 'closed')
+        return parser
+
+    def test_open_accepts_max_concurrent_allocs(self, open_parser):
+        args = open_parser.parse_args([
+            'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+            '--max-concurrent-allocs', '8',
+        ])
+        assert args.max_concurrent_allocs == 8
+
+    def test_open_default_is_none_so_workload_params_fallback_fires(self, open_parser):
+        """When the user does not supply --max-concurrent-allocs, the parser
+        default is None so the benchmark-side getattr-or-default lands on
+        the per-option WORKLOAD_PARAMS value."""
+        args = open_parser.parse_args([
+            'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+        ])
+        assert args.max_concurrent_allocs is None
+
+    def test_whatif_accepts_max_concurrent_allocs(self, whatif_parser):
+        args = whatif_parser.parse_args([
+            'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+            '--max-concurrent-allocs', '4',
+        ])
+        assert args.max_concurrent_allocs == 4
+
+    def test_closed_rejects_max_concurrent_allocs_flag(self, closed_parser):
+        with pytest.raises(SystemExit):
+            closed_parser.parse_args([
+                'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+                '--max-concurrent-allocs', '8',
+            ])
+
+    def test_closed_default_attr_is_none(self, closed_parser):
+        """CLOSED uses set_defaults so the namespace carries the attr even
+        though the flag is unregistered. The benchmark's CLOSED branch in
+        _build_option_kvcache_args reads only from WORKLOAD_PARAMS and
+        ignores this value, but the attr must exist so the OPEN getattr
+        check on the same namespace does not raise."""
+        args = closed_parser.parse_args([
+            'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+        ])
+        assert args.max_concurrent_allocs is None
+
+
+class TestKVCacheEnableLatencyTracing:
+    """OPEN/whatif expose --enable-latency-tracing (bpftrace device
+    latency); CLOSED rejects it (observability flag, not benchmark-defining,
+    but bpftrace requires sudo + a tracing-capable kernel and the CLOSED
+    invocation must be reproducible by anyone)."""
+
+    @pytest.fixture
+    def open_parser(self):
+        parser = argparse.ArgumentParser()
+        add_kvcache_arguments(parser, 'open')
+        return parser
+
+    @pytest.fixture
+    def whatif_parser(self):
+        parser = argparse.ArgumentParser()
+        add_kvcache_arguments(parser, 'whatif')
+        return parser
+
+    @pytest.fixture
+    def closed_parser(self):
+        parser = argparse.ArgumentParser()
+        add_kvcache_arguments(parser, 'closed')
+        return parser
+
+    def test_open_accepts_enable_latency_tracing(self, open_parser):
+        args = open_parser.parse_args([
+            'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+            '--enable-latency-tracing',
+        ])
+        assert args.enable_latency_tracing is True
+
+    def test_open_default_is_false(self, open_parser):
+        args = open_parser.parse_args([
+            'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+        ])
+        assert args.enable_latency_tracing is False
+
+    def test_whatif_accepts_enable_latency_tracing(self, whatif_parser):
+        args = whatif_parser.parse_args([
+            'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+            '--enable-latency-tracing',
+        ])
+        assert args.enable_latency_tracing is True
+
+    def test_closed_rejects_enable_latency_tracing_flag(self, closed_parser):
+        with pytest.raises(SystemExit):
+            closed_parser.parse_args([
+                'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+                '--enable-latency-tracing',
+            ])
+
+    def test_closed_default_attr_is_false(self, closed_parser):
+        args = closed_parser.parse_args([
+            'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+        ])
+        assert args.enable_latency_tracing is False
+
+
+class TestKVCacheAutoscalerModeChoices:
+    """The pre-fix code declared choices=['qos', 'predictive'] in mlpstorage
+    but kv-cache.py accepts choices=['qos', 'capacity']. Plumbing the flag
+    through to kv-cache.py would have caused 'predictive' to be rejected
+    downstream. The mlpstorage choices were corrected to match upstream."""
+
+    @pytest.fixture
+    def open_parser(self):
+        parser = argparse.ArgumentParser()
+        add_kvcache_arguments(parser, 'open')
+        return parser
+
+    def test_open_accepts_capacity(self, open_parser):
+        """'capacity' is the second valid kv-cache.py value — must be
+        accepted by mlpstorage."""
+        args = open_parser.parse_args([
+            'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+            '--autoscaler-mode', 'capacity',
+        ])
+        assert args.autoscaler_mode == 'capacity'
+
+    def test_open_rejects_predictive(self, open_parser):
+        """'predictive' was the stale value that did not exist downstream."""
+        with pytest.raises(SystemExit):
+            open_parser.parse_args([
+                'run', '--results-dir', '/tmp', '--systemname', 'sys-v1',
+                '--autoscaler-mode', 'predictive',
+            ])

--- a/tests/unit/test_run_summary.py
+++ b/tests/unit/test_run_summary.py
@@ -520,6 +520,67 @@ class TestKVCacheSection:
         output = _joined_status_calls(mock_logger)
         assert 'target_usage_ratio: 0.42' in output
 
+    @patch('mlpstorage_py.run_summary.logger')
+    def test_max_concurrent_allocs_row_present(self, mock_logger):
+        """max_concurrent_allocs (newly user-settable in OPEN/whatif) must
+        appear in the KVCache section so users see what value will reach
+        kv-cache.py."""
+        from mlpstorage_py.run_summary import print_run_summary
+
+        args = _make_args(benchmark='kvcache', command='run',
+                          data_access_protocol='file',
+                          max_concurrent_allocs=8)
+        print_run_summary(args)
+
+        output = _joined_status_calls(mock_logger)
+        assert 'max_concurrent_allocs:' in output
+        assert ' 8' in output
+
+    @patch('mlpstorage_py.run_summary.logger')
+    def test_max_concurrent_allocs_row_handles_unset(self, mock_logger):
+        """When the user does not pass --max-concurrent-allocs, the namespace
+        attribute is None and the summary must show '[not set]' — the
+        per-option WORKLOAD_PARAMS fallback in kvcache.py kicks in at run
+        time, but the summary fairly shows that the user did not pin it."""
+        from mlpstorage_py.run_summary import print_run_summary
+
+        args = _make_args(benchmark='kvcache', command='run',
+                          data_access_protocol='file',
+                          max_concurrent_allocs=None)
+        print_run_summary(args)
+
+        output = _joined_status_calls(mock_logger)
+        assert 'max_concurrent_allocs:' in output
+        assert '[not set]' in output
+
+    @patch('mlpstorage_py.run_summary.logger')
+    def test_enable_latency_tracing_row_present(self, mock_logger):
+        """--enable-latency-tracing must surface in the Optional Features
+        block so users can confirm their bpftrace toggle reached the run."""
+        from mlpstorage_py.run_summary import print_run_summary
+
+        args = _make_args(benchmark='kvcache', command='run',
+                          data_access_protocol='file',
+                          enable_latency_tracing=True)
+        print_run_summary(args)
+
+        output = _joined_status_calls(mock_logger)
+        assert 'enable_latency_tracing:' in output
+        assert 'True' in output
+
+    @patch('mlpstorage_py.run_summary.logger')
+    def test_enable_latency_tracing_row_handles_false(self, mock_logger):
+        from mlpstorage_py.run_summary import print_run_summary
+
+        args = _make_args(benchmark='kvcache', command='run',
+                          data_access_protocol='file',
+                          enable_latency_tracing=False)
+        print_run_summary(args)
+
+        output = _joined_status_calls(mock_logger)
+        assert 'enable_latency_tracing:' in output
+        assert 'False' in output
+
 
 class TestTier1AcceleratorFiltering:
     """Training-only Tier 1 fields are suppressed for vectordb/kvcache."""


### PR DESCRIPTION
## Summary

Two new tuning knobs become available in OPEN/whatif runs of the kvcache benchmark, and the six previously-dead optional-feature flags now actually reach the kv-cache.py subprocess. CLOSED behaviour is unchanged — the MLPerf-mandated invocation still carries only the WORKLOAD_PARAMS keys (no optional features).

## What changes for users

### Newly exposed in OPEN/whatif

| Flag | Behaviour |
|---|---|
| `--max-concurrent-allocs` | Caps concurrent in-flight cache allocations (kv-cache.py semaphore). Per-option WORKLOAD_PARAMS default (16/16/4 for options 1/2/3) still applies when unset; user values supersede one option at a time. Locked to the mandated defaults in CLOSED. |
| `--enable-latency-tracing` | Enables `bpftrace` block-layer device latency tracing for the run. Adds telemetry to stdout/JSON/XLSX without changing the canonical benchmark result. OPEN/whatif only — CLOSED's invocation must be reproducible by anyone without sudo + bpftrace. |

### Previously dead flags that now actually reach kv-cache.py

These were registered on the mlpstorage CLI in OPEN/whatif but the wrapper command only assembled `WORKLOAD_PARAMS` keys via `_build_option_kvcache_args`; the optional features sat on the args namespace and never reached the subprocess:

- `--disable-multi-turn`
- `--disable-prefix-caching`
- `--enable-rag`
- `--rag-num-docs`
- `--enable-autoscaling`
- `--autoscaler-mode`
- `--performance-profile`

A new helper `_build_global_kvcache_args` emits them in OPEN/whatif:

- store_true flags: emitted only when truthy.
- value flags: emitted only when non-None, so kv-cache.py's own defaults apply for any knob the user did not touch.

In CLOSED the helper returns `[]` — the MLPerf-mandated invocation shape (per-option `WORKLOAD_PARAMS` only) is preserved byte-for-byte.

## Adjacent fix

`--autoscaler-mode`'s mlpstorage-side choices were `['qos', 'predictive']` but `kv-cache.py` accepts `['qos', 'capacity']`. `predictive` would have been rejected by `kv-cache.py`'s argparse once the flag was actually forwarded; choices now mirror upstream.

## Run-configuration summary

Both new flags now appear in the `--- KVCache ---` block printed at run start:

- `max_concurrent_allocs:` row in Run Configuration (shows `[not set]` if the user did not pin it; the per-option WORKLOAD_PARAMS fallback fires at run time).
- `enable_latency_tracing:` row in Optional Features.

Users can confirm the value that will reach `kv-cache.py` before the run begins.

## End-to-end plumbing verification

Each of the 9 affected flags traced through every layer:

| Flag | mlpstorage CLI | `_build_global_kvcache_args` | wrapper argv | kv-cache.py argparse | kv-cache.py consumption |
|---|:-:|:-:|:-:|:-:|:-:|
| `--max-concurrent-allocs` | new | (via `_build_option_kvcache_args` — WORKLOAD_PARAMS key) | yes | cli.py:362 | benchmark via cli.py:471 |
| `--enable-latency-tracing` | new | yes | yes | cli.py:396 | benchmark via cli.py:483 |
| `--disable-multi-turn` | existing | now wired | yes | cli.py:337 | cli.py:459 |
| `--disable-prefix-caching` | existing | now wired | yes | cli.py:339 | cli.py:460 |
| `--enable-rag` | existing | now wired | yes | cli.py:341 | cli.py:461 |
| `--rag-num-docs` | existing | now wired | yes | cli.py:343 | cli.py:462 |
| `--enable-autoscaling` | existing | now wired | yes | cli.py:344 | cli.py:456 |
| `--autoscaler-mode` | choices fixed | now wired | yes | cli.py:346 | cli.py:457 |
| `--performance-profile` | existing | now wired | yes | cli.py:335 | cli.py:465 |

`mlperf_wrapper.py` uses `parse_known_args() + *forwarded`, so any flag the mlpstorage wrapper appends to the argv reaches `kv-cache.py` verbatim.

## Tests

37 new + 1 updated:

- `tests/unit/test_cli_kvcache.py`:
  - `TestKVCacheMaxConcurrentAllocs` (5) — OPEN/whatif accept the flag, CLOSED rejects it, defaults are sensible
  - `TestKVCacheEnableLatencyTracing` (5) — same shape for the new bpftrace toggle
  - `TestKVCacheAutoscalerModeChoices` (2) — `capacity` accepted, `predictive` rejected
  - updated `test_autoscaler_mode_argument` choices to match upstream
- `tests/unit/test_benchmarks_kvcache.py`:
  - existing `test_max_concurrent_allocs_always_from_workload_params` renamed and supplemented with 3 new tests: OPEN override, `0`-value override (kv-cache.py honours 0 as "no cap"), CLOSED ignores override
  - `TestBuildGlobalKvcacheArgs` — 16 parametrized tests pinning store_true / value-flag emission rules in both modes
  - `TestWrapperCommandForwardsGlobalArgs` (4) — end-to-end smoke that the wrapper argv carries the flags in OPEN, omits them in CLOSED
- `tests/unit/test_run_summary.py` (4) — Run Configuration shows the new rows whether the user set them or not

## Test plan

- [x] `tests/` — 2476 passed, 13 deselected
- [x] `mlpstorage_py/tests/` — 780 passed, 1 xfailed (pre-existing)
- [x] `kv_cache_benchmark/tests/` — 238 passed, 2 deselected
- [x] `vdb_benchmark/tests/tests/` — 144 passed
- [x] Total: 3638 passed
- [x] User confirmed `./mlpstorage whatif kvcache run --enable-latency-tracing --enable-rag ...` now surfaces the new flags in the Run Configuration block before the run starts
- [ ] Reviewer to verify the CLOSED-mode invocation shape is unchanged (no global flags forwarded; only `WORKLOAD_PARAMS` keys + `--rank-output-base` / `--rank-cache-base` / `--seed-base` / `--config`)