### PR TITLE
fix(#600): drop training-loop outputs from DATAGEN_REQUIRED_FILES

### DIFF
--- a/mlpstorage_py/submission_checker/checks/directory_checks.py
+++ b/mlpstorage_py/submission_checker/checks/directory_checks.py
@@ -82,11 +82,14 @@ class DirectoryCheck(BaseCheck):
         Check that each datagen timestamp directory contains:
         - training_datagen.stdout.log
         - training_datagen.stderr.log
-        - *output.json
-        - *per_epoch_stats.json
-        - *summary.json
         - dlio.log
+        - training_<datetime>_metadata.json   (mlpstorage-injected)
         - dlio_config/ (subdirectory)
+
+        Note: `output.json`, `per_epoch_stats.json`, and `summary.json` are
+        emitted by the DLIO training loop only, so they are NOT required
+        here (see RUN_REQUIRED_FILES / rule 2.1.19 for the run-side
+        contract). Issue #600.
 
         (Rules.md 2.1.14 datagenFiles)
         """

--- a/mlpstorage_py/submission_checker/constants.py
+++ b/mlpstorage_py/submission_checker/constants.py
@@ -58,10 +58,16 @@ PARSER_MAP = {
     "default": JSONParser
 }
 
+# Issue #600: prior versions copied this list from RUN_REQUIRED_FILES, which
+# wrongly demanded `*output.json` / `*per_epoch_stats.json` / `*summary.json`
+# in datagen directories — those are training-loop outputs, never written by
+# DLIO datagen (`workflow.generate_data=True, workflow.train=False` skips the
+# loop). `training_<ts>_metadata.json` is the mlpstorage-injected metadata
+# file written by `Benchmark.write_metadata` for every command.
 DATAGEN_REQUIRED_FILES = {
-    "v2.0": [r"training_datagen\.stdout.log", r"training_datagen.stderr\.log", r".*output\.json$", r".*per_epoch_stats\.json$", r".*summary\.json$", r"dlio\.log"],
-    "v3.0": [r"training_datagen\.stdout.log", r"training_datagen.stderr\.log", r".*output\.json$", r".*per_epoch_stats\.json$", r",*summary\.json$", r"dlio\.log"],
-    "default": [r"training_datagen\.stdout.log", r"training_datagen.stderr\.log", r".*output\.json$", r".*per_epoch_stats\.json$", r".*summary\.json$", r"dlio\.log"],
+    "v2.0":    [r"training_datagen\.stdout\.log$", r"training_datagen\.stderr\.log$", r"dlio\.log$", r"training_.*_metadata\.json$"],
+    "v3.0":    [r"training_datagen\.stdout\.log$", r"training_datagen\.stderr\.log$", r"dlio\.log$", r"training_.*_metadata\.json$"],
+    "default": [r"training_datagen\.stdout\.log$", r"training_datagen\.stderr\.log$", r"dlio\.log$", r"training_.*_metadata\.json$"],
 }
 
 DATAGEN_REQUIRED_FOLDERS = {

--- a/tests/unit/test_submission_checker_datagen_files.py
+++ b/tests/unit/test_submission_checker_datagen_files.py
@@ -1,0 +1,134 @@
+"""Tests for `DirectoryCheck.datagen_files_check` (Rules.md 2.1.14 datagenFiles).
+
+Pins the contract that the rule fires only against files DLIO datagen
+actually writes. DLIO datagen runs with
+``workflow.generate_data=True, workflow.train=False`` and therefore does
+NOT emit the training-loop outputs (``*output.json``, ``*per_epoch_stats.json``,
+``*summary.json``). Issue #600: prior to this fix, the required-files list
+was a copy of ``RUN_REQUIRED_FILES`` and every conforming datagen dir
+failed 2.1.14 with three spurious violations.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+
+def _populate_canonical_datagen_timestamp(timestamp_dir: Path) -> None:
+    """Drop into ``timestamp_dir`` exactly the files DLIO datagen emits.
+
+    Mirrors what `mlpstorage training datagen` produces in
+    ``<results-dir>/.../training/<model>/datagen/<ts>/`` — no
+    ``output.json`` / ``per_epoch_stats.json`` / ``summary.json``, because
+    those come from the training loop only.
+    """
+    (timestamp_dir / "training_datagen.stdout.log").write_text("stdout\n")
+    (timestamp_dir / "training_datagen.stderr.log").write_text("stderr\n")
+    (timestamp_dir / "dlio.log").write_text("dlio\n")
+    (timestamp_dir / "training_20260630_120000_metadata.json").write_text(
+        '{"benchmark_type": "training"}\n'
+    )
+    dlio_config = timestamp_dir / "dlio_config"
+    dlio_config.mkdir()
+    (dlio_config / "config.yaml").write_text("config: 1\n")
+    (dlio_config / "hydra.yaml").write_text("hydra: 1\n")
+    (dlio_config / "overrides.yaml").write_text("overrides: 1\n")
+
+
+def _build_datagen_check(workload_dir: Path, timestamp: str):
+    """Wire a `DirectoryCheck` against a workload directory."""
+    from mlpstorage_py.submission_checker.checks.directory_checks import (
+        DirectoryCheck,
+    )
+    from mlpstorage_py.submission_checker.configuration.configuration import (
+        Config,
+    )
+    from mlpstorage_py.submission_checker.constants import DEFAULT_SPEC_VERSION
+    from mlpstorage_py.submission_checker.loader import (
+        LoaderMetadata,
+        SubmissionLogs,
+    )
+
+    loader_metadata = LoaderMetadata(
+        division="closed",
+        submitter="Acme",
+        system="sys-v1",
+        mode="training",
+        benchmark="unet3d",
+        folder=str(workload_dir),
+    )
+    datagen_files = [(
+        {},
+        None,
+        timestamp,
+    )]
+    logs = SubmissionLogs(
+        datagen_files=datagen_files,
+        run_files=[],
+        checkpoint_files=None,
+        system_file={},
+        loader_metadata=loader_metadata,
+    )
+    config = Config(version=DEFAULT_SPEC_VERSION, submitters=None)
+    log = logging.getLogger("test_submission_checker_datagen_files")
+    return DirectoryCheck(log=log, config=config, submissions_logs=logs)
+
+
+class TestDatagenFilesCheck:
+    """Rule 2.1.14 must accept the canonical datagen timestamp shape."""
+
+    def test_accepts_canonical_datagen_dir(self, tmp_path):
+        """A datagen/<ts>/ with only DLIO-datagen-emitted files passes 2.1.14.
+
+        Pre-fix: this assertion failed because the required-files list
+        included three training-loop regexes
+        (``.*output\\.json$``, ``.*per_epoch_stats\\.json$``,
+        ``,*summary\\.json$``) that DLIO datagen never writes.
+        """
+        workload_dir = tmp_path / "training" / "unet3d"
+        workload_dir.mkdir(parents=True)
+        timestamp = "20260630_120000"
+        ts_dir = workload_dir / "datagen" / timestamp
+        ts_dir.mkdir(parents=True)
+        _populate_canonical_datagen_timestamp(ts_dir)
+
+        check = _build_datagen_check(workload_dir, timestamp)
+
+        assert check.datagen_files_check() is True, (
+            "datagen_files_check must accept a directory containing only "
+            "the files DLIO datagen actually writes; issue #600 fix."
+        )
+
+    def test_v3_required_list_has_no_training_loop_outputs(self):
+        """The v3.0 required-files list must not demand training-loop outputs.
+
+        ``output.json`` / ``per_epoch_stats.json`` / ``summary.json`` are
+        emitted by the training loop only — datagen runs skip the loop.
+        Also pins that the prior ``,*summary\\.json$`` typo is gone.
+        """
+        from mlpstorage_py.submission_checker.constants import (
+            DATAGEN_REQUIRED_FILES,
+        )
+
+        v3 = DATAGEN_REQUIRED_FILES["v3.0"]
+        joined = " ".join(v3)
+        assert "output" not in joined, (
+            "DATAGEN_REQUIRED_FILES[v3.0] must not require *output.json — "
+            "DLIO datagen never writes it (issue #600 bug 1)."
+        )
+        assert "per_epoch_stats" not in joined, (
+            "DATAGEN_REQUIRED_FILES[v3.0] must not require *per_epoch_stats.json"
+            " — DLIO datagen never writes it (issue #600 bug 1)."
+        )
+        assert ",*summary" not in joined, (
+            "Regex typo ',*summary\\.json$' must not appear in v3.0 row "
+            "(issue #600 bug 2)."
+        )
+        # `summary.json` is also a training-loop output; once bug 1 is
+        # fixed, no `summary` pattern should remain at all.
+        assert "summary" not in joined, (
+            "DATAGEN_REQUIRED_FILES[v3.0] must not require *summary.json — "
+            "DLIO datagen never writes it (issue #600 bug 1)."
+        )


### PR DESCRIPTION
## Summary

Fixes #600. `submission_checker` rule **2.1.14 `datagenFiles`** was demanding `*output.json`, `*per_epoch_stats.json`, and `*summary.json` in every datagen timestamp directory. DLIO datagen runs with `workflow.generate_data=True, workflow.train=False`, which **skips the training loop that emits those files** — so every conforming `datagen/<ts>/` failed 2.1.14 with three spurious violations, regardless of whether datagen itself ran cleanly.

The v3.0 row also carried a regex typo `,*summary\.json\$` (leading comma instead of dot). `,*` is a valid regex (zero-or-more commas) so the pattern still matched `summary.json` in practice, but the verbatim regex leaked into the user-facing \"not found\" error and looked like a defect.

## Changes

- **`mlpstorage_py/submission_checker/constants.py`** — strip the three training-loop regexes from all three rows of `DATAGEN_REQUIRED_FILES`, eliminating the comma typo as a side effect. Add `training_<datetime>_metadata.json` (mlpstorage-injected by `Benchmark.write_metadata` for every command, `base.py:201`+`:455`). Anchor the `.log` patterns with `\$` and properly escape the dots (small drive-by; prior entries were under-anchored).
- **`mlpstorage_py/submission_checker/checks/directory_checks.py`** — update the `datagen_files_check` docstring to match the new contract and explicitly note why the training-loop outputs are excluded.

`RUN_REQUIRED_FILES` (rule 2.1.19) and `CHECKPOINT_REQUIRED_FILES` (rule 2.1.25) are unchanged — both modes run the training loop, so those files are correctly required there.

## Test plan

- [x] **RED test first** (commit \`28a76c8\`): two unit tests in \`tests/unit/test_submission_checker_datagen_files.py\` pinning the contract — \`test_accepts_canonical_datagen_dir\` (builds a \`datagen/<ts>/\` with only the files DLIO datagen emits and asserts \`datagen_files_check()\` returns True) and \`test_v3_required_list_has_no_training_loop_outputs\` (pins that the v3.0 row carries no \`output\`, \`per_epoch_stats\`, \`summary\`, or \`,*summary\` regex). Both failed at the RED commit; logs showed exactly the three spurious 2.1.14 violations the issue describes.
- [x] **GREEN** after the fix (commit \`ac1acf6\`): both tests pass.
- [x] **Full CI test sweep — all 4 suites, zero failures, zero regressions:**
  - \`tests/\`: 2,437 passed, 13 deselected (slow)
  - \`mlpstorage_py/tests\`: 780 passed, 1 xfailed
  - \`vdb_benchmark/tests\`: 144 passed
  - \`kv_cache_benchmark/tests\`: 238 passed, 2 deselected
  - **Total: 3,599 passed**

## Out of scope

A latent dead-code bug in the \`skip_output_file\` guards at \`directory_checks.py:98\` and \`:204\` (compares regex string against literal \`\"*output.json\"\`, never matches) was discovered during verification but deferred to a separate PR to keep this change minimal.