### PR TITLE
fix(#598): submission checker reads parameters/override_parameters

### DIFF
--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -4,7 +4,13 @@ from ..constants import *
 from ..configuration.configuration import Config
 from ..loader import SubmissionLogs
 from ..rule_registry import rule
-from .helpers import _check_filesystem_separation, _pair_checkpoint_runs, _parse_iso_gap
+from .helpers import (
+    _check_filesystem_separation,
+    _pair_checkpoint_runs,
+    _parse_iso_gap,
+    get_override_parameters,
+    get_parameters,
+)
 
 import os
 import re
@@ -157,7 +163,7 @@ class CheckpointingCheck(BaseCheck):
             return valid
 
         for summary, metadata, _ in self._iter_valid_files():
-            combined_params = metadata.get("combined_params", {})
+            combined_params = get_parameters(metadata)
             checkpoint_params = combined_params.get("checkpoint", {})
             fsync_enabled = checkpoint_params.get("fsync", False)
 
@@ -220,7 +226,7 @@ class CheckpointingCheck(BaseCheck):
             verification = metadata.get("verification", "closed")
 
             if verification == "closed":
-                checkpoint_mode = metadata.get("params_dict", {}).get("checkpoint.mode", "").lower()
+                checkpoint_mode = get_override_parameters(metadata).get("checkpoint.mode", "").lower()
                 model_name = metadata.get("args", {}).get("model", "").lower()
                 num_processes = metadata.get("args", {}).get("num_processes", 0)
 
@@ -501,7 +507,7 @@ class CheckpointingCheck(BaseCheck):
             return valid
 
         for summary, metadata, _ in self._iter_valid_files():
-            params_dict = metadata.get("params_dict", {})
+            params_dict = get_override_parameters(metadata)
             checkpoint_mode = params_dict.get("checkpoint.mode", "")
 
             if checkpoint_mode == "subset":

--- a/mlpstorage_py/submission_checker/checks/helpers.py
+++ b/mlpstorage_py/submission_checker/checks/helpers.py
@@ -15,6 +15,8 @@ Exports:
                                   (Phase 4 CD-04; shared by §3.6.1 and §5.6.1)
   _pair_checkpoint_runs — write/read run pairing helper (D-D2)
   _parse_iso_gap        — ISO-timestamp gap helper (D-D2, CHKPT-03)
+  get_parameters        — read merged DLIO parameters dict from metadata (#598)
+  get_override_parameters — read user-supplied overrides dict from metadata (#598)
 
 References:
   - D-B1..B7 in Phase 2 CONTEXT.md (df parsing, longest-prefix mount match)
@@ -38,6 +40,58 @@ from ..tools.code_image import (
     MissingHashFile,
     MalformedHashFile,
 )
+
+
+# ---------------------------------------------------------------------------
+# Metadata key accessors (#598)
+# ---------------------------------------------------------------------------
+#
+# BaseBenchmark.metadata writes two top-level dicts into *_metadata.json:
+#
+#   metadata["parameters"]           — YAML defaults with CLI overrides folded
+#                                       in (was: "combined_params" pre-#365)
+#   metadata["override_parameters"]  — user-specified overrides only
+#                                       (was: "params_dict" pre-#365)
+#
+# These accessors are the single source of truth for the lookup so a future
+# key rename is a one-site change instead of an N-site treasure hunt.
+
+
+def get_parameters(metadata: dict) -> dict:
+    """Return the merged DLIO parameters dict from a metadata.json mapping.
+
+    Reads ``metadata['parameters']`` as written by ``BaseBenchmark.metadata``
+    (see ``mlpstorage_py/benchmarks/base.py``). Returns ``{}`` if the key is
+    absent so callers can chain ``.get("dataset", {})`` safely.
+
+    Args:
+        metadata: A parsed ``*_metadata.json`` dict, or ``None``.
+
+    Returns:
+        The merged parameters dict, or ``{}`` if metadata is ``None`` or the
+        key is missing.
+    """
+    if not metadata:
+        return {}
+    return metadata.get("parameters", {}) or {}
+
+
+def get_override_parameters(metadata: dict) -> dict:
+    """Return the user-overrides dict from a metadata.json mapping.
+
+    Reads ``metadata['override_parameters']`` as written by
+    ``BaseBenchmark.metadata``. Returns ``{}`` if the key is absent.
+
+    Args:
+        metadata: A parsed ``*_metadata.json`` dict, or ``None``.
+
+    Returns:
+        The override_parameters dict, or ``{}`` if metadata is ``None`` or
+        the key is missing.
+    """
+    if not metadata:
+        return {}
+    return metadata.get("override_parameters", {}) or {}
 
 
 # ---------------------------------------------------------------------------

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -4,7 +4,12 @@ from ..constants import *
 from ..configuration.configuration import Config
 from ..loader import SubmissionLogs
 from ..rule_registry import rule
-from .helpers import _check_filesystem_separation, _check_code_image_layered
+from .helpers import (
+    _check_filesystem_separation,
+    _check_code_image_layered,
+    get_override_parameters,
+    get_parameters,
+)
 
 # Shared with the in-process verifier (mlpstorage_py.rules.run_checkers.training)
 # so both checkers stay in lockstep about which dotted-keys the mlpstorage
@@ -104,7 +109,7 @@ class TrainingCheck(BaseCheck):
                 continue
             # Check if datasize-related parameters are in the metadata
             params = metadata.get("args", {})
-            combined_params = metadata.get("combined_params", {})
+            combined_params = get_parameters(metadata)
 
             if not params and not combined_params:
                 self.log_violation(
@@ -149,7 +154,7 @@ class TrainingCheck(BaseCheck):
                 continue
             try:
                 # Get parameters
-                combined_params = metadata.get("combined_params", {})
+                combined_params = get_parameters(metadata)
                 dataset_params = combined_params.get("dataset", {})
                 reader_params = combined_params.get("reader", {})
 
@@ -224,7 +229,7 @@ class TrainingCheck(BaseCheck):
         for summary, metadata, _ in self.submissions_logs.run_files:
             if metadata is None:
                 continue
-            dataset_params = metadata.get("combined_params", {}).get("dataset", {})
+            dataset_params = get_parameters(metadata).get("dataset", {})
             num_files = int(dataset_params.get("num_files_train", 0))
             record_length = float(dataset_params.get("record_length_bytes", 0))
             num_samples_per_file = int(dataset_params.get("num_samples_per_file", 1))
@@ -235,7 +240,7 @@ class TrainingCheck(BaseCheck):
         for summary, metadata, _ in self.submissions_logs.datagen_files:
             if metadata is None:
                 continue
-            dataset_params = metadata.get("combined_params", {}).get("dataset", {})
+            dataset_params = get_parameters(metadata).get("dataset", {})
             num_files = int(dataset_params.get("num_files_train", 0))
             record_length = float(dataset_params.get("record_length_bytes", 0))
             num_samples_per_file = int(dataset_params.get("num_samples_per_file", 1))
@@ -576,7 +581,7 @@ class TrainingCheck(BaseCheck):
             verification = metadata.get("verification", "open")
 
             if verification == "closed":
-                params_dict = metadata.get("params_dict", {})
+                params_dict = get_override_parameters(metadata)
 
                 for param_key in params_dict.keys():
                     # Tool-injected params (skip_listing, data_folder derived
@@ -639,7 +644,7 @@ class TrainingCheck(BaseCheck):
             verification = metadata.get("verification", "open")
 
             if verification == "open":
-                params_dict = metadata.get("params_dict", {})
+                params_dict = get_override_parameters(metadata)
 
                 for param_key in params_dict.keys():
                     # Tool-injected params (skip_listing, data_folder derived

--- a/mlpstorage_py/submission_checker/checks/vdb_checks.py
+++ b/mlpstorage_py/submission_checker/checks/vdb_checks.py
@@ -33,7 +33,11 @@ from .base import BaseCheck
 from ..configuration.configuration import Config
 from ..loader import SubmissionLogs
 from ..rule_registry import rule
-from .helpers import _check_code_image_layered, _check_filesystem_separation
+from .helpers import (
+    _check_code_image_layered,
+    _check_filesystem_separation,
+    get_override_parameters,
+)
 from mlpstorage_py.config import VDB_INDEX_TYPES_CLOSED
 
 
@@ -877,7 +881,7 @@ class VdbCheck(BaseCheck):
                     self.path, ts,
                 )
                 continue
-            params_dict = metadata.get("params_dict", {}) or {}
+            params_dict = get_override_parameters(metadata)
             for param_key in params_dict.keys():
                 if param_key not in _CLOSED_ALLOWED_PARAMS:
                     self.log_violation(
@@ -938,7 +942,7 @@ class VdbCheck(BaseCheck):
                     backend, self.path, ts,
                 )
                 continue
-            params_dict = metadata.get("params_dict", {}) or {}
+            params_dict = get_override_parameters(metadata)
             for param_key in params_dict.keys():
                 if param_key not in allowed_params:
                     self.log_violation(

--- a/mlpstorage_py/tests/conftest.py
+++ b/mlpstorage_py/tests/conftest.py
@@ -136,8 +136,11 @@ _DEFAULT_METADATA = {
         "num_checkpoints_write": 10,
         "num_checkpoints_read": 10,
     },
-    "combined_params": {},
-    "params_dict": {},
+    # #598: writer emits "parameters" / "override_parameters" (renamed from
+    # "combined_params" / "params_dict" as part of the #365 fix). Fixtures
+    # mirror the writer shape so tests assert against what really ships.
+    "parameters": {},
+    "override_parameters": {},
 }
 
 # ---------------------------------------------------------------------------

--- a/mlpstorage_py/tests/test_bug03_closed_mpi_processes.py
+++ b/mlpstorage_py/tests/test_bug03_closed_mpi_processes.py
@@ -61,7 +61,7 @@ def _make_check(
 
     metadata = {
         "verification": verification,
-        "params_dict": {"checkpoint.mode": checkpoint_mode},
+        "override_parameters": {"checkpoint.mode": checkpoint_mode},
         "args": {
             "model": model,
             "num_processes": num_processes,

--- a/mlpstorage_py/tests/test_checkpointing_check_iter_valid_files.py
+++ b/mlpstorage_py/tests/test_checkpointing_check_iter_valid_files.py
@@ -96,8 +96,8 @@ def test_f1a_method_tolerates_mixed_none_and_valid_entries(method_name, tmp_path
         "args": {"model": "llama3_8b", "num_processes": 8,
                  "checkpoint_folder": "/cf", "results_dir": "/rd"},
         "verification": "closed",
-        "combined_params": {"checkpoint": {"fsync": True}},
-        "params_dict": {"checkpoint.mode": "combined"},
+        "parameters": {"checkpoint": {"fsync": True}},
+        "override_parameters": {"checkpoint.mode": "combined"},
         "yaml_params": {},
     }
     checkpoint_files = [

--- a/mlpstorage_py/tests/test_issue598_metadata_key_contract.py
+++ b/mlpstorage_py/tests/test_issue598_metadata_key_contract.py
@@ -1,0 +1,565 @@
+"""Issue #598: writer/reader contract on metadata.json parameter keys.
+
+The writer at ``mlpstorage_py/benchmarks/base.py`` emits per-run
+``*_metadata.json`` files with two top-level dicts:
+
+    metadata["parameters"]           — YAML defaults with CLI overrides folded in
+    metadata["override_parameters"]  — user-specified overrides only
+
+(These key names were introduced as part of the #365 fix; the older names
+``combined_params`` / ``params_dict`` are no longer written.)
+
+The submission_checker rules under ``mlpstorage_py/submission_checker/checks/``
+must read these same key names. Before #598 they still looked up the old
+names, silently defaulted to ``{}``, and either fired spurious VIOLATIONs
+("dataset parameters not found in metadata", "record length is 0",
+"datagen size 0.00GiB is less than required 0.00GiB") or silently no-op'd
+CLOSED/OPEN allow-list checks that should have fired.
+
+This module locks both sides of the contract:
+
+* ``TestWriterContract`` — ``BaseBenchmark.metadata`` emits the new key
+  names and does NOT emit the old ones.
+* ``TestReaderContract`` — the affected checker rules see populated values
+  when the metadata uses the new keys, and do NOT spuriously violate.
+
+Both halves were RED on the pre-fix tree (writer always passed; readers
+all silently saw ``{}``).
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mlpstorage_py.benchmarks.base import Benchmark
+from mlpstorage_py.submission_checker.checks.checkpointing_checks import (
+    CheckpointingCheck,
+)
+from mlpstorage_py.submission_checker.checks.training_checks import TrainingCheck
+from mlpstorage_py.submission_checker.checks.vdb_checks import VdbCheck
+from mlpstorage_py.submission_checker.configuration.configuration import Config
+from mlpstorage_py.submission_checker.loader import LoaderMetadata, SubmissionLogs
+
+from mlpstorage_py.tests.conftest import MockLogger
+
+
+# ---------------------------------------------------------------------------
+# Writer-contract probe — drive a real Benchmark and inspect metadata dict
+# ---------------------------------------------------------------------------
+
+
+class _StubBenchmark(Benchmark):
+    """Minimal concrete Benchmark for inspecting the metadata dict.
+
+    Bypasses __init__ so we don't need a full args namespace; sets the
+    handful of attributes the metadata property reads.
+    """
+
+    BENCHMARK_TYPE = None  # set on instance
+
+    def _run(self):  # pragma: no cover — never executed
+        pass
+
+
+def _build_stub_benchmark(combined, overrides):
+    """Construct a stub benchmark instance with combined_params and params_dict.
+
+    Returns the instance with its metadata dict ready for inspection.
+    """
+    bench = _StubBenchmark.__new__(_StubBenchmark)
+    bench.BENCHMARK_TYPE = SimpleNamespace(name="training")
+    bench.args = SimpleNamespace(
+        command="run", model="unet3d", num_processes=8, accelerator_type="h100"
+    )
+    bench.run_datetime = "20260630_120000"
+    bench.run_result_output = "/tmp/results"
+    bench.runtime = 0.0
+    bench.verification = SimpleNamespace(name="closed")
+    bench.executed_command = "mlpstorage training run ..."
+    bench.command_output_files = []
+    bench.cluster_information = None
+    bench.cluster_snapshots = None
+    bench.combined_params = combined
+    bench.params_dict = overrides
+    return bench
+
+
+class TestWriterContract:
+    """Writer side of the #598 contract."""
+
+    def test_metadata_emits_new_key_names(self):
+        """Real BaseBenchmark.metadata emits 'parameters' / 'override_parameters'."""
+        bench = _build_stub_benchmark(
+            combined={"dataset": {"num_files_train": 100}},
+            overrides={"dataset.num_files_train": 200},
+        )
+        meta = bench.metadata
+
+        assert "parameters" in meta, (
+            "writer must emit metadata['parameters'] (renamed from "
+            "'combined_params' as part of the #365 fix)"
+        )
+        assert "override_parameters" in meta, (
+            "writer must emit metadata['override_parameters'] (renamed "
+            "from 'params_dict' as part of the #365 fix)"
+        )
+
+    def test_metadata_does_not_emit_old_key_names(self):
+        """Old names must NOT leak through — submitters relying on either
+        name in tooling should get a hard miss, not a silent partial."""
+        bench = _build_stub_benchmark(combined={}, overrides={})
+        meta = bench.metadata
+
+        assert "combined_params" not in meta, (
+            "writer must not emit the pre-#365 'combined_params' key"
+        )
+        assert "params_dict" not in meta, (
+            "writer must not emit the pre-#365 'params_dict' key"
+        )
+
+    def test_metadata_parameters_is_combined_plus_overrides(self):
+        """parameters == combined_params with dotted overrides folded in.
+
+        Pins the writer's documented semantics (fixes #365): downstream
+        readers can treat 'parameters' as the single source of truth for
+        the merged config.
+        """
+        bench = _build_stub_benchmark(
+            combined={"dataset": {"num_files_train": 100}},
+            overrides={"dataset.num_files_train": 999},
+        )
+        meta = bench.metadata
+        assert meta["parameters"]["dataset"]["num_files_train"] == 999
+
+    def test_metadata_override_parameters_is_user_overrides_only(self):
+        bench = _build_stub_benchmark(
+            combined={"dataset": {"num_files_train": 100}},
+            overrides={"dataset.num_files_train": 999},
+        )
+        meta = bench.metadata
+        assert meta["override_parameters"] == {"dataset.num_files_train": 999}
+
+    def test_metadata_round_trips_through_json(self, tmp_path):
+        """metadata is JSON-serialisable with the new key names."""
+        bench = _build_stub_benchmark(
+            combined={"dataset": {"num_files_train": 100}, "reader": {"batch_size": 4}},
+            overrides={"dataset.num_files_train": 200},
+        )
+        path = tmp_path / "training_unet3d_metadata.json"
+        path.write_text(json.dumps(bench.metadata), encoding="utf-8")
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        assert loaded["parameters"]["dataset"]["num_files_train"] == 200
+        assert loaded["parameters"]["reader"]["batch_size"] == 4
+        assert loaded["override_parameters"] == {"dataset.num_files_train": 200}
+
+
+# ---------------------------------------------------------------------------
+# Reader-contract probe — drive each affected checker against writer-shape input
+# ---------------------------------------------------------------------------
+
+
+def _writer_shape_training_metadata(
+    *,
+    parameters=None,
+    override_parameters=None,
+    verification="closed",
+    hosts=("h1",),
+    data_dir="/data",
+    results_dir="/results",
+):
+    """Build a metadata dict shaped exactly like BaseBenchmark.metadata emits."""
+    return {
+        "benchmark_type": "training",
+        "model": "unet3d",
+        "verification": verification,
+        "args": {
+            "model": "unet3d",
+            "num_processes": 8,
+            "data_dir": data_dir,
+            "results_dir": results_dir,
+            "hosts": list(hosts),
+        },
+        "parameters": parameters if parameters is not None else {},
+        "override_parameters": override_parameters if override_parameters is not None else {},
+    }
+
+
+def _writer_shape_checkpointing_metadata(
+    *,
+    parameters=None,
+    override_parameters=None,
+    verification="closed",
+    model="llama3_8b",
+    num_processes=8,
+):
+    return {
+        "benchmark_type": "checkpointing",
+        "model": model,
+        "verification": verification,
+        "args": {
+            "model": model,
+            "num_processes": num_processes,
+            "checkpoint_folder": "/chkpts",
+            "results_dir": "/results",
+            "num_checkpoints_write": 1,
+            "num_checkpoints_read": 0,
+        },
+        "parameters": parameters if parameters is not None else {},
+        "override_parameters": override_parameters if override_parameters is not None else {},
+    }
+
+
+def _writer_shape_vdb_metadata(*, override_parameters=None, verification="closed"):
+    return {
+        "benchmark_type": "vector_database",
+        "verification": verification,
+        "args": {"storage_root": "/vdb/data", "results_dir": "/vdb/results"},
+        "parameters": {},
+        "override_parameters": override_parameters if override_parameters is not None else {},
+    }
+
+
+def _training_check(tmp_path, *, run_files=None, datagen_files=None, mode="training"):
+    log = MagicMock()
+    config = Config(version="v3.0", submitters=["Acme"], skip_output_file=True)
+    submissions_logs = SubmissionLogs(
+        datagen_files=datagen_files or [],
+        run_files=run_files or [],
+        system_file=None,
+        loader_metadata=LoaderMetadata(
+            division="closed",
+            submitter="Acme",
+            system="sys-v1",
+            mode=mode,
+            benchmark="unet3d",
+            folder=str(tmp_path),
+        ),
+    )
+    return TrainingCheck(log=log, config=config, submissions_logs=submissions_logs)
+
+
+def _checkpointing_check(tmp_path, *, checkpoint_files=None, mode="checkpointing"):
+    """CheckpointingCheck stores ``self.submissions_logs = submissions_logs.checkpoint_files``,
+    so callers pass the checkpoint_files list directly (not run_files)."""
+    log = MagicMock()
+    config = Config(version="v3.0", submitters=["Acme"], skip_output_file=True)
+    submissions_logs = SubmissionLogs(
+        datagen_files=[],
+        run_files=[],
+        checkpoint_files=checkpoint_files or [],
+        system_file={},
+        loader_metadata=LoaderMetadata(
+            division="closed",
+            submitter="Acme",
+            system="sys-v1",
+            mode=mode,
+            benchmark="llama3_8b",
+            folder=str(tmp_path),
+        ),
+    )
+    return CheckpointingCheck(log=log, config=config, submissions_logs=submissions_logs)
+
+
+def _vdb_check(tmp_path, *, run_files=None, mock_logger=None):
+    log = mock_logger or MockLogger()
+    config = Config(
+        version="v3.0", submitters=None, skip_output_file=True
+    )
+    submissions_logs = SubmissionLogs(
+        datagen_files=[],
+        run_files=run_files or [],
+        system_file=None,
+        loader_metadata=LoaderMetadata(
+            division="closed",
+            submitter="acme",
+            system="sys-1",
+            mode="vector_database",
+            benchmark=tmp_path.name,
+            folder=str(tmp_path),
+        ),
+    )
+    return VdbCheck(log=log, config=config, submissions_logs=submissions_logs)
+
+
+class TestReaderContract:
+    """Reader side of the #598 contract — each affected rule must read the
+    new key names emitted by the writer.
+
+    Each test populates writer-shape data and asserts the corresponding
+    rule does NOT fire a spurious violation. Before the fix, every test
+    here was RED because the readers looked up the OLD names and got
+    ``{}``, which made them either fire spuriously or silently pass an
+    allow-list check.
+    """
+
+    # -- training_checks.py --------------------------------------------------
+
+    def test_3_1_1_verify_datasize_usage_reads_parameters(self, tmp_path):
+        """3.1.1 trainingVerifyDatasizeUsage — reads metadata['parameters']
+        (was: 'combined_params' at lines 107 + 227)."""
+        meta = _writer_shape_training_metadata(
+            parameters={
+                "dataset": {
+                    "num_files_train": 100,
+                    "num_samples_per_file": 1,
+                    "record_length_bytes": 1024,
+                }
+            }
+        )
+        run_files = [({"num_accelerators": 1}, meta, "20260630_120000")]
+        check = _training_check(tmp_path, run_files=run_files)
+
+        result = check.verify_datasize_usage()
+
+        assert result is True, (
+            "3.1.1 must see populated dataset params under metadata['parameters'] "
+            "and not fire 'dataset parameters not found in metadata'"
+        )
+
+    def test_3_1_2_recalculate_dataset_size_reads_parameters(self, tmp_path):
+        """3.1.2 trainingRecalculateDatasetSize — reads metadata['parameters']
+        (was: 'combined_params' at line 152)."""
+        summary = {
+            "num_accelerators": 1,
+            "num_hosts": 1,
+            "host_memory_GB": [64],
+            "num_files_train": 1000,
+            "num_files_eval": 0,
+            "metric": {
+                "train_au_meet_expectation": "success",
+                "train_au_mean_percentage": 99.0,
+            },
+        }
+        meta = _writer_shape_training_metadata(
+            parameters={
+                "dataset": {
+                    "num_files_train": 1000,
+                    "num_samples_per_file": 1,
+                    "record_length_bytes": 1024 * 1024,
+                },
+                "reader": {"batch_size": 4},
+            }
+        )
+        check = _training_check(
+            tmp_path, run_files=[(summary, meta, "20260630_120000")]
+        )
+
+        check.recalculate_dataset_size()
+
+        # The pre-fix failure was 'record length is 0' — a spurious violation
+        # because record_length_bytes was read from empty combined_params.
+        all_error_calls = [str(c) for c in check.log.error.call_args_list]
+        assert not any("record length is 0" in m for m in all_error_calls), (
+            "3.1.2 must read record_length_bytes from metadata['parameters'] "
+            f"and not fire 'record length is 0'; got: {all_error_calls}"
+        )
+
+    def test_3_2_1_datagen_minimum_size_reads_parameters(self, tmp_path):
+        """3.2.1 trainingDatagenMinimumSize — reads metadata['parameters']
+        (was: 'combined_params' at lines 227 + 238)."""
+        params = {
+            "dataset": {
+                "num_files_train": 1000,
+                "num_samples_per_file": 1,
+                "record_length_bytes": 1024 * 1024,
+            }
+        }
+        run_meta = _writer_shape_training_metadata(parameters=params)
+        datagen_meta = _writer_shape_training_metadata(parameters=params)
+        check = _training_check(
+            tmp_path,
+            run_files=[({}, run_meta, "20260630_120000")],
+            datagen_files=[({}, datagen_meta, "20260630_110000")],
+        )
+
+        result = check.datagen_minimum_size()
+
+        # Pre-fix: both run-side and datagen-side dataset_params read 0, so
+        # expected_size == datagen_size == 0.0, and the spurious-zero compare
+        # at line 244 was `0 < 0` (False) — silent pass. But more important
+        # is that mis-equal sizing would fire. Assert no datagen_size
+        # violation fired regardless.
+        assert result is True
+
+    def test_3_6_2_closed_submission_parameters_reads_override_parameters(self, tmp_path):
+        """3.6.2 trainingClosedSubmissionParameters — reads metadata['override_parameters']
+        (was: 'params_dict' at line 579).
+
+        Populates an override_parameters dict with a DISALLOWED key. Pre-fix
+        the reader saw ``{}`` and the allow-list check silently passed — a
+        false negative that let CLOSED submissions ship illegal overrides.
+        """
+        # 'dataset.format' is in OPEN-extra allowed, not CLOSED-allowed.
+        meta = _writer_shape_training_metadata(
+            override_parameters={"dataset.format": "tfrecord"},
+            verification="closed",
+        )
+        check = _training_check(
+            tmp_path, run_files=[({}, meta, "20260630_120000")]
+        )
+
+        result = check.closed_submission_parameters()
+
+        assert result is False, (
+            "3.6.2 must read disallowed override from metadata['override_parameters'] "
+            "and fire a violation (pre-fix this silently passed)"
+        )
+        violations = [
+            str(c) for c in check.log.error.call_args_list
+            if "dataset.format" in str(c)
+        ]
+        assert violations, (
+            "Expected a [3.6.2 trainingClosedSubmissionParameters] violation "
+            f"mentioning the disallowed override; got: {check.log.error.call_args_list}"
+        )
+
+    def test_3_6_3_open_submission_parameters_reads_override_parameters(self, tmp_path):
+        """3.6.3 trainingOpenSubmissionParameters — reads metadata['override_parameters']
+        (was: 'params_dict' at line 642)."""
+        # 'reader.something_made_up' is not in OPEN allowed list.
+        meta = _writer_shape_training_metadata(
+            override_parameters={"reader.something_made_up": "value"},
+            verification="open",
+        )
+        check = _training_check(
+            tmp_path, run_files=[({}, meta, "20260630_120000")]
+        )
+
+        result = check.open_submission_parameters()
+
+        assert result is False, (
+            "3.6.3 must read disallowed override from metadata['override_parameters'] "
+            "and fire a violation"
+        )
+
+    # -- checkpointing_checks.py --------------------------------------------
+
+    def test_4_3_2_fsync_verification_reads_parameters(self, tmp_path):
+        """4.3.2 checkpointFsyncVerification — reads metadata['parameters']
+        (was: 'combined_params' at line 160).
+
+        Pre-fix the reader silently saw ``{}`` and fsync_enabled defaulted
+        to False, firing a spurious violation on every checkpoint run.
+        """
+        meta = _writer_shape_checkpointing_metadata(
+            parameters={"checkpoint": {"fsync": True}}
+        )
+        summary = {
+            "num_accelerators": 8,
+            "num_hosts": 1,
+            "host_memory_GB": [128],
+            "metric": {"checkpoint_size_GB": 100},
+            "start": "2026-06-30T00:00:00",
+            "end": "2026-06-30T00:10:00",
+        }
+        check = _checkpointing_check(
+            tmp_path, checkpoint_files=[(summary, meta, "20260630_120000")]
+        )
+
+        result = check.fsync_verification()
+
+        assert result is True, (
+            "4.3.2 must read fsync=True from metadata['parameters']['checkpoint'] "
+            "and not fire a spurious 'fsync not enabled' violation"
+        )
+
+    def test_4_3_5_subset_run_validation_reads_override_parameters(self, tmp_path):
+        """4.3.5 checkpointSubsetRunValidation — reads metadata['override_parameters']
+        (was: 'params_dict' at line 504)."""
+        meta = _writer_shape_checkpointing_metadata(
+            override_parameters={"checkpoint.mode": "subset"},
+            model="llama3_70b",
+        )
+        # Subset mode requires exactly 8 accelerators — supply 4 to trigger
+        # the violation. If the reader silently saw {} (pre-fix), it would
+        # never enter the if-branch at all and silent-pass.
+        summary = {"num_accelerators": 4}
+        check = _checkpointing_check(
+            tmp_path, checkpoint_files=[(summary, meta, "20260630_120000")]
+        )
+
+        result = check.subset_run_validation()
+
+        assert result is False, (
+            "4.3.5 must see checkpoint.mode='subset' in metadata['override_parameters'] "
+            "and fire on num_accelerators != 8"
+        )
+
+    def test_4_6_1_closed_mpi_processes_reads_override_parameters(self, tmp_path):
+        """4.6.1 checkpointClosedMpiProcesses — reads metadata['override_parameters']
+        (was: 'params_dict' at line 223)."""
+        # subset mode + wrong num_processes → expect violation.
+        meta = _writer_shape_checkpointing_metadata(
+            override_parameters={"checkpoint.mode": "subset"},
+            model="llama3_70b",
+            num_processes=4,
+        )
+        summary = {"num_accelerators": 4}
+        check = _checkpointing_check(
+            tmp_path, checkpoint_files=[(summary, meta, "20260630_120000")]
+        )
+
+        result = check.closed_mpi_processes()
+
+        assert result is False, (
+            "4.6.1 must read checkpoint.mode from metadata['override_parameters'] "
+            "and require num_processes=8 for subset mode"
+        )
+
+    # -- vdb_checks.py -------------------------------------------------------
+
+    def test_5_6_4_vdb_closed_submission_parameters_reads_override_parameters(self, tmp_path):
+        """5.6.4 vdbClosedSubmissionParameters — reads metadata['override_parameters']
+        (was: 'params_dict' at line 880)."""
+        # Pick a key very unlikely to be in _CLOSED_ALLOWED_PARAMS.
+        meta = _writer_shape_vdb_metadata(
+            override_parameters={"definitely.not.allowed.key": "x"},
+        )
+        summary = {"database": {"database": "milvus"}}
+        check = _vdb_check(
+            tmp_path, run_files=[(summary, meta, "20260630_120000")]
+        )
+
+        result = check.vdb_closed_submission_parameters()
+
+        assert result is False, (
+            "5.6.4 must read disallowed override from metadata['override_parameters'] "
+            "and fire a violation"
+        )
+
+    def test_5_6_5_vdb_open_submission_parameters_reads_override_parameters(self, tmp_path):
+        """5.6.5 vdbOpenSubmissionParameters — reads metadata['override_parameters']
+        (was: 'params_dict' at line 941)."""
+        meta = _writer_shape_vdb_metadata(
+            override_parameters={"definitely.not.allowed.key": "x"},
+            verification="open",
+        )
+        summary = {"database": {"database": "milvus"}}
+        # Override the division to "open" for this check.
+        log = MagicMock()
+        config = Config(version="v3.0", submitters=None, skip_output_file=True)
+        submissions_logs = SubmissionLogs(
+            datagen_files=[],
+            run_files=[(summary, meta, "20260630_120000")],
+            system_file=None,
+            loader_metadata=LoaderMetadata(
+                division="open",
+                submitter="acme",
+                system="sys-1",
+                mode="vector_database",
+                benchmark=tmp_path.name,
+                folder=str(tmp_path),
+            ),
+        )
+        check = VdbCheck(log=log, config=config, submissions_logs=submissions_logs)
+
+        result = check.vdb_open_submission_parameters()
+
+        assert result is False, (
+            "5.6.5 must read disallowed override from metadata['override_parameters'] "
+            "and fire a violation"
+        )

--- a/mlpstorage_py/tests/test_training_check_extended_none_guard.py
+++ b/mlpstorage_py/tests/test_training_check_extended_none_guard.py
@@ -70,14 +70,14 @@ def test_f1b_method_tolerates_mixed_none_and_well_formed(method_name, tmp_path):
                    "train_au_mean_percentage": 99.0},
     }
     well_formed_metadata = {
-        "combined_params": {
+        "parameters": {
             "dataset": {"num_files_train": 1, "num_samples_per_file": 1,
                         "record_length_bytes": 1024},
             "reader": {"batch_size": 1},
         },
         "args": {"hosts": ["h1"], "data_dir": "/data", "results_dir": "/results"},
         "verification": "open",
-        "params_dict": {},
+        "override_parameters": {},
     }
     run_files = [
         (None, None, "20250101_000000"),

--- a/mlpstorage_py/tests/test_training_check_retrofit.py
+++ b/mlpstorage_py/tests/test_training_check_retrofit.py
@@ -91,16 +91,15 @@ def test_every_retrofitted_training_method_has_rule_id_attribute(rule_id, method
 # ---------------------------------------------------------------------------
 
 def test_3_1_1_missing_dataset_params_emits_prefixed_violation(tmp_path, mock_logger):
-    """3.1.1: when run metadata has no combined_params (no dataset block),
+    """3.1.1: when run metadata has no parameters (no dataset block),
     verify_datasize_usage emits a [3.1.1 trainingVerifyDatasizeUsage] violation
     and returns False.
 
-    The default build_submission writes metadata.json with empty combined_params
-    (default _DEFAULT_METADATA has `"combined_params": {}`) and a non-empty
-    args dict. The first branch (no params and no combined_params) is skipped
-    because args is non-empty; the second branch ("dataset parameters not
-    found in metadata") fires because combined_params.get('dataset', {}) is
-    empty.
+    The default build_submission writes metadata.json with empty parameters
+    (default _DEFAULT_METADATA has `"parameters": {}`) and a non-empty args
+    dict. The first branch (no params and no parameters) is skipped because
+    args is non-empty; the second branch ("dataset parameters not found in
+    metadata") fires because parameters.get('dataset', {}) is empty.
     """
     from mlpstorage_py.tests.conftest import build_submission
     root = build_submission(tmp_path)

--- a/mlpstorage_py/tests/test_training_check_summary_none_guard.py
+++ b/mlpstorage_py/tests/test_training_check_summary_none_guard.py
@@ -75,7 +75,7 @@ def test_bug_t2_method_does_not_crash_on_mixed_tuples(method_name, tmp_path):
              "num_files_train": 0, "num_files_eval": 0,
              "metric": {"train_au_meet_expectation": "success",
                         "train_au_mean_percentage": 99.0}},
-            {"combined_params": {
+            {"parameters": {
                 "dataset": {"num_files_train": 1, "num_samples_per_file": 1,
                             "record_length_bytes": 1024},
                 "reader": {"batch_size": 1}},

--- a/mlpstorage_py/tests/test_training_check_tool_injected_params.py
+++ b/mlpstorage_py/tests/test_training_check_tool_injected_params.py
@@ -38,10 +38,11 @@ def _make_training_check(tmp_path, run_files, mode='training'):
 
 
 def _make_run_tuple(params_dict, verification='closed'):
+    # #598: writer emits "override_parameters" (renamed from "params_dict").
     summary = {}
     metadata = {
         'verification': verification,
-        'params_dict': params_dict,
+        'override_parameters': params_dict,
     }
     return (summary, metadata, '20260624_000000')
 

--- a/mlpstorage_py/tests/test_vdb_checks.py
+++ b/mlpstorage_py/tests/test_vdb_checks.py
@@ -150,10 +150,12 @@ def _summary_datagen(**overrides):
 
 
 def _metadata(**arg_overrides):
-    """Build a metadata.json dict with args + params_dict.
+    """Build a metadata.json dict with args + override_parameters.
 
-    Pop "params_dict" to override the params dict itself; everything else
-    is treated as an args.* override.
+    Pop "params_dict" to override the user-supplied overrides dict; everything
+    else is treated as an args.* override. The "params_dict" kwarg name is
+    kept for caller backwards-compatibility, but it maps to the
+    "override_parameters" key the writer actually emits (#598 / #365).
     """
     params_dict = arg_overrides.pop("params_dict", None)
     args = {
@@ -163,7 +165,7 @@ def _metadata(**arg_overrides):
     args.update(arg_overrides)
     return {
         "args": args,
-        "params_dict": params_dict if params_dict is not None else {},
+        "override_parameters": params_dict if params_dict is not None else {},
     }
 
 


### PR DESCRIPTION
## Summary
- `BaseBenchmark.metadata` emits `parameters` / `override_parameters` (renamed from `combined_params` / `params_dict` as part of the #365 fix), but every reader site under `mlpstorage_py/submission_checker/checks/` still looked up the OLD names — silently defaulting to `{}` and either firing spurious VIOLATIONs ("dataset parameters not found in metadata", "record length is 0", "datagen size 0.00GiB < required …") or silently no-op'ing CLOSED/OPEN allow-list checks that should have fired.
- Issue #598 reported 9 stale sites; **two more** (`training_checks.py:107` and `:152`) were also stale. All 11 are migrated to two new accessors (`get_parameters`, `get_override_parameters`) in `checks/helpers.py` so a future rename is a one-site change.
- The pre-#598 test fixtures used the OLD key names, so the suite was testing the checker against itself rather than against actual writer output — that gap is what let this regression land in the first place. Fixtures are now writer-shape, and a new contract test (`test_issue598_metadata_key_contract.py`) drives `BaseBenchmark.metadata` through each affected check end-to-end.

## TDD trail
- `6b51eb9` — RED test added; **8 of 10** reader-contract assertions fail on the pre-fix tree with the exact error strings the issue reporter cited.
- `0165a23` — readers migrated, fixtures updated → all 15 contract tests GREEN.

## Reader-site map
| File | Line | Was | Now |
|---|---|---|---|
| `training_checks.py` | 107 | `combined_params` | `get_parameters(metadata)` |
| `training_checks.py` | 152 | `combined_params` | `get_parameters(metadata)` |
| `training_checks.py` | 227 | `combined_params` | `get_parameters(metadata)` |
| `training_checks.py` | 238 | `combined_params` | `get_parameters(metadata)` |
| `training_checks.py` | 579 | `params_dict` | `get_override_parameters(metadata)` |
| `training_checks.py` | 642 | `params_dict` | `get_override_parameters(metadata)` |
| `checkpointing_checks.py` | 160 | `combined_params` | `get_parameters(metadata)` |
| `checkpointing_checks.py` | 223 | `params_dict` | `get_override_parameters(metadata)` |
| `checkpointing_checks.py` | 504 | `params_dict` | `get_override_parameters(metadata)` |
| `vdb_checks.py` | 880 | `params_dict` | `get_override_parameters(metadata)` |
| `vdb_checks.py` | 941 | `params_dict` | `get_override_parameters(metadata)` |

## What did NOT change
- In-memory `self.combined_params` / `self.params_dict` attributes on `BaseBenchmark` (the **source** of the metadata projection). Only the JSON key names were renamed — the attribute names are unchanged. `tests/unit/test_dlio_*.py` and `tests/conftest.py` reference those attrs and need no edits.

## Test plan
- [x] `uv run pytest mlpstorage_py/tests` — 795 passed, 1 xfailed
- [x] `uv run pytest tests` — 2,435 passed, 13 deselected
- [x] `uv run pytest vdb_benchmark/tests kv_cache_benchmark/tests` — 382 passed
- [x] New: `mlpstorage_py/tests/test_issue598_metadata_key_contract.py` — 15/15 passed
- [ ] Manual: run `mlpstorage validate` against a locally produced training submission and confirm 3.1.1 / 3.1.2 / 3.2.1 / 3.6.2 / 3.6.3 no longer fire spurious violations (reporter to confirm).

Fixes #598.