### PR TITLE
Patch submission checker for v3.0

### DIFF
--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -76,6 +76,20 @@ class ReportGenerator:
             apply_logging_options(self.logger, args)
 
         self.results_dir = results_dir
+        # Detect the canonical mlpstorage submission tree (sentinel-bearing root
+        # with <division>/<orgname>/results/<system>/<benchmark-type>/...) and
+        # resolve --results-dir down to the per-system subtree that contains
+        # the benchmark-type directories the rest of ReportGenerator expects.
+        # No-op when --results-dir already points at a flat benchmark-type root.
+        self.results_dir = self._resolve_effective_results_dir(self.results_dir)
+
+        # Honor --output-dir for write_{json,csv}_file (falls back to results_dir).
+        output_dir = None
+        if self.args is not None:
+            output_dir = getattr(self.args, 'output_dir', None)
+        self.output_dir = output_dir or self.results_dir
+        if self.output_dir and self.output_dir != self.results_dir:
+            os.makedirs(self.output_dir, exist_ok=True)
 
         # Initialize formatters
         self.msg_formatter = ValidationMessageFormatter(use_colors=use_colors)
@@ -92,6 +106,63 @@ class ReportGenerator:
 
         self.accumulate_results()
         self.print_results()
+
+    def _resolve_effective_results_dir(self, results_dir: str) -> str:
+        """Resolve --results-dir to the directory that holds benchmark-type subdirs.
+
+        Accepts both shapes:
+
+        * Flat layout (legacy / what ResultsDirectoryValidator expected):
+          ``<results-dir>/<benchmark-type>/<model>/...`` — returned unchanged.
+        * Canonical mlpstorage submission tree (what ``mlpstorage init`` /
+          ``<bench> run`` / ``validate`` produce):
+          ``<sentinel-root>/<division>/<orgname>/results/<system>/<benchmark-type>/...``
+          — resolved down to the per-system subtree.
+
+        When ``--systemname`` is supplied, the canonical-tree resolution
+        scopes to ``results/<systemname>/`` so reportgen aggregates only
+        that system's runs (fixes the prior behavior of walking every
+        system's runs regardless of --systemname).
+        """
+        from pathlib import Path  # local import to avoid hoisting Path globally
+        root = Path(results_dir)
+        if not root.is_dir():
+            return results_dir
+        # Already flat?
+        expected = ResultsDirectoryValidator.EXPECTED_BENCHMARK_TYPES
+        if any((root / b).is_dir() for b in expected):
+            return results_dir
+        # Canonical tree probe.
+        systemname = None
+        if self.args is not None:
+            systemname = getattr(self.args, 'systemname', None)
+        for division in ('closed', 'open'):
+            division_dir = root / division
+            if not division_dir.is_dir():
+                continue
+            for org_dir in sorted(p for p in division_dir.iterdir() if p.is_dir()):
+                results_root = org_dir / 'results'
+                if not results_root.is_dir():
+                    continue
+                if systemname:
+                    system_dir = results_root / systemname
+                    if system_dir.is_dir():
+                        self.logger.info(
+                            "Detected canonical submission tree; scoping to "
+                            "%s/results/%s for --systemname=%s",
+                            org_dir, systemname, systemname,
+                        )
+                        return str(system_dir)
+                else:
+                    systems = [p for p in results_root.iterdir() if p.is_dir()]
+                    if len(systems) == 1:
+                        self.logger.info(
+                            "Detected canonical submission tree with single system; "
+                            "scoping to %s",
+                            systems[0],
+                        )
+                        return str(systems[0])
+        return results_dir
 
     def _validate_directory_structure(self) -> bool:
         """
@@ -125,11 +196,17 @@ class ReportGenerator:
     def generate_reports(self):
         # Verify the results directory exists:
         self.logger.info(f'Generating reports for {self.results_dir}')
-        run_result_dicts = [report.benchmark_run.as_dict() for report in self.run_results.values()]
 
+        # Always traverse the full directory and emit one rollup
+        # results.json / results.csv covering every discovered run, written
+        # to self.output_dir (which defaults to self.results_dir when
+        # --output-dir is not supplied).
+        run_result_dicts = [
+            report.benchmark_run.as_dict() for report in self.run_results.values()
+        ]
         self.write_csv_file(run_result_dicts)
         self.write_json_file(run_result_dicts)
-            
+
         return EXIT_CODE.SUCCESS
 
     def accumulate_results(self) -> None:
@@ -414,13 +491,13 @@ class ReportGenerator:
 
 
     def write_json_file(self, results):
-        json_file = os.path.join(self.results_dir,'results.json')
+        json_file = os.path.join(self.output_dir, 'results.json')
         self.logger.info(f'Writing results to {json_file}')
         with open(json_file, 'w') as f:
             json.dump(results, f, indent=2)
 
     def write_csv_file(self, results):
-        csv_file = os.path.join(self.results_dir,'results.csv')
+        csv_file = os.path.join(self.output_dir, 'results.csv')
         self.logger.info(f'Writing results to {csv_file}')
         flattened_results = [flatten_nested_dict(r) for r in results]
         flattened_results = [remove_nan_values(r) for r in flattened_results]

--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -157,7 +157,7 @@ class CheckpointingCheck(BaseCheck):
             return valid
 
         for summary, metadata, _ in self._iter_valid_files():
-            combined_params = metadata.get("combined_params", {})
+            combined_params = metadata.get("parameters", {})
             checkpoint_params = combined_params.get("checkpoint", {})
             fsync_enabled = checkpoint_params.get("fsync", False)
 
@@ -220,7 +220,7 @@ class CheckpointingCheck(BaseCheck):
             verification = metadata.get("verification", "closed")
 
             if verification == "closed":
-                checkpoint_mode = metadata.get("params_dict", {}).get("checkpoint.mode", "").lower()
+                checkpoint_mode = metadata.get("override_parameters", {}).get("checkpoint.mode", "").lower()
                 model_name = metadata.get("args", {}).get("model", "").lower()
                 num_processes = metadata.get("args", {}).get("num_processes", 0)
 
@@ -501,7 +501,7 @@ class CheckpointingCheck(BaseCheck):
             return valid
 
         for summary, metadata, _ in self._iter_valid_files():
-            params_dict = metadata.get("params_dict", {})
+            params_dict = metadata.get("override_parameters", {})
             checkpoint_mode = params_dict.get("checkpoint.mode", "")
 
             if checkpoint_mode == "subset":
@@ -877,13 +877,20 @@ class CheckpointingCheck(BaseCheck):
             }
             ok, df_found = _check_filesystem_separation(chkpt_args, logfile_path)
             if not df_found:
-                self.log_violation(
+                # TODO-001: runtime df capture is missing in mlpstorage CLI
+                # (`Benchmark._execute_command` in benchmarks/base.py never invokes
+                # `df` before/after the DLIO subprocess). Emit a warning rather
+                # than an error so conforming submissions are not blocked on
+                # an upstream producer gap. Restore log_violation once the
+                # writer side ships the `df` block in *_run.stdout.log.
+                self.warn_violation(
                     "4.4.2", "checkpointFilesystemCheck", logfile_path,
-                    "df output not found",
+                    "df output not found (mlpstorage CLI does not yet capture df; TODO-001)",
                 )
-                valid = False
                 continue
             if not ok:
+                # df WAS found (e.g. submitter manually injected it), so this
+                # is a real same-mount finding and remains an error.
                 self.log_violation(
                     "4.4.2", "checkpointFilesystemCheck", logfile_path,
                     "checkpoint_folder and results_dir are on the same filesystem",

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -104,7 +104,7 @@ class TrainingCheck(BaseCheck):
                 continue
             # Check if datasize-related parameters are in the metadata
             params = metadata.get("args", {})
-            combined_params = metadata.get("combined_params", {})
+            combined_params = metadata.get("parameters", {})
 
             if not params and not combined_params:
                 self.log_violation(
@@ -149,7 +149,7 @@ class TrainingCheck(BaseCheck):
                 continue
             try:
                 # Get parameters
-                combined_params = metadata.get("combined_params", {})
+                combined_params = metadata.get("parameters", {})
                 dataset_params = combined_params.get("dataset", {})
                 reader_params = combined_params.get("reader", {})
 
@@ -224,7 +224,7 @@ class TrainingCheck(BaseCheck):
         for summary, metadata, _ in self.submissions_logs.run_files:
             if metadata is None:
                 continue
-            dataset_params = metadata.get("combined_params", {}).get("dataset", {})
+            dataset_params = metadata.get("parameters", {}).get("dataset", {})
             num_files = int(dataset_params.get("num_files_train", 0))
             record_length = float(dataset_params.get("record_length_bytes", 0))
             num_samples_per_file = int(dataset_params.get("num_samples_per_file", 1))
@@ -235,7 +235,7 @@ class TrainingCheck(BaseCheck):
         for summary, metadata, _ in self.submissions_logs.datagen_files:
             if metadata is None:
                 continue
-            dataset_params = metadata.get("combined_params", {}).get("dataset", {})
+            dataset_params = metadata.get("parameters", {}).get("dataset", {})
             num_files = int(dataset_params.get("num_files_train", 0))
             record_length = float(dataset_params.get("record_length_bytes", 0))
             num_samples_per_file = int(dataset_params.get("num_samples_per_file", 1))
@@ -300,11 +300,22 @@ class TrainingCheck(BaseCheck):
                 )
                 valid = False
             elif num_files_train > expected_train:
-                self.log_violation(
+                # Downgraded to warning: expected_train comes from the
+                # NUM_DATASET_TRAIN_FILES placeholder in
+                # submission_checker/constants.py (e.g. unet3d=14000), which
+                # is still marked "# TODO: Ask for correct values" upstream.
+                # Real submissions can legitimately exceed it (host-memory
+                # multiplier inflates num_files_train well past 14000), so
+                # firing this as an error would block every otherwise-
+                # conforming run. Restore log_violation once the canonical
+                # dataset cardinalities ship upstream.
+                self.warn_violation(
                     "3.3.1", "trainingRunDataMatchesDatasize", self.path,
-                    "num_files_train should be lower than in dataset",
+                    f"num_files_train ({num_files_train}) exceeds expected "
+                    f"cardinality ({expected_train}); expected value is a "
+                    "known upstream placeholder — treat as informational "
+                    "until canonical dataset cardinalities are published",
                 )
-                valid = False
 
             if num_files_eval is None:
                 self.log_violation(
@@ -313,11 +324,16 @@ class TrainingCheck(BaseCheck):
                 )
                 valid = False
             elif num_files_eval > expected_eval:
-                self.log_violation(
+                # Same rationale as num_files_train above — placeholder
+                # expected value; downgrade to warning to avoid blocking
+                # otherwise-conforming submissions.
+                self.warn_violation(
                     "3.3.1", "trainingRunDataMatchesDatasize", self.path,
-                    "num_files_eval should be lower than in dataset",
+                    f"num_files_eval ({num_files_eval}) exceeds expected "
+                    f"cardinality ({expected_eval}); expected value is a "
+                    "known upstream placeholder — treat as informational "
+                    "until canonical dataset cardinalities are published",
                 )
-                valid = False
 
         return valid
     
@@ -576,7 +592,7 @@ class TrainingCheck(BaseCheck):
             verification = metadata.get("verification", "open")
 
             if verification == "closed":
-                params_dict = metadata.get("params_dict", {})
+                params_dict = metadata.get("override_parameters", {})
 
                 for param_key in params_dict.keys():
                     # Tool-injected params (skip_listing, data_folder derived
@@ -639,7 +655,7 @@ class TrainingCheck(BaseCheck):
             verification = metadata.get("verification", "open")
 
             if verification == "open":
-                params_dict = metadata.get("params_dict", {})
+                params_dict = metadata.get("override_parameters", {})
 
                 for param_key in params_dict.keys():
                     # Tool-injected params (skip_listing, data_folder derived
@@ -736,13 +752,20 @@ class TrainingCheck(BaseCheck):
             args = metadata.get("args", {})
             ok, df_found = _check_filesystem_separation(args, logfile_path)
             if not df_found:
-                self.log_violation(
+                # TODO-001: runtime df capture is missing in mlpstorage CLI
+                # (`Benchmark._execute_command` in benchmarks/base.py never invokes
+                # `df` before/after the DLIO subprocess). Emit a warning rather
+                # than an error so conforming submissions are not blocked on
+                # an upstream producer gap. Restore log_violation once the
+                # writer side ships the `df` block in *_run.stdout.log.
+                self.warn_violation(
                     "3.4.2", "trainingMlpstorageFilesystemCheck", logfile_path,
-                    "df output not found",
+                    "df output not found (mlpstorage CLI does not yet capture df; TODO-001)",
                 )
-                valid = False
                 continue
             if not ok:
+                # df WAS found (e.g. submitter manually injected it), so this
+                # is a real same-mount finding and remains an error.
                 self.log_violation(
                     "3.4.2", "trainingMlpstorageFilesystemCheck", logfile_path,
                     "data_dir and results_dir are on the same filesystem",

--- a/mlpstorage_py/submission_checker/checks/vdb_checks.py
+++ b/mlpstorage_py/submission_checker/checks/vdb_checks.py
@@ -877,7 +877,7 @@ class VdbCheck(BaseCheck):
                     self.path, ts,
                 )
                 continue
-            params_dict = metadata.get("params_dict", {}) or {}
+            params_dict = metadata.get("override_parameters", {}) or {}
             for param_key in params_dict.keys():
                 if param_key not in _CLOSED_ALLOWED_PARAMS:
                     self.log_violation(
@@ -938,7 +938,7 @@ class VdbCheck(BaseCheck):
                     backend, self.path, ts,
                 )
                 continue
-            params_dict = metadata.get("params_dict", {}) or {}
+            params_dict = metadata.get("override_parameters", {}) or {}
             for param_key in params_dict.keys():
                 if param_key not in allowed_params:
                     self.log_violation(

--- a/mlpstorage_py/submission_checker/constants.py
+++ b/mlpstorage_py/submission_checker/constants.py
@@ -59,9 +59,13 @@ PARSER_MAP = {
 }
 
 DATAGEN_REQUIRED_FILES = {
-    "v2.0": [r"training_datagen\.stdout.log", r"training_datagen.stderr\.log", r".*output\.json$", r".*per_epoch_stats\.json$", r".*summary\.json$", r"dlio\.log"],
-    "v3.0": [r"training_datagen\.stdout.log", r"training_datagen.stderr\.log", r".*output\.json$", r".*per_epoch_stats\.json$", r",*summary\.json$", r"dlio\.log"],
-    "default": [r"training_datagen\.stdout.log", r"training_datagen.stderr\.log", r".*output\.json$", r".*per_epoch_stats\.json$", r".*summary\.json$", r"dlio\.log"],
+    # DLIO datagen runs with workflow.generate_data=True, workflow.train=False, so it
+    # does NOT emit the *output.json / *per_epoch_stats.json / *summary.json files that
+    # the training loop produces. The required-files list reflects only what datagen
+    # actually writes plus the mlpstorage-injected per-datagen metadata.
+    "v2.0": [r"training_datagen\.stdout\.log$", r"training_datagen\.stderr\.log$", r"dlio\.log$", r"training_.*_metadata\.json$"],
+    "v3.0": [r"training_datagen\.stdout\.log$", r"training_datagen\.stderr\.log$", r"dlio\.log$", r"training_.*_metadata\.json$"],
+    "default": [r"training_datagen\.stdout\.log$", r"training_datagen\.stderr\.log$", r"dlio\.log$", r"training_.*_metadata\.json$"],
 }
 
 DATAGEN_REQUIRED_FOLDERS = {

--- a/mlpstorage_py/tests/test_bug03_closed_mpi_processes.py
+++ b/mlpstorage_py/tests/test_bug03_closed_mpi_processes.py
@@ -61,7 +61,10 @@ def _make_check(
 
     metadata = {
         "verification": verification,
-        "params_dict": {"checkpoint.mode": checkpoint_mode},
+        # Key name aligns with what mlpstorage writes to *_metadata.json
+        # (parameters / override_parameters), matching the reader sites in
+        # checkpointing_checks.py:223 / .py:504.
+        "override_parameters": {"checkpoint.mode": checkpoint_mode},
         "args": {
             "model": model,
             "num_processes": num_processes,

--- a/mlpstorage_py/tests/test_checkpointing_check_phase2.py
+++ b/mlpstorage_py/tests/test_checkpointing_check_phase2.py
@@ -438,8 +438,11 @@ class TestChkpt06_CheckpointFilesystemCheck:
     def test_df_not_found_emits_4_4_2_missing(self, tmp_path, mock_logger):
         """No df logfile → [4.4.2 checkpointFilesystemCheck] 'df output not found'.
 
-        This is the intentional fail-on-real-submission path per D-B4 / D-B6.
         TODO-001: runtime df capture in mlpstorage CLI is the long-term fix.
+        Until DLIO (or mlpstorage) emits the `df` block in *_run.stdout.log,
+        df-not-found is emitted as a warning (not an error) so conforming
+        submissions are not blocked on an upstream producer gap. The check
+        therefore returns True; the violation surfaces on mock_logger.warnings.
         """
         from mlpstorage_py.tests.conftest import build_submission
         root = build_submission(
@@ -450,11 +453,14 @@ class TestChkpt06_CheckpointFilesystemCheck:
         )
         check = _run_checkpointing_check(root, mock_logger)
         result = check.checkpoint_filesystem_check()
-        assert result is False
-        assert len(mock_logger.errors) >= 1
-        assert mock_logger.errors[0].startswith("[4.4.2 checkpointFilesystemCheck]"), \
-            f"Expected [4.4.2 checkpointFilesystemCheck]; got {mock_logger.errors[0]!r}"
-        assert "df output not found" in mock_logger.errors[0]
+        assert result is True
+        assert mock_logger.errors == [], (
+            f"df-not-found is a warning (TODO-001); errors must stay empty. Got: {mock_logger.errors}"
+        )
+        assert len(mock_logger.warnings) >= 1
+        assert mock_logger.warnings[0].startswith("[4.4.2 checkpointFilesystemCheck]"), \
+            f"Expected [4.4.2 checkpointFilesystemCheck]; got {mock_logger.warnings[0]!r}"
+        assert "df output not found" in mock_logger.warnings[0]
 
     def test_object_api_silent_passes(self, tmp_path, mock_logger):
         """benchmark_API='object' → silent-pass; no errors emitted (D-B7)."""

--- a/mlpstorage_py/tests/test_training_check_phase2.py
+++ b/mlpstorage_py/tests/test_training_check_phase2.py
@@ -182,8 +182,11 @@ class TestTrain02_MlpstorageFilesystemCheck:
     def test_df_not_found_emits_3_4_2_missing(self, tmp_path, mock_logger):
         """No df logfile → [3.4.2 trainingMlpstorageFilesystemCheck] 'df output not found'.
 
-        This is the intentional fail-on-real-submission path per D-B4 / D-B6.
         TODO-001: runtime df capture in mlpstorage CLI is the long-term fix.
+        Until DLIO (or mlpstorage) emits the `df` block in *_run.stdout.log,
+        df-not-found is emitted as a warning (not an error) so conforming
+        submissions are not blocked on an upstream producer gap. The check
+        therefore returns True; the violation surfaces on mock_logger.warnings.
         """
         from mlpstorage_py.tests.conftest import build_submission
         root = build_submission(
@@ -194,12 +197,15 @@ class TestTrain02_MlpstorageFilesystemCheck:
         )
         check = _run_training_check(root, mock_logger)
         result = check.mlpstorage_filesystem_check()
-        assert result is False
-        assert len(mock_logger.errors) >= 1
-        assert mock_logger.errors[0].startswith("[3.4.2 trainingMlpstorageFilesystemCheck]"), \
-            f"Expected prefix [3.4.2 trainingMlpstorageFilesystemCheck]; got {mock_logger.errors[0]!r}"
-        assert "df output not found" in mock_logger.errors[0], \
-            f"Expected 'df output not found' in error; got {mock_logger.errors[0]!r}"
+        assert result is True
+        assert mock_logger.errors == [], (
+            f"df-not-found is a warning (TODO-001); errors must stay empty. Got: {mock_logger.errors}"
+        )
+        assert len(mock_logger.warnings) >= 1
+        assert mock_logger.warnings[0].startswith("[3.4.2 trainingMlpstorageFilesystemCheck]"), \
+            f"Expected prefix [3.4.2 trainingMlpstorageFilesystemCheck]; got {mock_logger.warnings[0]!r}"
+        assert "df output not found" in mock_logger.warnings[0], \
+            f"Expected 'df output not found' in warning; got {mock_logger.warnings[0]!r}"
 
     def test_object_api_silent_passes(self, tmp_path, mock_logger):
         """benchmark_API='object' → silent-pass; no errors emitted (D-B7)."""
@@ -252,10 +258,11 @@ class TestTrain02_DfBlockNotFoundIsRuleIdTagged:
     """
 
     def test_df_not_found_violation_includes_logfile_path(self, tmp_path, mock_logger):
-        """df-not-found error must include 'training_run.stdout.log' in the message.
+        """df-not-found warning must include 'training_run.stdout.log' in the message.
 
-        This ensures submitters can grep for the failing logfile path from the
-        violation output.
+        TODO-001: until DLIO/mlpstorage capture df, df-not-found is a warning
+        (not an error). The submitter-grep contract still applies — the
+        logfile path must appear in the warning message.
         """
         from mlpstorage_py.tests.conftest import build_submission
         root = build_submission(
@@ -265,12 +272,12 @@ class TestTrain02_DfBlockNotFoundIsRuleIdTagged:
         )
         check = _run_training_check(root, mock_logger)
         check.mlpstorage_filesystem_check()
-        assert len(mock_logger.errors) >= 1
+        assert len(mock_logger.warnings) >= 1
         # The violation message must reference the logfile path
         assert any(
             "training_run.stdout.log" in m
-            for m in mock_logger.errors
+            for m in mock_logger.warnings
         ), (
-            f"Expected 'training_run.stdout.log' in at least one error message; "
-            f"got {mock_logger.errors}"
+            f"Expected 'training_run.stdout.log' in at least one warning message; "
+            f"got {mock_logger.warnings}"
         )

--- a/mlpstorage_py/tests/test_training_check_tool_injected_params.py
+++ b/mlpstorage_py/tests/test_training_check_tool_injected_params.py
@@ -41,7 +41,9 @@ def _make_run_tuple(params_dict, verification='closed'):
     summary = {}
     metadata = {
         'verification': verification,
-        'params_dict': params_dict,
+        # `override_parameters` is the key mlpstorage actually writes; the
+        # reader site in training_checks.py:595/:658 reads from there.
+        'override_parameters': params_dict,
     }
     return (summary, metadata, '20260624_000000')
 

--- a/mlpstorage_py/tests/test_vdb_checks.py
+++ b/mlpstorage_py/tests/test_vdb_checks.py
@@ -150,10 +150,13 @@ def _summary_datagen(**overrides):
 
 
 def _metadata(**arg_overrides):
-    """Build a metadata.json dict with args + params_dict.
+    """Build a metadata.json dict with args + override_parameters.
 
-    Pop "params_dict" to override the params dict itself; everything else
-    is treated as an args.* override.
+    Pop "params_dict" to override the override_parameters dict itself; everything
+    else is treated as an args.* override. The keyword-argument name on this
+    helper is kept as `params_dict` for call-site compatibility, but the
+    metadata key it lands under is `override_parameters` — the name mlpstorage
+    actually writes and that vdb_checks.py:880/:941 reads.
     """
     params_dict = arg_overrides.pop("params_dict", None)
     args = {
@@ -163,7 +166,7 @@ def _metadata(**arg_overrides):
     args.update(arg_overrides)
     return {
         "args": args,
-        "params_dict": params_dict if params_dict is not None else {},
+        "override_parameters": params_dict if params_dict is not None else {},
     }
 
 


### PR DESCRIPTION
This pull request introduces several important improvements and bug fixes to the report generation and submission checking logic for mlpstorage. The most significant changes are the introduction of robust directory resolution in the report generator, improved handling of output directories, updates to parameter extraction to match new metadata conventions, and adjustments to error/warning reporting to avoid blocking submissions on known upstream issues.

**Report Generation Improvements**
- Enhanced the `ReportGenerator` to automatically detect and resolve the correct results directory, supporting both legacy and canonical mlpstorage submission tree layouts. This ensures reports are generated for the intended system and benchmark-type directories, improving compatibility and correctness. (`mlpstorage_py/report_generator.py`) [[1]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381R79-R92) [[2]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381R110-R166)
- Added support for specifying an `--output-dir` for generated report files, defaulting to the resolved results directory if not provided. Output files (`results.json`, `results.csv`) are now consistently written to this location. (`mlpstorage_py/report_generator.py`) [[1]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381R79-R92) [[2]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381L417-R500)

**Submission Checker Parameter Handling**
- Updated all checker modules to extract parameters from the correct metadata keys (`parameters` and `override_parameters`), replacing legacy keys (`combined_params`, `params_dict`). This aligns validation logic with the current metadata structure and avoids missing or misinterpreted parameters. (`mlpstorage_py/submission_checker/checks/checkpointing_checks.py`, `mlpstorage_py/submission_checker/checks/training_checks.py`, `mlpstorage_py/submission_checker/checks/vdb_checks.py`) [[1]](diffhunk://#diff-38ec20461200130fca257ee40a5beba92f4c628dc94b82d310fd7f641c7dc415L160-R160) [[2]](diffhunk://#diff-38ec20461200130fca257ee40a5beba92f4c628dc94b82d310fd7f641c7dc415L223-R223) [[3]](diffhunk://#diff-38ec20461200130fca257ee40a5beba92f4c628dc94b82d310fd7f641c7dc415L504-R504) [[4]](diffhunk://#diff-d7f0f03842767044c515db00cf478b2990b140629ded259ed5d5ba52ec1bd6e7L107-R107) [[5]](diffhunk://#diff-d7f0f03842767044c515db00cf478b2990b140629ded259ed5d5ba52ec1bd6e7L152-R152) [[6]](diffhunk://#diff-d7f0f03842767044c515db00cf478b2990b140629ded259ed5d5ba52ec1bd6e7L227-R227) [[7]](diffhunk://#diff-d7f0f03842767044c515db00cf478b2990b140629ded259ed5d5ba52ec1bd6e7L238-R238) [[8]](diffhunk://#diff-d7f0f03842767044c515db00cf478b2990b140629ded259ed5d5ba52ec1bd6e7L579-R595) [[9]](diffhunk://#diff-d7f0f03842767044c515db00cf478b2990b140629ded259ed5d5ba52ec1bd6e7L642-R658) [[10]](diffhunk://#diff-844dd7771421c8a99de0f340f4197bcc80eeec0c6388784dee52bc5851514ddbL880-R880) [[11]](diffhunk://#diff-844dd7771421c8a99de0f340f4197bcc80eeec0c6388784dee52bc5851514ddbL941-R941)

**Error and Warning Reporting Adjustments**
- Downgraded certain violations to warnings (e.g., missing `df` output in filesystem checks, dataset cardinality checks) to avoid blocking submissions due to known upstream limitations or placeholder values. This ensures that conforming submissions are not penalized for issues outside their control, with clear TODO comments for future restoration of stricter checks. (`mlpstorage_py/submission_checker/checks/checkpointing_checks.py`, `mlpstorage_py/submission_checker/checks/training_checks.py`) [[1]](diffhunk://#diff-38ec20461200130fca257ee40a5beba92f4c628dc94b82d310fd7f641c7dc415L880-R893) [[2]](diffhunk://#diff-d7f0f03842767044c515db00cf478b2990b140629ded259ed5d5ba52ec1bd6e7L303-L307) [[3]](diffhunk://#diff-d7f0f03842767044c515db00cf478b2990b140629ded259ed5d5ba52ec1bd6e7L316-L320) [[4]](diffhunk://#diff-d7f0f03842767044c515db00cf478b2990b140629ded259ed5d5ba52ec1bd6e7L739-R768)

**Datagen Required Files Update**
- Corrected the list of required files for datagen runs to reflect what is actually produced, removing references to files not generated in datagen-only workflows and ensuring the checker expects only what is present. (`mlpstorage_py/submission_checker/constants.py`)

These changes collectively improve the robustness, usability, and accuracy of report generation and submission validation.

Fixes
#598 #599 #600 #601 