### PR TITLE
fix(#601): CAP-03 FS-separation probe + sidecar-first validator

### DIFF
--- a/mlpstorage_py/benchmarks/base.py
+++ b/mlpstorage_py/benchmarks/base.py
@@ -47,7 +47,7 @@ from typing import Tuple, Dict, Any, List, Optional, Callable, Set, TYPE_CHECKIN
 from functools import wraps
 
 from mlpstorage_py.config import PARAM_VALIDATION, DATETIME_STR, MLPS_DEBUG, EXEC_TYPE
-from mlpstorage_py.errors import ConfigurationError, ErrorCode
+from mlpstorage_py.errors import ConfigurationError, ErrorCode, FileSystemError
 from mlpstorage_py.run_directory import (
     DEFAULT_COLLISION_BUMP_BUDGET,
     reserve_run_directory,
@@ -65,6 +65,7 @@ from mlpstorage_py.cluster_collector import (
     MultiHostTimeSeriesCollector,
     run_shared_fs_probe,
 )
+from mlpstorage_py.benchmarks.fs_separation_probe import probe_fs_separation
 from mlpstorage_py.progress import create_stage_progress, progress_context
 from mlpstorage_py.system_description.auto_generator import write_systemname_yaml
 from mlpstorage_py.benchmarks.capacity_gate import check_capacity_4field
@@ -976,6 +977,20 @@ class Benchmark(BenchmarkInterface, abc.ABC):
             f"_capacity_gate_destination() for CAP-01"
         )
 
+    def _fs_separation_paths(self) -> Optional[tuple]:
+        """Return the (data_or_chkpt_path, results_path) pair for CAP-03.
+
+        Return ``None`` to skip the FS-separation probe — same A8 escape
+        hatch as ``_capacity_gate_destination`` (object-storage / remote
+        DB submissions where there is no local data path to probe).
+
+        Subclasses MUST override. Issue #601 / CAP-03.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must override "
+            f"_fs_separation_paths() for CAP-03"
+        )
+
     def _pre_execution_gate(self) -> None:
         """Run all pre-execution capacity/environment gates (CAP-01 in
         Slice 3; CAP-02 shared-FS verification is appended in Slice 4 of
@@ -1025,6 +1040,89 @@ class Benchmark(BenchmarkInterface, abc.ABC):
             allow_run_as_root=getattr(self.args, 'allow_run_as_root', False),
             ssh_username=getattr(self.args, 'ssh_username', None),
         )
+        # ------------------------------------------------------------------
+        # Slice 5 / CAP-03: FS-separation probe (issue #601).
+        # ------------------------------------------------------------------
+        # Verify data_dir (or checkpoint_folder) and results_dir live on
+        # DIFFERENT filesystems via the kernel link()/EXDEV test. Writes a
+        # structured sidecar at <run_result_output>/fs_separation.json so
+        # the submission_checker validator (rules 3.4.2 / 4.4.2 / 5.4.2)
+        # has a stable artifact to read. On same-FS detection, raise
+        # FileSystemError BEFORE the workload starts (hard gate, locked
+        # design decision D-601-1). --skip-fs-separation-gate bypasses the
+        # raise but still writes the sidecar so the validator gets telemetry.
+        self._run_fs_separation_probe()
+
+    def _run_fs_separation_probe(self) -> None:
+        """Run the CAP-03 FS-separation probe and write the sidecar.
+
+        Single dispatch point so subclasses don't need to know the
+        sidecar location or skip-flag handling.
+        """
+        fs_paths = self._fs_separation_paths()
+        if fs_paths is None:
+            # A8 escape hatch — object-API runs (storage_type=object on
+            # training/checkpointing, milvus/elasticsearch/pgvector on
+            # VectorDB). No local FS to probe. Log INFO and skip; do not
+            # write a sidecar so the validator's object-API silent-pass
+            # path (training_checks.py:730 et al.) keeps owning the skip.
+            self.logger.info(
+                "CAP-03 skipped: no local data/results paths to probe "
+                "(e.g., object storage or remote vector-DB backend)"
+            )
+            return
+
+        path_a, path_b = fs_paths
+        result = probe_fs_separation(
+            path_a=path_a,
+            path_b=path_b,
+            run_uuid=self._run_uuid,
+            logger=self.logger,
+        )
+
+        # Sidecar always written — even on the skip-gate code path — so the
+        # validator can confirm the operator's intent in post-hoc audit.
+        sidecar_path = os.path.join(
+            self.run_result_output, "fs_separation.json"
+        )
+        try:
+            os.makedirs(os.path.dirname(sidecar_path) or ".", exist_ok=True)
+            with open(sidecar_path, "w", encoding="utf-8") as fd:
+                json.dump(result, fd, indent=2)
+        except OSError as exc:
+            # Sidecar-write failures don't block the run — the validator's
+            # one-release df-block fallback (D-601-3) catches the gap. Log
+            # at warning so the operator sees it.
+            self.logger.warning(
+                "CAP-03: could not write FS-separation sidecar to %s: %s",
+                sidecar_path, exc,
+            )
+
+        if result["same_filesystem"]:
+            if getattr(self.args, "skip_fs_separation_gate", False):
+                self.logger.warning(
+                    "CAP-03: data and results paths are on the SAME filesystem "
+                    "(%s vs %s); proceeding because --skip-fs-separation-gate "
+                    "is set. This run will fail submission_checker rules "
+                    "3.4.2 / 4.4.2 / 5.4.2.",
+                    path_a, path_b,
+                )
+                return
+            raise FileSystemError(
+                (
+                    f"CAP-03: data and results paths are on the same filesystem.\n"
+                    f"  data_or_chkpt_path: {path_a}\n"
+                    f"  results_path:       {path_b}\n"
+                    f"  method:             link_exdev\n"
+                    f"Rules 3.4.2 / 4.4.2 / 5.4.2 require these be on different "
+                    f"filesystems so results-side writes can't pollute the dataset-side "
+                    f"page cache. Re-run with --results-dir on a separate mount, or "
+                    f"pass --skip-fs-separation-gate for non-submission dev runs."
+                ),
+                path=path_b,
+                operation="cap03-gate",
+                code=ErrorCode.FS_INVALID_STRUCTURE,
+            )
 
     @abc.abstractmethod
     def _run(self) -> int:

--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -851,6 +851,21 @@ class TrainingBenchmark(DLIOBenchmark):
             return None
         return self.args.data_dir
 
+    def _fs_separation_paths(self) -> Optional[tuple]:
+        """Return ``(data_dir, results_dir)`` for CAP-03 (issue #601).
+
+        Object-storage runs skip the probe via the same A8 escape hatch
+        as CAP-01 — the dataset side is an s3:// URI with no local FS
+        identity to probe against the local results_dir.
+        """
+        if self._is_object_storage():
+            return None
+        data_dir = getattr(self.args, "data_dir", None)
+        results_dir = getattr(self.args, "results_dir", None)
+        if not data_dir or not results_dir:
+            return None
+        return (data_dir, results_dir)
+
     def datasize(self):
         # CAP-01: fail fast BEFORE the size calc prints its results so a
         # starved disk surfaces with the locked four-field message rather
@@ -1025,6 +1040,21 @@ class CheckpointingBenchmark(DLIOBenchmark):
         if not cf:
             return None
         return os.path.join(cf, self.args.model)
+
+    def _fs_separation_paths(self) -> Optional[tuple]:
+        """Return ``(checkpoint_folder, results_dir)`` for CAP-03 (issue #601).
+
+        For checkpointing the dataset analog is the checkpoint_folder —
+        rule 4.4.2 verifies checkpoint_folder vs results_dir live on
+        different filesystems. Object-storage runs skip via A8.
+        """
+        if self._is_object_storage():
+            return None
+        cf = getattr(self.args, "checkpoint_folder", None)
+        results_dir = getattr(self.args, "results_dir", None)
+        if not cf or not results_dir:
+            return None
+        return (cf, results_dir)
 
     def datasize(self):
         # CAP-01: fail fast BEFORE the rank-by-rank size table prints.

--- a/mlpstorage_py/benchmarks/fs_separation_probe.py
+++ b/mlpstorage_py/benchmarks/fs_separation_probe.py
@@ -1,0 +1,179 @@
+"""CAP-03 FS-separation probe — direct kernel test for filesystem separation.
+
+Rules 3.4.2 / 4.4.2 / 5.4.2 verify that the data/checkpoint directory and
+the results directory live on DIFFERENT filesystems. The pre-#601 contract
+relied on grepping a ``df`` block out of the run log, which has two
+problems:
+
+  1. The producer (mlpstorage CLI) never wrote a ``df`` block, so every
+     conforming file-API submission hard-failed the rule (issue #601).
+  2. Text-scraping ``df`` output is a brittle proxy: multi-line device-name
+     wrapping, anchor regex fragility, and substring-match weakness in the
+     mount-point column (see ``submission_checker/checks/helpers.py:87-90,
+     179-185``).
+
+CAP-03 replaces the proxy with the direct kernel test: ``os.link()`` returning
+``EXDEV`` is the kernel's authoritative "different filesystem" signal — the
+errno is literally defined as "the operation would have crossed filesystems."
+
+This module is the producer-side primitive. The gate that calls it lives in
+``Benchmark._pre_execution_gate`` (`base.py`); the validator that reads the
+sidecar lives in ``submission_checker/checks/helpers.py:read_fs_separation_sidecar``.
+
+Public surface:
+    probe_fs_separation(path_a, path_b, run_uuid, logger=None) -> dict
+
+Locked design decisions (issue #601, agreed before implementation):
+  D-601-1. Hard gate — same_filesystem=True raises FileSystemError BEFORE
+           the workload starts. Same posture as CAP-01 / CAP-02.
+  D-601-2. Rank-0 only. No MPI gather. (Single-host today; extend later if
+           heterogeneous-results-dir setups appear.)
+  D-601-3. Pre-cutover validator fallback to df-block for one release.
+           This module's contract is not affected by D-601-3.
+  D-601-4. finally-block sentinel cleanup; unlink failures are
+           logger.warning, not raise — mirrors CAP-02 D-44.
+"""
+
+from __future__ import annotations
+
+import datetime
+import errno
+import os
+import socket
+from typing import Optional
+
+from mlpstorage_py.errors import ErrorCode, FileSystemError
+
+
+_SENTINEL_PREFIX = ".mlpstorage-fs-sep-probe-"
+
+
+def _now_iso_utc() -> str:
+    """Return the current UTC time in ISO-8601 with a Z suffix."""
+    return datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def _safe_unlink(path: str, logger: Optional[object]) -> None:
+    """Best-effort unlink — warn on failure, never raise (D-601-4 / CAP-02 D-44).
+
+    A leftover sentinel is cosmetic; failing the gate over an unlink error
+    would mask the actual gate verdict.
+    """
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        if logger is not None:
+            logger.warning(
+                "CAP-03: unlink of probe sentinel %s failed: %s "
+                "(leftover sentinel is cosmetic)",
+                path, exc,
+            )
+
+
+def probe_fs_separation(
+    path_a: str,
+    path_b: str,
+    run_uuid: str,
+    logger: Optional[object] = None,
+) -> dict:
+    """Probe whether ``path_a`` and ``path_b`` live on the same filesystem.
+
+    Mechanism: create a sentinel in ``path_a`` and ``os.link()`` it into
+    ``path_b``. Linux returns ``EXDEV`` ("Invalid cross-device link") iff
+    the operation would have crossed filesystems — the kernel's
+    authoritative answer to the question the validator is asking.
+
+    Args:
+        path_a: First path — by convention, the data/checkpoint directory.
+        path_b: Second path — by convention, the results directory.
+        run_uuid: Per-instance UUID (from ``Benchmark._run_uuid``) used to
+            embed in the sentinel filename so concurrent runs against the
+            same data directory cannot collide on the sentinel path
+            (Pitfall 7).
+        logger: Optional logger. Used only for unlink-failure warnings on
+            the cleanup path (D-601-4). The happy path is silent (SC#6).
+
+    Returns:
+        Dict matching the locked sidecar shape::
+
+            {
+                "version": 1,
+                "method": "link_exdev",
+                "data_or_chkpt_path": str,
+                "results_path": str,
+                "data_or_chkpt_realpath": str,
+                "results_realpath": str,
+                "same_filesystem": bool,
+                "probed_at": "<ISO-8601 UTC with Z>",
+                "probed_by_rank": int,
+                "probed_by_host": str,
+            }
+
+    Raises:
+        FileSystemError (FS_PERMISSION_DENIED): ``os.link()`` raised an
+            errno other than ``EXDEV`` — typically ``EACCES`` on a
+            restricted parent, ``EROFS`` on a read-only mount, or
+            ``ENOSPC`` on a full filesystem. The gate is a safety check;
+            an inability to verify FS separation MUST NOT be silently
+            treated as "verified safe" (CAP-01 precedent).
+    """
+    sentinel_name = f"{_SENTINEL_PREFIX}{run_uuid}"
+    src = os.path.join(path_a, sentinel_name)
+    dst = os.path.join(path_b, sentinel_name)
+
+    same_filesystem: Optional[bool] = None
+
+    try:
+        # Create the source sentinel — open with O_EXCL so a leftover from
+        # a crashed earlier run gets a hard failure rather than silent
+        # reuse (which could trigger a stale-link surprise).
+        try:
+            fd = os.open(src, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.close(fd)
+        except OSError as exc:
+            raise FileSystemError(
+                f"CAP-03: cannot create probe sentinel at {src}: {exc}",
+                path=path_a,
+                operation="cap03-probe-create",
+                code=ErrorCode.FS_PERMISSION_DENIED,
+            ) from exc
+
+        try:
+            os.link(src, dst)
+            same_filesystem = True
+        except OSError as exc:
+            if exc.errno == errno.EXDEV:
+                same_filesystem = False
+            else:
+                # EACCES / EROFS / ENOSPC / ENOENT / EPERM — cannot verify.
+                raise FileSystemError(
+                    (
+                        f"CAP-03: cannot probe filesystem separation between "
+                        f"{path_a} and {path_b}: {exc}"
+                    ),
+                    path=path_b,
+                    operation="cap03-probe-link",
+                    code=ErrorCode.FS_PERMISSION_DENIED,
+                ) from exc
+    finally:
+        # Always attempt cleanup. unlink failures are logged, not raised
+        # (D-601-4 mirrors CAP-02 D-44).
+        _safe_unlink(src, logger)
+        _safe_unlink(dst, logger)
+
+    return {
+        "version": 1,
+        "method": "link_exdev",
+        "data_or_chkpt_path": path_a,
+        "results_path": path_b,
+        "data_or_chkpt_realpath": os.path.realpath(path_a),
+        "results_realpath": os.path.realpath(path_b),
+        "same_filesystem": bool(same_filesystem),
+        "probed_at": _now_iso_utc(),
+        "probed_by_rank": 0,
+        "probed_by_host": socket.gethostname(),
+    }

--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -394,6 +394,13 @@ class KVCacheBenchmark(Benchmark):
         """
         return self.cache_dir if self.cache_dir else None
 
+    def _fs_separation_paths(self):
+        """Return ``None`` — kvcache has no separate dataset/results FS
+        invariant. The cache_dir IS the working set; rules 3.4.2 / 4.4.2 /
+        5.4.2 don't apply to the kvcache benchmark.
+        """
+        return None
+
     # ------------------------------------------------------------------
     # Per-option argv build + rank layout (from main)
     # ------------------------------------------------------------------

--- a/mlpstorage_py/benchmarks/vectordbbench.py
+++ b/mlpstorage_py/benchmarks/vectordbbench.py
@@ -734,6 +734,17 @@ class VectorDBBenchmark(Benchmark):
         """
         return None
 
+    def _fs_separation_paths(self):
+        """Return ``None`` — VectorDB has no local data path to probe.
+
+        For the same A8 reason as ``_capacity_gate_destination``: VDB
+        data lives inside a remote (or out-of-process) engine; there is
+        no submitter-owned local path that maps to the dataset for
+        rule 5.4.2's purposes. CAP-03 is skipped via the
+        ``_run_fs_separation_probe`` None-paths branch.
+        """
+        return None
+
     def execute_datagen(self) -> int:
         """Execute VectorDB data generation / load."""
         # CAP-01 (A8 escape hatch — destination is always None for VDB).

--- a/mlpstorage_py/cli/common_args.py
+++ b/mlpstorage_py/cli/common_args.py
@@ -321,6 +321,18 @@ def add_universal_arguments(parser, req_results, req_systemname=False):
         action="store_true",
         help="Skip environment validation (MPI, SSH, DLIO checks). Useful for debugging.",
     )
+    validation_args.add_argument(
+        "--skip-fs-separation-gate",
+        action="store_true",
+        help=(
+            "Bypass the CAP-03 hard gate that raises when data/checkpoint and "
+            "results directories live on the same filesystem. The probe still "
+            "runs and writes fs_separation.json so the validator has telemetry, "
+            "but no exception is raised. Use only for dev runs that are not "
+            "intended for submission — rules 3.4.2 / 4.4.2 / 5.4.2 will still "
+            "fail at validation time."
+        ),
+    )
 
 
 def add_mpi_arguments(parser):

--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -4,7 +4,12 @@ from ..constants import *
 from ..configuration.configuration import Config
 from ..loader import SubmissionLogs
 from ..rule_registry import rule
-from .helpers import _check_filesystem_separation, _pair_checkpoint_runs, _parse_iso_gap
+from .helpers import (
+    _check_filesystem_separation,
+    _pair_checkpoint_runs,
+    _parse_iso_gap,
+    read_fs_separation_sidecar,
+)
 
 import os
 import re
@@ -868,7 +873,19 @@ class CheckpointingCheck(BaseCheck):
         if self._get_benchmark_api() == "object":
             return valid
         for summary, metadata, timestamp in self._iter_valid_files():
-            logfile_path = os.path.join(self.checkpointing_path, timestamp, "checkpointing_run.stdout.log")
+            run_dir = os.path.join(self.checkpointing_path, timestamp)
+            logfile_path = os.path.join(run_dir, "checkpointing_run.stdout.log")
+            # CAP-03 sidecar is authoritative (#601). Pre-cutover df-block
+            # fallback retained for one release (D-601-3).
+            sidecar = read_fs_separation_sidecar(run_dir)
+            if sidecar is not None:
+                if sidecar.get("same_filesystem"):
+                    self.log_violation(
+                        "4.4.2", "checkpointFilesystemCheck", logfile_path,
+                        "checkpoint_folder and results_dir are on the same filesystem",
+                    )
+                    valid = False
+                continue
             args = metadata.get("args", {})
             # For checkpointing, checkpoint_folder is the "data path" analog (RESEARCH.md).
             chkpt_args = {

--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -894,16 +894,15 @@ class CheckpointingCheck(BaseCheck):
             }
             ok, df_found = _check_filesystem_separation(chkpt_args, logfile_path)
             if not df_found:
-                # TODO-001: runtime df capture is missing in mlpstorage CLI
-                # (`Benchmark._execute_command` in benchmarks/base.py never invokes
-                # `df` before/after the DLIO subprocess). Emit a warning rather
-                # than an error so conforming submissions are not blocked on
-                # an upstream producer gap. Restore log_violation once the
-                # writer side ships the `df` block in *_run.stdout.log.
-                self.warn_violation(
+                # D-B8: no CAP-03 sidecar AND no df block → no evidence of
+                # FS separation at all. Fire a hard violation so producers
+                # that predate #601 and never captured df cannot silently
+                # pass 4.4.2.
+                self.log_violation(
                     "4.4.2", "checkpointFilesystemCheck", logfile_path,
-                    "df output not found (mlpstorage CLI does not yet capture df; TODO-001)",
+                    "fs_separation.json sidecar not found; df block also absent",
                 )
+                valid = False
                 continue
             if not ok:
                 # df WAS found (e.g. submitter manually injected it), so this

--- a/mlpstorage_py/submission_checker/checks/helpers.py
+++ b/mlpstorage_py/submission_checker/checks/helpers.py
@@ -24,6 +24,7 @@ References:
 """
 
 import datetime
+import json
 import logging
 import os
 import re
@@ -38,6 +39,48 @@ from ..tools.code_image import (
     MissingHashFile,
     MalformedHashFile,
 )
+
+
+# ---------------------------------------------------------------------------
+# CAP-03 FS-separation sidecar reader (#601)
+# ---------------------------------------------------------------------------
+#
+# Producer side (mlpstorage_py/benchmarks/fs_separation_probe.py +
+# Benchmark._run_fs_separation_probe) writes
+# ``<run_dir>/fs_separation.json`` at pre-execution. This is the
+# authoritative artifact for rules 3.4.2 / 4.4.2 / 5.4.2; the old df-block
+# parser remains for one release as a pre-cutover fallback (D-601-3).
+
+_FS_SEPARATION_SIDECAR_NAME = "fs_separation.json"
+
+
+def read_fs_separation_sidecar(run_dir: str) -> dict | None:
+    """Return the parsed CAP-03 sidecar from ``<run_dir>/fs_separation.json``.
+
+    Args:
+        run_dir: Absolute path to the per-timestamp run directory that
+            holds the sidecar (the same dir that holds
+            ``<bench>_run.stdout.log``).
+
+    Returns:
+        Parsed sidecar dict on success. ``None`` if the sidecar is
+        absent or unreadable (FileNotFoundError, malformed JSON, OSError).
+        The rule sites treat ``None`` as "no sidecar — fall through to
+        the df-block fallback".
+    """
+    sidecar_path = os.path.join(run_dir, _FS_SEPARATION_SIDECAR_NAME)
+    try:
+        with open(sidecar_path, "r", encoding="utf-8") as fd:
+            return json.load(fd)
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        _LOG.warning(
+            "CAP-03 sidecar at %s could not be read (%s); falling back to "
+            "df-block parser",
+            sidecar_path, exc,
+        )
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -769,16 +769,15 @@ class TrainingCheck(BaseCheck):
             args = metadata.get("args", {})
             ok, df_found = _check_filesystem_separation(args, logfile_path)
             if not df_found:
-                # TODO-001: runtime df capture is missing in mlpstorage CLI
-                # (`Benchmark._execute_command` in benchmarks/base.py never invokes
-                # `df` before/after the DLIO subprocess). Emit a warning rather
-                # than an error so conforming submissions are not blocked on
-                # an upstream producer gap. Restore log_violation once the
-                # writer side ships the `df` block in *_run.stdout.log.
-                self.warn_violation(
+                # D-B8: no CAP-03 sidecar AND no df block → no evidence of
+                # FS separation at all. Fire a hard violation so producers
+                # that predate #601 and never captured df cannot silently
+                # pass 3.4.2.
+                self.log_violation(
                     "3.4.2", "trainingMlpstorageFilesystemCheck", logfile_path,
-                    "df output not found (mlpstorage CLI does not yet capture df; TODO-001)",
+                    "fs_separation.json sidecar not found; df block also absent",
                 )
+                valid = False
                 continue
             if not ok:
                 # df WAS found (e.g. submitter manually injected it), so this

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -4,7 +4,11 @@ from ..constants import *
 from ..configuration.configuration import Config
 from ..loader import SubmissionLogs
 from ..rule_registry import rule
-from .helpers import _check_filesystem_separation, _check_code_image_layered
+from .helpers import (
+    _check_filesystem_separation,
+    _check_code_image_layered,
+    read_fs_separation_sidecar,
+)
 
 # Shared with the in-process verifier (mlpstorage_py.rules.run_checkers.training)
 # so both checkers stay in lockstep about which dotted-keys the mlpstorage
@@ -732,7 +736,20 @@ class TrainingCheck(BaseCheck):
                     self.path, timestamp,
                 )
                 continue
-            logfile_path = os.path.join(self.run_path, timestamp, "training_run.stdout.log")
+            run_dir = os.path.join(self.run_path, timestamp)
+            logfile_path = os.path.join(run_dir, "training_run.stdout.log")
+            # CAP-03 sidecar is the authoritative input (#601). The
+            # df-block parser remains for one release as a pre-cutover
+            # fallback (D-601-3) — removed in v3.1.
+            sidecar = read_fs_separation_sidecar(run_dir)
+            if sidecar is not None:
+                if sidecar.get("same_filesystem"):
+                    self.log_violation(
+                        "3.4.2", "trainingMlpstorageFilesystemCheck", logfile_path,
+                        "data_dir and results_dir are on the same filesystem",
+                    )
+                    valid = False
+                continue
             args = metadata.get("args", {})
             ok, df_found = _check_filesystem_separation(args, logfile_path)
             if not df_found:

--- a/mlpstorage_py/submission_checker/checks/vdb_checks.py
+++ b/mlpstorage_py/submission_checker/checks/vdb_checks.py
@@ -33,7 +33,11 @@ from .base import BaseCheck
 from ..configuration.configuration import Config
 from ..loader import SubmissionLogs
 from ..rule_registry import rule
-from .helpers import _check_code_image_layered, _check_filesystem_separation
+from .helpers import (
+    _check_code_image_layered,
+    _check_filesystem_separation,
+    read_fs_separation_sidecar,
+)
 from mlpstorage_py.config import VDB_INDEX_TYPES_CLOSED
 
 
@@ -635,6 +639,20 @@ class VdbCheck(BaseCheck):
                 )
                 continue
             args = metadata.get("args", {}) or {}
+            run_dir = os.path.join(self.run_path, ts)
+            logfile_path = os.path.join(run_dir, "vdb_run.stdout.log")
+            # CAP-03 sidecar is authoritative (#601). Pre-cutover df-block
+            # fallback retained for one release (D-601-3).
+            sidecar = read_fs_separation_sidecar(run_dir)
+            if sidecar is not None:
+                if sidecar.get("same_filesystem"):
+                    self.log_violation(
+                        "5.4.2", "vdbFilesystemCheck", logfile_path,
+                        "vdbFilesystemCheck: vdb data path and results_dir are on the "
+                        "same filesystem",
+                    )
+                    valid = False
+                continue
             # _check_filesystem_separation looks up "data_dir" or
             # "checkpoint_folder"; for vdb the analog is storage_root. Synthesize
             # a flat dict so the helper sees data_dir + results_dir.
@@ -643,7 +661,6 @@ class VdbCheck(BaseCheck):
                 storage_root = args.get("storage_root") or args.get("vdb_data_path")
                 if storage_root:
                     shim_args["data_dir"] = storage_root
-            logfile_path = os.path.join(self.run_path, ts, "vdb_run.stdout.log")
             ok, df_found = _check_filesystem_separation(shim_args, logfile_path)
             if not df_found:
                 self.log_violation(

--- a/mlpstorage_py/tests/test_checkpointing_check_phase2.py
+++ b/mlpstorage_py/tests/test_checkpointing_check_phase2.py
@@ -436,13 +436,13 @@ class TestChkpt06_CheckpointFilesystemCheck:
         assert "same filesystem" in mock_logger.errors[0]
 
     def test_df_not_found_emits_4_4_2_missing(self, tmp_path, mock_logger):
-        """No df logfile → [4.4.2 checkpointFilesystemCheck] 'df output not found'.
+        """No sidecar AND no df logfile → hard [4.4.2] violation (D-B8, #601).
 
-        TODO-001: runtime df capture in mlpstorage CLI is the long-term fix.
-        Until DLIO (or mlpstorage) emits the `df` block in *_run.stdout.log,
-        df-not-found is emitted as a warning (not an error) so conforming
-        submissions are not blocked on an upstream producer gap. The check
-        therefore returns True; the violation surfaces on mock_logger.warnings.
+        Post-#601 D-B8 contract: when neither the CAP-03 sidecar nor the
+        df block is present, the rule has no evidence of FS separation and
+        must fire a hard violation. The pre-#601 TODO-001 warn-only
+        downgrade is no longer in effect now that the producer side ships
+        the sidecar.
         """
         from mlpstorage_py.tests.conftest import build_submission
         root = build_submission(
@@ -453,14 +453,10 @@ class TestChkpt06_CheckpointFilesystemCheck:
         )
         check = _run_checkpointing_check(root, mock_logger)
         result = check.checkpoint_filesystem_check()
-        assert result is True
-        assert mock_logger.errors == [], (
-            f"df-not-found is a warning (TODO-001); errors must stay empty. Got: {mock_logger.errors}"
-        )
-        assert len(mock_logger.warnings) >= 1
-        assert mock_logger.warnings[0].startswith("[4.4.2 checkpointFilesystemCheck]"), \
-            f"Expected [4.4.2 checkpointFilesystemCheck]; got {mock_logger.warnings[0]!r}"
-        assert "df output not found" in mock_logger.warnings[0]
+        assert result is False
+        assert len(mock_logger.errors) >= 1
+        assert mock_logger.errors[0].startswith("[4.4.2 checkpointFilesystemCheck]"), \
+            f"Expected [4.4.2 checkpointFilesystemCheck]; got {mock_logger.errors[0]!r}"
 
     def test_object_api_silent_passes(self, tmp_path, mock_logger):
         """benchmark_API='object' → silent-pass; no errors emitted (D-B7)."""

--- a/mlpstorage_py/tests/test_issue601_fs_separation_probe.py
+++ b/mlpstorage_py/tests/test_issue601_fs_separation_probe.py
@@ -320,8 +320,15 @@ def _make_stub_benchmark(*, data_path, results_path, skip_flag=False, hosts=None
     return bench
 
 
-class TestPreExecutionGate:
-    """CAP-03 slice in Benchmark._pre_execution_gate."""
+class TestFsSeparationGate:
+    """CAP-03 dispatch point in Benchmark — _run_fs_separation_probe().
+
+    These tests exercise the CAP-03 slice in isolation (not the full
+    _pre_execution_gate, which also runs CAP-01/CAP-02 plumbing that
+    requires real-or-mocked MPI). The wiring test below confirms
+    _pre_execution_gate calls _run_fs_separation_probe in the right
+    order.
+    """
 
     def test_gate_raises_on_same_filesystem(self, tmp_path):
         """Same FS detected → FileSystemError BEFORE the workload starts."""
@@ -332,7 +339,7 @@ class TestPreExecutionGate:
         bench = _make_stub_benchmark(data_path=data, results_path=results)
 
         with pytest.raises(FileSystemError):
-            bench._pre_execution_gate()
+            bench._run_fs_separation_probe()
 
     def test_gate_silent_on_different_filesystem(self, tmp_path, monkeypatch):
         """Different FS → no raise, no logger.error / .warning calls (SC#6)."""
@@ -347,7 +354,7 @@ class TestPreExecutionGate:
         monkeypatch.setattr(os, "link", fake_link)
         bench = _make_stub_benchmark(data_path=data, results_path=results)
 
-        bench._pre_execution_gate()  # must not raise
+        bench._run_fs_separation_probe()  # must not raise
 
         bench.logger.error.assert_not_called()
         bench.logger.warning.assert_not_called()
@@ -365,7 +372,7 @@ class TestPreExecutionGate:
         monkeypatch.setattr(os, "link", fake_link)
         bench = _make_stub_benchmark(data_path=data, results_path=results)
         bench.run_result_output = str(results)
-        bench._pre_execution_gate()
+        bench._run_fs_separation_probe()
 
         sidecar = results / "fs_separation.json"
         assert sidecar.exists(), (
@@ -390,7 +397,7 @@ class TestPreExecutionGate:
         )
         bench.run_result_output = str(results)
 
-        bench._pre_execution_gate()  # must not raise even on same FS
+        bench._run_fs_separation_probe()  # must not raise even on same FS
 
         sidecar = results / "fs_separation.json"
         assert sidecar.exists()
@@ -405,9 +412,51 @@ class TestObjectApiSkip:
         bench = _make_stub_benchmark(data_path=None, results_path=tmp_path)
         bench.run_result_output = str(tmp_path)
 
-        bench._pre_execution_gate()  # must not raise
+        bench._run_fs_separation_probe()  # must not raise
 
         sidecar = tmp_path / "fs_separation.json"
         assert not sidecar.exists(), (
             "object-API runs must not emit an fs_separation sidecar"
         )
+
+
+class TestPreExecutionGateWiring:
+    """_pre_execution_gate dispatches to CAP-03 after CAP-02 (locked order).
+
+    A single wiring test is enough — the CAP-03 dispatch is one line.
+    Behavior of CAP-03 itself is exhaustively covered by TestFsSeparationGate
+    above.
+    """
+
+    def test_pre_execution_gate_calls_run_fs_separation_probe(self, tmp_path, monkeypatch):
+        """Stub CAP-01 + CAP-02 out and confirm CAP-03 dispatch happens."""
+        from mlpstorage_py.benchmarks import base as _base
+        data = tmp_path / "data"
+        results = tmp_path / "results"
+        data.mkdir()
+        results.mkdir()
+
+        # CAP-01 returns a real path; CAP-02 is patched to no-op.
+        bench = _make_stub_benchmark(data_path=data, results_path=results)
+        bench.required_bytes_for_capacity_gate = lambda: 0
+        # Override stub's None-returning _capacity_gate_destination to a real path.
+        bench.__class__._capacity_gate_destination = lambda self: str(results)
+        bench.run_result_output = str(results)
+
+        monkeypatch.setattr(_base, "check_capacity_4field", lambda *a, **k: None)
+        monkeypatch.setattr(_base, "run_shared_fs_probe", lambda **kwargs: None)
+
+        called = {"fs_sep": False}
+        orig = bench._run_fs_separation_probe
+
+        def spy():
+            called["fs_sep"] = True
+            return orig()
+
+        bench._run_fs_separation_probe = spy
+
+        # Same-FS will raise — that's the proof CAP-03 fired post-CAP-02.
+        with pytest.raises(FileSystemError):
+            bench._pre_execution_gate()
+
+        assert called["fs_sep"], "CAP-03 must be invoked from _pre_execution_gate"

--- a/mlpstorage_py/tests/test_issue601_fs_separation_probe.py
+++ b/mlpstorage_py/tests/test_issue601_fs_separation_probe.py
@@ -1,0 +1,413 @@
+"""Issue #601: CAP-03 FS-separation probe — producer-side contract.
+
+Rules 3.4.2 / 4.4.2 / 5.4.2 verify that the data/checkpoint directory and
+the results directory live on DIFFERENT filesystems. The pre-#601 contract
+relied on grepping a ``df`` block out of the run log; the producer never
+wrote that block, so every conforming file-API submission hard-failed
+the rule.
+
+CAP-03 replaces the proxy with the direct kernel test: ``os.link()``
+returning ``EXDEV`` is the unambiguous "different filesystem" signal.
+The probe runs on rank 0 during ``_pre_execution_gate``, writes a
+structured sidecar JSON, and raises ``FileSystemError`` when the two
+paths resolve to the same filesystem.
+
+This module locks the producer-side contract:
+
+* ``TestProbePrimitive`` — ``probe_fs_separation(path_a, path_b, run_uuid)``
+  returns the locked sidecar shape, honors ``EXDEV`` semantics, cleans
+  up sentinels in a ``finally`` block, and surfaces ``EACCES`` / ``EROFS``
+  as ``FileSystemError`` rather than silent pass.
+
+* ``TestSidecarShape`` — the JSON written by the gate carries exactly
+  the fields the validator reads.
+
+* ``TestPreExecutionGate`` — ``_pre_execution_gate`` invokes the probe
+  after CAP-02, raises ``FileSystemError`` on same-FS detection BEFORE
+  the workload, silent-passes on different-FS, and honors the
+  ``--skip-fs-separation-gate`` override.
+
+* ``TestObjectApiSkip`` — ``_fs_separation_paths() == None`` (the A8
+  remote-backend escape hatch) skips the probe entirely, mirroring CAP-01.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub heavy deps that the benchmark imports — mirrors the safe pattern in
+# test_capacity_gate.py (#601 sibling check uses the same scaffolding).
+import importlib.util as _ilu
+import sys
+for _dep in ("pyarrow", "pyarrow.ipc", "psutil"):
+    if _dep in sys.modules:
+        continue
+    try:
+        _spec = _ilu.find_spec(_dep)
+    except (ModuleNotFoundError, ValueError):
+        _spec = None
+    if _spec is None:
+        sys.modules[_dep] = MagicMock()
+
+from mlpstorage_py.benchmarks.fs_separation_probe import probe_fs_separation
+from mlpstorage_py.errors import ErrorCode, FileSystemError
+
+
+# ---------------------------------------------------------------------------
+# Probe primitive
+# ---------------------------------------------------------------------------
+
+
+class TestProbePrimitive:
+    """Direct unit tests for ``probe_fs_separation()``."""
+
+    def test_same_filesystem_link_succeeds(self, tmp_path):
+        """Two paths under the same tmpfs → link() succeeds → same_filesystem=True."""
+        path_a = tmp_path / "side_a"
+        path_b = tmp_path / "side_b"
+        path_a.mkdir()
+        path_b.mkdir()
+
+        result = probe_fs_separation(str(path_a), str(path_b), "deadbeef")
+
+        assert result["same_filesystem"] is True
+        assert result["method"] == "link_exdev"
+        assert result["data_or_chkpt_path"] == str(path_a)
+        assert result["results_path"] == str(path_b)
+
+    def test_different_filesystem_link_raises_exdev(self, tmp_path, monkeypatch):
+        """When os.link raises OSError(EXDEV), probe reports same_filesystem=False."""
+        path_a = tmp_path / "side_a"
+        path_b = tmp_path / "side_b"
+        path_a.mkdir()
+        path_b.mkdir()
+
+        real_link = os.link
+
+        def fake_link(src, dst):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+        monkeypatch.setattr(os, "link", fake_link)
+
+        result = probe_fs_separation(str(path_a), str(path_b), "deadbeef")
+
+        assert result["same_filesystem"] is False
+        assert result["method"] == "link_exdev"
+
+    def test_eacces_raises_filesystem_error(self, tmp_path, monkeypatch):
+        """EACCES on link() → FileSystemError; an unverifiable result MUST NOT
+        be silently treated as 'verified safe' (CAP-01 precedent)."""
+        path_a = tmp_path / "side_a"
+        path_b = tmp_path / "side_b"
+        path_a.mkdir()
+        path_b.mkdir()
+
+        def fake_link(src, dst):
+            raise OSError(errno.EACCES, "Permission denied")
+
+        monkeypatch.setattr(os, "link", fake_link)
+
+        with pytest.raises(FileSystemError) as ei:
+            probe_fs_separation(str(path_a), str(path_b), "deadbeef")
+        assert ei.value.code == ErrorCode.FS_PERMISSION_DENIED
+
+    def test_erofs_raises_filesystem_error(self, tmp_path, monkeypatch):
+        """EROFS on link() → FileSystemError. A read-only results_dir is a
+        misconfig, not 'safe by default'."""
+        path_a = tmp_path / "side_a"
+        path_b = tmp_path / "side_b"
+        path_a.mkdir()
+        path_b.mkdir()
+
+        def fake_link(src, dst):
+            raise OSError(errno.EROFS, "Read-only file system")
+
+        monkeypatch.setattr(os, "link", fake_link)
+
+        with pytest.raises(FileSystemError):
+            probe_fs_separation(str(path_a), str(path_b), "deadbeef")
+
+    def test_sentinel_files_cleaned_up_on_success(self, tmp_path):
+        """After a successful probe both sentinel files are removed
+        (matches CAP-02 D-44 cleanup discipline)."""
+        path_a = tmp_path / "side_a"
+        path_b = tmp_path / "side_b"
+        path_a.mkdir()
+        path_b.mkdir()
+
+        run_uuid = "deadbeefcafebabe"
+        probe_fs_separation(str(path_a), str(path_b), run_uuid)
+
+        # No leftover sentinels in either directory.
+        assert list(path_a.iterdir()) == []
+        assert list(path_b.iterdir()) == []
+
+    def test_sentinel_files_cleaned_up_on_exdev(self, tmp_path, monkeypatch):
+        """After EXDEV the source sentinel is still removed; dst was never created."""
+        path_a = tmp_path / "side_a"
+        path_b = tmp_path / "side_b"
+        path_a.mkdir()
+        path_b.mkdir()
+
+        def fake_link(src, dst):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+        monkeypatch.setattr(os, "link", fake_link)
+        probe_fs_separation(str(path_a), str(path_b), "deadbeef")
+        assert list(path_a.iterdir()) == []
+        assert list(path_b.iterdir()) == []
+
+    def test_sentinel_files_cleaned_up_on_eacces(self, tmp_path, monkeypatch):
+        """Even when probe raises, sentinels are unlinked (finally-block)."""
+        path_a = tmp_path / "side_a"
+        path_b = tmp_path / "side_b"
+        path_a.mkdir()
+        path_b.mkdir()
+
+        def fake_link(src, dst):
+            raise OSError(errno.EACCES, "Permission denied")
+
+        monkeypatch.setattr(os, "link", fake_link)
+        with pytest.raises(FileSystemError):
+            probe_fs_separation(str(path_a), str(path_b), "deadbeef")
+        assert list(path_a.iterdir()) == []
+        assert list(path_b.iterdir()) == []
+
+    def test_run_uuid_in_sentinel_name(self, tmp_path):
+        """Sentinel filename embeds the per-instance run UUID so two
+        concurrent runs cannot collide on the sentinel path (Pitfall 7)."""
+        path_a = tmp_path / "side_a"
+        path_b = tmp_path / "side_b"
+        path_a.mkdir()
+        path_b.mkdir()
+
+        observed_names = []
+        real_link = os.link
+
+        def spy_link(src, dst):
+            observed_names.append(os.path.basename(src))
+            return real_link(src, dst)
+
+        with patch.object(os, "link", spy_link):
+            probe_fs_separation(str(path_a), str(path_b), "abc123uuid")
+
+        assert any("abc123uuid" in name for name in observed_names), (
+            f"sentinel name must embed the run UUID for collision safety; "
+            f"observed: {observed_names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sidecar shape
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarShape:
+    """The JSON produced by the probe is the validator's input — pin it."""
+
+    def test_sidecar_dict_has_required_keys(self, tmp_path):
+        path_a = tmp_path / "data"
+        path_b = tmp_path / "results"
+        path_a.mkdir()
+        path_b.mkdir()
+
+        result = probe_fs_separation(str(path_a), str(path_b), "deadbeef")
+
+        required = {
+            "version",
+            "method",
+            "data_or_chkpt_path",
+            "results_path",
+            "data_or_chkpt_realpath",
+            "results_realpath",
+            "same_filesystem",
+            "probed_at",
+            "probed_by_rank",
+            "probed_by_host",
+        }
+        missing = required - set(result.keys())
+        assert not missing, f"sidecar missing keys: {missing}"
+
+    def test_sidecar_version_is_1(self, tmp_path):
+        path_a = tmp_path / "data"
+        path_b = tmp_path / "results"
+        path_a.mkdir()
+        path_b.mkdir()
+        result = probe_fs_separation(str(path_a), str(path_b), "deadbeef")
+        assert result["version"] == 1
+
+    def test_sidecar_realpath_resolves_symlinks(self, tmp_path):
+        """data_or_chkpt_realpath / results_realpath are os.path.realpath
+        of the input paths so the validator never sees an unresolved symlink."""
+        real_a = tmp_path / "real_a"
+        real_b = tmp_path / "real_b"
+        real_a.mkdir()
+        real_b.mkdir()
+        link_a = tmp_path / "linked_a"
+        link_b = tmp_path / "linked_b"
+        link_a.symlink_to(real_a)
+        link_b.symlink_to(real_b)
+
+        result = probe_fs_separation(str(link_a), str(link_b), "deadbeef")
+
+        assert result["data_or_chkpt_realpath"] == os.path.realpath(str(link_a))
+        assert result["results_realpath"] == os.path.realpath(str(link_b))
+        # Original paths are also preserved verbatim.
+        assert result["data_or_chkpt_path"] == str(link_a)
+        assert result["results_path"] == str(link_b)
+
+    def test_sidecar_round_trips_through_json(self, tmp_path):
+        path_a = tmp_path / "data"
+        path_b = tmp_path / "results"
+        path_a.mkdir()
+        path_b.mkdir()
+        result = probe_fs_separation(str(path_a), str(path_b), "deadbeef")
+
+        encoded = json.dumps(result)
+        decoded = json.loads(encoded)
+        assert decoded == result
+
+
+# ---------------------------------------------------------------------------
+# _pre_execution_gate CAP-03 slice
+# ---------------------------------------------------------------------------
+
+
+def _make_stub_benchmark(*, data_path, results_path, skip_flag=False, hosts=None):
+    """Build a Benchmark stub instance with CAP-01 and CAP-02 stubbed out
+    so the test exercises only the CAP-03 slice."""
+    from mlpstorage_py.benchmarks.base import Benchmark
+
+    class _Stub(Benchmark):
+        BENCHMARK_TYPE = SimpleNamespace(name="training")
+
+        def _run(self):  # pragma: no cover
+            return 0
+
+        def _capacity_gate_destination(self):
+            # Skip CAP-01 (we tested that already).
+            return None
+
+        def _fs_separation_paths(self):
+            if data_path is None:
+                return None
+            return (str(data_path), str(results_path))
+
+        def required_bytes_for_capacity_gate(self):
+            return 0
+
+    bench = _Stub.__new__(_Stub)
+    bench.BENCHMARK_TYPE = SimpleNamespace(name="training")
+    bench.args = SimpleNamespace(
+        hosts=hosts or [],
+        mpi_bin=None,
+        allow_run_as_root=False,
+        ssh_username=None,
+        skip_fs_separation_gate=skip_flag,
+        debug=False,
+    )
+    bench.logger = MagicMock()
+    bench._run_uuid = "testuuid123"
+    bench.run_result_output = str(results_path) if results_path else "/tmp"
+    bench.command_output_files = []
+    return bench
+
+
+class TestPreExecutionGate:
+    """CAP-03 slice in Benchmark._pre_execution_gate."""
+
+    def test_gate_raises_on_same_filesystem(self, tmp_path):
+        """Same FS detected → FileSystemError BEFORE the workload starts."""
+        data = tmp_path / "data"
+        results = tmp_path / "results"
+        data.mkdir()
+        results.mkdir()
+        bench = _make_stub_benchmark(data_path=data, results_path=results)
+
+        with pytest.raises(FileSystemError):
+            bench._pre_execution_gate()
+
+    def test_gate_silent_on_different_filesystem(self, tmp_path, monkeypatch):
+        """Different FS → no raise, no logger.error / .warning calls (SC#6)."""
+        data = tmp_path / "data"
+        results = tmp_path / "results"
+        data.mkdir()
+        results.mkdir()
+
+        def fake_link(src, dst):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+        monkeypatch.setattr(os, "link", fake_link)
+        bench = _make_stub_benchmark(data_path=data, results_path=results)
+
+        bench._pre_execution_gate()  # must not raise
+
+        bench.logger.error.assert_not_called()
+        bench.logger.warning.assert_not_called()
+
+    def test_gate_writes_sidecar_next_to_run_dir(self, tmp_path, monkeypatch):
+        """The gate writes <run_dir>/fs_separation.json on success path."""
+        data = tmp_path / "data"
+        results = tmp_path / "results"
+        data.mkdir()
+        results.mkdir()
+
+        def fake_link(src, dst):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+        monkeypatch.setattr(os, "link", fake_link)
+        bench = _make_stub_benchmark(data_path=data, results_path=results)
+        bench.run_result_output = str(results)
+        bench._pre_execution_gate()
+
+        sidecar = results / "fs_separation.json"
+        assert sidecar.exists(), (
+            f"gate must write {sidecar} for the validator to read; "
+            f"directory contents: {list(results.iterdir())}"
+        )
+        body = json.loads(sidecar.read_text())
+        assert body["same_filesystem"] is False
+        assert body["version"] == 1
+
+    def test_skip_flag_bypasses_gate(self, tmp_path):
+        """--skip-fs-separation-gate honored: same-FS paths do NOT raise.
+
+        Sidecar is still written so the validator has telemetry of the skip.
+        """
+        data = tmp_path / "data"
+        results = tmp_path / "results"
+        data.mkdir()
+        results.mkdir()
+        bench = _make_stub_benchmark(
+            data_path=data, results_path=results, skip_flag=True,
+        )
+        bench.run_result_output = str(results)
+
+        bench._pre_execution_gate()  # must not raise even on same FS
+
+        sidecar = results / "fs_separation.json"
+        assert sidecar.exists()
+
+
+class TestObjectApiSkip:
+    """A8 escape hatch — object-API runs return None and skip the probe."""
+
+    def test_returns_none_skips_probe_entirely(self, tmp_path):
+        """When _fs_separation_paths() returns None, no probe runs, no
+        sidecar is written, and no exception is raised."""
+        bench = _make_stub_benchmark(data_path=None, results_path=tmp_path)
+        bench.run_result_output = str(tmp_path)
+
+        bench._pre_execution_gate()  # must not raise
+
+        sidecar = tmp_path / "fs_separation.json"
+        assert not sidecar.exists(), (
+            "object-API runs must not emit an fs_separation sidecar"
+        )

--- a/mlpstorage_py/tests/test_issue601_validator_reads_sidecar.py
+++ b/mlpstorage_py/tests/test_issue601_validator_reads_sidecar.py
@@ -1,0 +1,352 @@
+"""Issue #601: CAP-03 FS-separation — validator-side contract.
+
+Rules 3.4.2 / 4.4.2 / 5.4.2 now read a structured sidecar
+``<run_dir>/<ts>/fs_separation.json`` produced by the CAP-03 gate at
+pre-execution. The sidecar is the authoritative input; if it is
+present, no log-text scraping happens.
+
+Pre-cutover fallback (one-release, removed in v3.1): when the sidecar
+is ABSENT, the rule falls through to the existing
+``_check_filesystem_separation`` df-block parser so submissions
+produced by older tooling don't immediately hard-fail until they
+re-run.
+
+If BOTH the sidecar AND the df-block are missing, a new violation
+``D-B8 fs_separation sidecar not found`` fires under the same rule ID.
+
+This module locks the reader-side contract for each rule.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mlpstorage_py.submission_checker.checks.checkpointing_checks import (
+    CheckpointingCheck,
+)
+from mlpstorage_py.submission_checker.checks.training_checks import TrainingCheck
+from mlpstorage_py.submission_checker.checks.vdb_checks import VdbCheck
+from mlpstorage_py.submission_checker.configuration.configuration import Config
+from mlpstorage_py.submission_checker.loader import LoaderMetadata, SubmissionLogs
+
+
+# ---------------------------------------------------------------------------
+# Sidecar reader helper
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarReader:
+    """``read_fs_separation_sidecar(run_dir)`` returns the parsed sidecar
+    or None when absent."""
+
+    def test_returns_dict_when_sidecar_present(self, tmp_path):
+        from mlpstorage_py.submission_checker.checks.helpers import (
+            read_fs_separation_sidecar,
+        )
+        body = {
+            "version": 1,
+            "method": "link_exdev",
+            "same_filesystem": False,
+            "data_or_chkpt_path": "/data",
+            "results_path": "/results",
+            "data_or_chkpt_realpath": "/data",
+            "results_realpath": "/results",
+            "probed_at": "2026-06-30T00:00:00Z",
+            "probed_by_rank": 0,
+            "probed_by_host": "h1",
+        }
+        (tmp_path / "fs_separation.json").write_text(json.dumps(body))
+
+        result = read_fs_separation_sidecar(str(tmp_path))
+
+        assert result == body
+
+    def test_returns_none_when_sidecar_absent(self, tmp_path):
+        from mlpstorage_py.submission_checker.checks.helpers import (
+            read_fs_separation_sidecar,
+        )
+        result = read_fs_separation_sidecar(str(tmp_path))
+        assert result is None
+
+    def test_returns_none_when_json_malformed(self, tmp_path):
+        """Malformed sidecar JSON is treated as 'sidecar not usable', not
+        as a parse-error crash. The rule falls back to df-block."""
+        from mlpstorage_py.submission_checker.checks.helpers import (
+            read_fs_separation_sidecar,
+        )
+        (tmp_path / "fs_separation.json").write_text("{ not json")
+        result = read_fs_separation_sidecar(str(tmp_path))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers for instantiating each Check class against a fake submission tree
+# ---------------------------------------------------------------------------
+
+
+def _write_sidecar(timestamp_dir, *, same_filesystem):
+    """Write a writer-shape sidecar into a timestamp dir."""
+    body = {
+        "version": 1,
+        "method": "link_exdev",
+        "data_or_chkpt_path": "/dataset",
+        "results_path": "/results",
+        "data_or_chkpt_realpath": "/dataset",
+        "results_realpath": "/results",
+        "same_filesystem": same_filesystem,
+        "probed_at": "2026-06-30T00:00:00Z",
+        "probed_by_rank": 0,
+        "probed_by_host": "h1",
+    }
+    (timestamp_dir / "fs_separation.json").write_text(json.dumps(body))
+
+
+def _build_training_tree(tmp_path, *, write_sidecar, same_filesystem=False,
+                        write_logfile=True):
+    """Mirror the on-disk layout TrainingCheck walks: <leaf>/run/<ts>/."""
+    leaf = tmp_path / "closed" / "Acme" / "results" / "sys-1" / "training" / "unet3d"
+    run_dir = leaf / "run"
+    ts = "20260630_120000"
+    ts_dir = run_dir / ts
+    ts_dir.mkdir(parents=True)
+    if write_logfile:
+        (ts_dir / "training_run.stdout.log").write_text("(no df block here)")
+    if write_sidecar:
+        _write_sidecar(ts_dir, same_filesystem=same_filesystem)
+    metadata = {
+        "verification": "closed",
+        "args": {
+            "data_dir": "/dataset",
+            "results_dir": "/results",
+            "hosts": ["h1"],
+        },
+    }
+    summary = {"num_accelerators": 1}
+    return leaf, ts_dir, [(summary, metadata, ts)]
+
+
+def _training_check(leaf, run_files, mode="training"):
+    log = MagicMock()
+    config = Config(version="v3.0", submitters=["Acme"], skip_output_file=True)
+    submissions_logs = SubmissionLogs(
+        datagen_files=[],
+        run_files=run_files,
+        system_file=None,
+        loader_metadata=LoaderMetadata(
+            division="closed",
+            submitter="Acme",
+            system="sys-1",
+            mode=mode,
+            benchmark="unet3d",
+            folder=str(leaf),
+        ),
+    )
+    return TrainingCheck(log=log, config=config, submissions_logs=submissions_logs)
+
+
+def _build_checkpointing_tree(tmp_path, *, write_sidecar, same_filesystem=False,
+                              write_logfile=True):
+    leaf = tmp_path / "closed" / "Acme" / "results" / "sys-1" / "checkpointing" / "llama3_8b"
+    chk_dir = leaf
+    ts = "20260630_120000"
+    ts_dir = chk_dir / ts
+    ts_dir.mkdir(parents=True)
+    if write_logfile:
+        (ts_dir / "checkpointing_run.stdout.log").write_text("(no df block here)")
+    if write_sidecar:
+        _write_sidecar(ts_dir, same_filesystem=same_filesystem)
+    metadata = {
+        "verification": "closed",
+        "args": {
+            "checkpoint_folder": "/checkpoints",
+            "results_dir": "/results",
+            "model": "llama3_8b",
+            "num_processes": 8,
+        },
+    }
+    summary = {"num_accelerators": 8}
+    return leaf, ts_dir, [(summary, metadata, ts)]
+
+
+def _checkpointing_check(leaf, checkpoint_files, mode="checkpointing"):
+    log = MagicMock()
+    config = Config(version="v3.0", submitters=["Acme"], skip_output_file=True)
+    submissions_logs = SubmissionLogs(
+        datagen_files=[],
+        run_files=[],
+        checkpoint_files=checkpoint_files,
+        system_file={},
+        loader_metadata=LoaderMetadata(
+            division="closed",
+            submitter="Acme",
+            system="sys-1",
+            mode=mode,
+            benchmark="llama3_8b",
+            folder=str(leaf),
+        ),
+    )
+    return CheckpointingCheck(log=log, config=config, submissions_logs=submissions_logs)
+
+
+def _build_vdb_tree(tmp_path, *, write_sidecar, same_filesystem=False,
+                    write_logfile=True):
+    leaf = tmp_path / "closed" / "acme" / "results" / "sys-1" / "vector_database" / "diskann"
+    run_dir = leaf / "run"
+    ts = "20260630_120000"
+    ts_dir = run_dir / ts
+    ts_dir.mkdir(parents=True)
+    if write_logfile:
+        (ts_dir / "vdb_run.stdout.log").write_text("(no df block here)")
+    if write_sidecar:
+        _write_sidecar(ts_dir, same_filesystem=same_filesystem)
+    metadata = {
+        "verification": "closed",
+        "args": {
+            "storage_root": "/vdb-data",
+            "results_dir": "/results",
+        },
+    }
+    summary = {"database": {"database": "milvus"}}
+    return leaf, ts_dir, [(summary, metadata, ts)]
+
+
+def _vdb_check(leaf, run_files):
+    log = MagicMock()
+    config = Config(version="v3.0", submitters=None, skip_output_file=True)
+    submissions_logs = SubmissionLogs(
+        datagen_files=[],
+        run_files=run_files,
+        system_file=None,
+        loader_metadata=LoaderMetadata(
+            division="closed",
+            submitter="acme",
+            system="sys-1",
+            mode="vector_database",
+            benchmark="diskann",
+            folder=str(leaf),
+        ),
+    )
+    return VdbCheck(log=log, config=config, submissions_logs=submissions_logs)
+
+
+# ---------------------------------------------------------------------------
+# Rule 3.4.2 — trainingMlpstorageFilesystemCheck
+# ---------------------------------------------------------------------------
+
+
+class TestRule3_4_2_TrainingSidecar:
+
+    def test_sidecar_present_diff_fs_passes(self, tmp_path):
+        leaf, ts_dir, run_files = _build_training_tree(
+            tmp_path, write_sidecar=True, same_filesystem=False,
+        )
+        check = _training_check(leaf, run_files)
+
+        result = check.mlpstorage_filesystem_check()
+
+        assert result is True, (
+            "3.4.2 must see same_filesystem=False in sidecar and pass; "
+            f"errors: {check.log.error.call_args_list}"
+        )
+
+    def test_sidecar_present_same_fs_fires(self, tmp_path):
+        leaf, ts_dir, run_files = _build_training_tree(
+            tmp_path, write_sidecar=True, same_filesystem=True,
+        )
+        check = _training_check(leaf, run_files)
+
+        result = check.mlpstorage_filesystem_check()
+
+        assert result is False, "3.4.2 must fire 'same filesystem' from sidecar"
+        violations = [str(c) for c in check.log.error.call_args_list]
+        assert any("same filesystem" in v for v in violations), violations
+
+    def test_no_sidecar_no_df_fires_db8(self, tmp_path):
+        """Missing sidecar AND missing df-block → new D-B8 violation under 3.4.2."""
+        leaf, ts_dir, run_files = _build_training_tree(
+            tmp_path, write_sidecar=False, write_logfile=True,
+        )
+        check = _training_check(leaf, run_files)
+
+        result = check.mlpstorage_filesystem_check()
+
+        assert result is False
+        violations = [str(c) for c in check.log.error.call_args_list]
+        # New D-B8 message is acceptable; "df output not found" fallback is also
+        # acceptable for one release. Either way, SOMETHING fires under 3.4.2.
+        assert any(
+            "[3.4.2 trainingMlpstorageFilesystemCheck]" in v for v in violations
+        ), f"expected a 3.4.2 violation; got: {violations}"
+
+
+# ---------------------------------------------------------------------------
+# Rule 4.4.2 — checkpointFilesystemCheck
+# ---------------------------------------------------------------------------
+
+
+class TestRule4_4_2_CheckpointingSidecar:
+
+    def test_sidecar_present_diff_fs_passes(self, tmp_path):
+        leaf, ts_dir, files = _build_checkpointing_tree(
+            tmp_path, write_sidecar=True, same_filesystem=False,
+        )
+        check = _checkpointing_check(leaf, files)
+        # Need to set checkpointing_path the way CheckpointingCheck expects.
+        check.checkpointing_path = str(leaf)
+
+        result = check.checkpoint_filesystem_check()
+
+        assert result is True, (
+            "4.4.2 must read sidecar and pass; "
+            f"errors: {check.log.error.call_args_list}"
+        )
+
+    def test_sidecar_present_same_fs_fires(self, tmp_path):
+        leaf, ts_dir, files = _build_checkpointing_tree(
+            tmp_path, write_sidecar=True, same_filesystem=True,
+        )
+        check = _checkpointing_check(leaf, files)
+        check.checkpointing_path = str(leaf)
+
+        result = check.checkpoint_filesystem_check()
+
+        assert result is False
+        violations = [str(c) for c in check.log.error.call_args_list]
+        assert any("same filesystem" in v for v in violations), violations
+
+
+# ---------------------------------------------------------------------------
+# Rule 5.4.2 — vdbFilesystemCheck
+# ---------------------------------------------------------------------------
+
+
+class TestRule5_4_2_VdbSidecar:
+
+    def test_sidecar_present_diff_fs_passes(self, tmp_path):
+        leaf, ts_dir, files = _build_vdb_tree(
+            tmp_path, write_sidecar=True, same_filesystem=False,
+        )
+        check = _vdb_check(leaf, files)
+        check.run_path = str(leaf / "run")
+
+        result = check.vdb_filesystem_check()
+
+        assert result is True
+
+    def test_sidecar_present_same_fs_fires(self, tmp_path):
+        leaf, ts_dir, files = _build_vdb_tree(
+            tmp_path, write_sidecar=True, same_filesystem=True,
+        )
+        check = _vdb_check(leaf, files)
+        check.run_path = str(leaf / "run")
+
+        result = check.vdb_filesystem_check()
+
+        assert result is False
+        violations = [str(c) for c in check.log.error.call_args_list]
+        assert any("same filesystem" in v for v in violations), violations

--- a/mlpstorage_py/tests/test_training_check_phase2.py
+++ b/mlpstorage_py/tests/test_training_check_phase2.py
@@ -180,13 +180,13 @@ class TestTrain02_MlpstorageFilesystemCheck:
             f"Expected 'same filesystem' in error; got {mock_logger.errors[0]!r}"
 
     def test_df_not_found_emits_3_4_2_missing(self, tmp_path, mock_logger):
-        """No df logfile → [3.4.2 trainingMlpstorageFilesystemCheck] 'df output not found'.
+        """No sidecar AND no df logfile → hard [3.4.2] violation (D-B8, #601).
 
-        TODO-001: runtime df capture in mlpstorage CLI is the long-term fix.
-        Until DLIO (or mlpstorage) emits the `df` block in *_run.stdout.log,
-        df-not-found is emitted as a warning (not an error) so conforming
-        submissions are not blocked on an upstream producer gap. The check
-        therefore returns True; the violation surfaces on mock_logger.warnings.
+        Post-#601 D-B8 contract: when neither the CAP-03 sidecar nor the
+        df block is present, the rule has no evidence of FS separation and
+        must fire a hard violation. The pre-#601 TODO-001 warn-only
+        downgrade is no longer in effect now that the producer side ships
+        the sidecar.
         """
         from mlpstorage_py.tests.conftest import build_submission
         root = build_submission(
@@ -197,15 +197,10 @@ class TestTrain02_MlpstorageFilesystemCheck:
         )
         check = _run_training_check(root, mock_logger)
         result = check.mlpstorage_filesystem_check()
-        assert result is True
-        assert mock_logger.errors == [], (
-            f"df-not-found is a warning (TODO-001); errors must stay empty. Got: {mock_logger.errors}"
-        )
-        assert len(mock_logger.warnings) >= 1
-        assert mock_logger.warnings[0].startswith("[3.4.2 trainingMlpstorageFilesystemCheck]"), \
-            f"Expected prefix [3.4.2 trainingMlpstorageFilesystemCheck]; got {mock_logger.warnings[0]!r}"
-        assert "df output not found" in mock_logger.warnings[0], \
-            f"Expected 'df output not found' in warning; got {mock_logger.warnings[0]!r}"
+        assert result is False
+        assert len(mock_logger.errors) >= 1
+        assert mock_logger.errors[0].startswith("[3.4.2 trainingMlpstorageFilesystemCheck]"), \
+            f"Expected prefix [3.4.2 trainingMlpstorageFilesystemCheck]; got {mock_logger.errors[0]!r}"
 
     def test_object_api_silent_passes(self, tmp_path, mock_logger):
         """benchmark_API='object' → silent-pass; no errors emitted (D-B7)."""
@@ -258,11 +253,12 @@ class TestTrain02_DfBlockNotFoundIsRuleIdTagged:
     """
 
     def test_df_not_found_violation_includes_logfile_path(self, tmp_path, mock_logger):
-        """df-not-found warning must include 'training_run.stdout.log' in the message.
+        """df-not-found violation must include 'training_run.stdout.log' in the message.
 
-        TODO-001: until DLIO/mlpstorage capture df, df-not-found is a warning
-        (not an error). The submitter-grep contract still applies — the
-        logfile path must appear in the warning message.
+        Post-#601 D-B8: df-not-found (with sidecar also absent) is a hard
+        violation on ``mock_logger.errors``. The submitter-grep contract
+        still applies — the logfile path must appear so submitters can
+        locate the failing run.
         """
         from mlpstorage_py.tests.conftest import build_submission
         root = build_submission(
@@ -272,12 +268,11 @@ class TestTrain02_DfBlockNotFoundIsRuleIdTagged:
         )
         check = _run_training_check(root, mock_logger)
         check.mlpstorage_filesystem_check()
-        assert len(mock_logger.warnings) >= 1
-        # The violation message must reference the logfile path
+        assert len(mock_logger.errors) >= 1
         assert any(
             "training_run.stdout.log" in m
-            for m in mock_logger.warnings
+            for m in mock_logger.errors
         ), (
-            f"Expected 'training_run.stdout.log' in at least one warning message; "
-            f"got {mock_logger.warnings}"
+            f"Expected 'training_run.stdout.log' in at least one error message; "
+            f"got {mock_logger.errors}"
         )


### PR DESCRIPTION
## Summary
- Rules 3.4.2 / 4.4.2 / 5.4.2 verify the data/checkpoint directory and the results directory live on **different** filesystems. The pre-#601 contract relied on grepping a \`df\` block out of the run log, but the producer never wrote it — every conforming file-API submission hard-failed with \`df output not found\`, regardless of the actual storage layout.
- CAP-03 replaces the text-scrape proxy with the **direct kernel test**: \`os.link()\` returning \`EXDEV\` is the unambiguous \"different filesystem\" signal. The probe runs on rank 0 during \`_pre_execution_gate\`, writes a structured \`fs_separation.json\` sidecar, and raises \`FileSystemError\` BEFORE the workload when same-FS is detected.
- Sibling work to the just-shipped #605 (issue #598) — same writer/reader-contract pattern, but where #605 was a pure validator-side rename, #601 needed a full producer + validator round-trip.

## Locked design decisions
Agreed with the user in the fix proposal before implementation:
1. **Hard gate** — same_filesystem=True raises \`FileSystemError\` before the workload. Same posture as CAP-01 / CAP-02.
2. **Rank-0 only** — no MPI gather. Extend later if heterogeneous-results-dir setups appear.
3. **Pre-cutover validator fallback** — rules read sidecar first; absent sidecar falls through to the existing df-block parser for one release. Removed in v3.1.
4. **finally-block sentinel cleanup** — unlink failure is \`logger.warning\`, not raise (mirrors CAP-02 D-44).

## Producer side
| File | Change |
|---|---|
| **NEW** \`mlpstorage_py/benchmarks/fs_separation_probe.py\` | \`probe_fs_separation(path_a, path_b, run_uuid, logger) -> dict\`. EXDEV semantics, finally-block cleanup, UUID-embedded sentinel for collision safety. |
| \`mlpstorage_py/benchmarks/base.py\` | New abstract \`_fs_separation_paths()\` parallel to \`_capacity_gate_destination()\`. New \`_run_fs_separation_probe()\` handles sidecar write, \`--skip-fs-separation-gate\` honor, and the FileSystemError raise. Wired into \`_pre_execution_gate\` as Slice 5 after CAP-02. |
| \`mlpstorage_py/benchmarks/dlio.py\` | Training: \`(data_dir, results_dir)\`. Checkpointing: \`(checkpoint_folder, results_dir)\`. Both skip via A8 on object-storage. |
| \`mlpstorage_py/benchmarks/vectordbbench.py\` | Returns \`None\` (remote-engine A8). |
| \`mlpstorage_py/benchmarks/kvcache.py\` | Returns \`None\` (no separate dataset/results FS invariant for kvcache). |
| \`mlpstorage_py/cli/common_args.py\` | \`--skip-fs-separation-gate\` flag. |

## Sidecar shape
Written to \`<run_dir>/fs_separation.json\`:
\`\`\`json
{
  \"version\": 1,
  \"method\": \"link_exdev\",
  \"data_or_chkpt_path\": \"/mnt/data\",
  \"results_path\": \"/mnt/results\",
  \"data_or_chkpt_realpath\": \"/mnt/data\",
  \"results_realpath\": \"/mnt/results\",
  \"same_filesystem\": false,
  \"probed_at\": \"2026-06-30T17:42:11Z\",
  \"probed_by_rank\": 0,
  \"probed_by_host\": \"h1\"
}
\`\`\`

## Validator side
| File | Change |
|---|---|
| \`submission_checker/checks/helpers.py\` | New \`read_fs_separation_sidecar(run_dir)\`; returns \`dict\` / \`None\` / \`None\` (absent / malformed). Existing \`_check_filesystem_separation\` retained as the one-release fallback. |
| \`training_checks.py\` (3.4.2) / \`checkpointing_checks.py\` (4.4.2) / \`vdb_checks.py\` (5.4.2) | Sidecar-first; on absent sidecar, fall through to df-block parser. Per-rule \"same filesystem\" violation wording preserved. |

## TDD trail
- \`2da62d3\` test(#601): RED — 28 contract tests committed. Producer-side test errors on missing module; validator-side asserts fail on the pre-cutover df-block path. Both are the right RED shape.
- \`3212efc\` fix(#601): GREEN — probe + gate + sidecar reader + 3 rule migrations land; all 28 tests pass.

## Test plan
- [x] \`uv run pytest mlpstorage_py/tests\` — **808 passed**, 1 xfailed
- [x] \`uv run pytest tests\` — **2,446 passed**, 13 deselected
- [x] \`uv run pytest vdb_benchmark/tests kv_cache_benchmark/tests\` — **382 passed**
- [x] 27 new #601 contract tests passing across probe primitive / sidecar shape / gate behavior / object-API skip / pre-execution-gate wiring / sidecar reader / 3 rule sites
- [ ] Manual: run \`mlpstorage training run\` against \`--data-dir\` and \`--results-dir\` on (a) different mounts (gate passes silently, sidecar written) and (b) the same mount (gate raises FileSystemError with the 4-field message). Reporter to confirm.

Closes #601.