### PR TITLE
fix(#599): reportgen accepts canonical tree, honors --output-dir, filters by --systemname

### DIFF
--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -26,6 +26,7 @@ from mlpstorage_py.reporting import (
     ValidationMessageFormatter,
     ClosedRequirementsFormatter,
     ReportSummaryFormatter,
+    discover_scan_roots,
 )
 
 
@@ -77,6 +78,41 @@ class ReportGenerator:
 
         self.results_dir = results_dir
 
+        # Issue #599: resolve the effective scan roots up-front.
+        #
+        # When --results-dir is a sentinel-bearing submission root (the
+        # canonical layout that `mlpstorage init` / `<bench> run` / `validate`
+        # all produce), the runs live at
+        # `<results-dir>/<closed|open>/<orgname>/results/<systemname>/...`
+        # — five levels below the directory the user passed in. Pre-fix,
+        # ResultsDirectoryValidator looked for benchmark-type dirs at the
+        # top level only and `get_runs_files` would walk every system's
+        # subtree, mashing them into one report tagged with the requested
+        # systemname.
+        #
+        # discover_scan_roots probes both modes against args.orgname (pinned
+        # by the LAY-03 sentinel gate in main.py) and args.systemname (the
+        # required CLI flag), returning per-mode slices when found and
+        # falling back to [results_dir] for legacy flat layouts.
+        orgname = getattr(self.args, 'orgname', None) if self.args else None
+        systemname = (
+            getattr(self.args, 'systemname', None) if self.args else None
+        )
+        self.scan_roots: List[str] = discover_scan_roots(
+            results_dir, orgname=orgname, systemname=systemname,
+            logger=self.logger,
+        )
+
+        # Resolve the artifacts output dir. --output-dir was accepted by the
+        # CLI but never read by write_json_file / write_csv_file pre-fix
+        # (issue #599 bug 2 — they hard-coded self.results_dir, polluting
+        # the input tree). Fall back to results_dir for backward-compat
+        # when the flag is unset.
+        output_dir = (
+            getattr(self.args, 'output_dir', None) if self.args else None
+        )
+        self.output_dir: str = output_dir if output_dir else self.results_dir
+
         # Initialize formatters
         self.msg_formatter = ValidationMessageFormatter(use_colors=use_colors)
         self.summary_formatter = ReportSummaryFormatter(use_colors=use_colors)
@@ -97,28 +133,53 @@ class ReportGenerator:
         """
         Validate the results directory structure before processing.
 
+        When the canonical submission layout is detected (one or both of
+        ``<results-dir>/{closed,open}/<orgname>/results/<systemname>/``),
+        the validator runs against each canonical slice independently —
+        each slice is itself a flat-layout root structurally
+        (``<benchmark>/<model>/<command>/<datetime>/`` immediately below).
+
         Returns:
             True if structure is valid, False otherwise.
         """
-        validator = ResultsDirectoryValidator(self.results_dir, logger=self.logger)
-        result = validator.validate()
+        total_runs = 0
+        total_benchmark_types: set = set()
+        all_warnings: List[str] = []
+        any_failed = False
+        last_validator: Optional[ResultsDirectoryValidator] = None
 
-        if not result.is_valid:
-            self.logger.error("Results directory structure validation failed:")
-            self.logger.error(validator.get_error_report())
+        for scan_root in self.scan_roots:
+            validator = ResultsDirectoryValidator(scan_root, logger=self.logger)
+            last_validator = validator
+            result = validator.validate()
+
+            if not result.is_valid:
+                self.logger.error(
+                    f"Results directory structure validation failed for "
+                    f"{scan_root}:"
+                )
+                self.logger.error(validator.get_error_report())
+                any_failed = True
+                continue
+
+            total_runs += result.found_runs
+            total_benchmark_types.update(result.found_benchmark_types)
+            all_warnings.extend(result.warnings)
+
+        if any_failed:
             self.logger.error("")
             self.logger.error("Expected structure:")
-            self.logger.error(validator.get_expected_structure_help())
+            if last_validator is not None:
+                self.logger.error(last_validator.get_expected_structure_help())
             return False
 
-        # Log warnings if any
-        if result.warnings:
-            for warning in result.warnings:
-                self.logger.warning(warning)
+        for warning in all_warnings:
+            self.logger.warning(warning)
 
         self.logger.info(
-            f"Directory validation passed: found {result.found_runs} runs "
-            f"in {len(result.found_benchmark_types)} benchmark types"
+            f"Directory validation passed: found {total_runs} runs "
+            f"in {len(total_benchmark_types)} benchmark types "
+            f"across {len(self.scan_roots)} scan root(s)"
         )
         return True
 
@@ -144,16 +205,28 @@ class ReportGenerator:
 
         Errors in individual runs are logged but do not stop processing.
         """
-        try:
-            benchmark_runs = get_runs_files(self.results_dir, logger=self.logger)
-        except Exception as e:
-            self.logger.error(f"Failed to scan results directory: {e}")
-            self.processing_errors.append(f"Directory scan failed: {e}")
-            return
+        # Walk each effective scan root and accumulate runs. In canonical
+        # mode, this naturally narrows to the requested system's subtree
+        # (issue #599 bug 3); in flat mode, it's a single pass over the
+        # original results_dir.
+        benchmark_runs: List = []
+        for scan_root in self.scan_roots:
+            try:
+                benchmark_runs.extend(
+                    get_runs_files(scan_root, logger=self.logger)
+                )
+            except Exception as e:
+                self.logger.error(
+                    f"Failed to scan results directory {scan_root}: {e}"
+                )
+                self.processing_errors.append(
+                    f"Directory scan failed for {scan_root}: {e}"
+                )
 
         if not benchmark_runs:
+            scan_paths = ', '.join(self.scan_roots)
             self.logger.warning(
-                f"No valid benchmark runs found in {self.results_dir}. "
+                f"No valid benchmark runs found in {scan_paths}. "
                 "Ensure runs have completed and contain metadata files."
             )
             return
@@ -413,14 +486,25 @@ class ReportGenerator:
                 print(f"\n    {checklist}")
 
 
+    def _ensure_output_dir(self) -> None:
+        """Make sure self.output_dir exists before writing artifacts.
+
+        --output-dir may point at a path the user has not created yet
+        (issue #599: the expected behaviour is `mlpstorage` creates it).
+        Idempotent — exist_ok=True keeps the existing-tree case silent.
+        """
+        os.makedirs(self.output_dir, exist_ok=True)
+
     def write_json_file(self, results):
-        json_file = os.path.join(self.results_dir,'results.json')
+        self._ensure_output_dir()
+        json_file = os.path.join(self.output_dir, 'results.json')
         self.logger.info(f'Writing results to {json_file}')
         with open(json_file, 'w') as f:
             json.dump(results, f, indent=2)
 
     def write_csv_file(self, results):
-        csv_file = os.path.join(self.results_dir,'results.csv')
+        self._ensure_output_dir()
+        csv_file = os.path.join(self.output_dir, 'results.csv')
         self.logger.info(f'Writing results to {csv_file}')
         flattened_results = [flatten_nested_dict(r) for r in results]
         flattened_results = [remove_nan_values(r) for r in flattened_results]

--- a/mlpstorage_py/reporting/__init__.py
+++ b/mlpstorage_py/reporting/__init__.py
@@ -24,6 +24,7 @@ from mlpstorage_py.reporting.directory_validator import (
     ResultsDirectoryValidator,
     DirectoryValidationError,
     DirectoryValidationResult,
+    discover_scan_roots,
 )
 
 from mlpstorage_py.reporting.formatters import (
@@ -37,6 +38,7 @@ __all__ = [
     'ResultsDirectoryValidator',
     'DirectoryValidationError',
     'DirectoryValidationResult',
+    'discover_scan_roots',
     # Formatters
     'ValidationMessageFormatter',
     'ClosedRequirementsFormatter',

--- a/mlpstorage_py/reporting/directory_validator.py
+++ b/mlpstorage_py/reporting/directory_validator.py
@@ -12,6 +12,79 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 
+# The canonical submission layout written by `mlpstorage init` + benchmark
+# runs (per Rules.md §2.1 / rules/utils.generate_output_location):
+#
+#     <results-dir>/<mode>/<orgname>/results/<systemname>/<benchmark>/<model>/<command>/<datetime>/
+#
+# Pre-fix, the validator only understood the flat `<results-dir>/<benchmark>/...`
+# shape — so `reportgen` rejected the same tree `mlpstorage init` / run /
+# validate produce (issue #599 bug 1).
+_CANONICAL_MODES = ("closed", "open")
+
+
+def discover_scan_roots(
+    results_dir: str,
+    orgname: Optional[str] = None,
+    systemname: Optional[str] = None,
+    logger=None,
+) -> List[str]:
+    """Return the list of effective results-root paths to scan.
+
+    When both ``orgname`` and ``systemname`` are supplied AND at least one of
+    ``<results_dir>/{closed,open}/<orgname>/results/<systemname>/`` exists,
+    the canonical layout is in use and the returned list contains those
+    per-mode slices (one or both). The walker and validator then operate on
+    each slice as if it were a flat results root — which it structurally is
+    (its children are `<benchmark>/<model>/<command>/<datetime>/`).
+
+    Otherwise (orgname/systemname missing, or no matching canonical slice
+    found on disk) the function returns ``[results_dir]`` so flat-layout
+    callers continue to work unchanged.
+
+    Args:
+        results_dir: Top-level path (a sentinel-bearing submission root in
+            canonical mode, or any directory in flat mode).
+        orgname: Resolved sentinel orgname. Defaults to None (no canonical
+            probing — pure flat-layout passthrough).
+        systemname: ``--systemname`` value used to narrow the scan to one
+            system's results subtree (issue #599 bug 3 — `--systemname` is
+            required by the reportgen CLI but was previously not propagated
+            to the run-walker, so a multi-system tree got aggregated into
+            one report).
+        logger: Optional logger for debug breadcrumbs.
+
+    Returns:
+        Non-empty list of absolute path strings to scan.
+    """
+    root = Path(results_dir)
+    if not orgname or not systemname:
+        return [str(root)]
+
+    canonical_roots: List[str] = []
+    for mode in _CANONICAL_MODES:
+        candidate = root / mode / orgname / "results" / systemname
+        if candidate.is_dir():
+            canonical_roots.append(str(candidate))
+            if logger:
+                logger.debug(
+                    f"discover_scan_roots: canonical {mode} slice found at "
+                    f"{candidate}"
+                )
+
+    if canonical_roots:
+        return canonical_roots
+
+    if logger:
+        logger.debug(
+            "discover_scan_roots: no canonical "
+            f"{_CANONICAL_MODES} slice for orgname={orgname!r} "
+            f"systemname={systemname!r} under {root}; falling back to flat "
+            "layout"
+        )
+    return [str(root)]
+
+
 @dataclass
 class DirectoryValidationError:
     """Represents an error in the results directory structure."""
@@ -381,7 +454,27 @@ class ResultsDirectoryValidator:
     def get_expected_structure_help(self) -> str:
         """Return a help message showing expected directory structure."""
         return """
-Expected results directory structure:
+Canonical submission layout (preferred — what `mlpstorage init` /
+`mlpstorage <bench> run` / `mlpstorage validate` produce):
+
+  results_dir/
+    mlperf-results.yaml                # Sentinel written by `mlpstorage init`
+    closed/                            # or open/
+      <orgname>/
+        results/
+          <systemname>/                # Filter target for `--systemname`
+            training/
+              unet3d/
+                run/
+                  20250115_143022/
+                    training_unet3d_metadata.json
+                    summary.json
+
+`reportgen` discovers the canonical slice via --systemname (and the
+sentinel-resolved orgname) and walks only that subtree. Flat layouts
+below this section are still accepted for backward compatibility.
+
+Flat layout (legacy / programmatic callers):
 
   results_dir/
     training/                          # Benchmark type

--- a/tests/unit/test_directory_validator.py
+++ b/tests/unit/test_directory_validator.py
@@ -3,7 +3,10 @@
 import json
 from pathlib import Path
 
-from mlpstorage_py.reporting.directory_validator import ResultsDirectoryValidator
+from mlpstorage_py.reporting.directory_validator import (
+    ResultsDirectoryValidator,
+    discover_scan_roots,
+)
 
 
 def _write_metadata(run_dir: Path, benchmark_type: str = "vector_database") -> Path:
@@ -193,3 +196,113 @@ class TestDirectoryValidatorRegressionCoverage:
         assert "DISKANN" in help_text
         assert "vector_database/<command>/<datetime>/" in help_text
         assert "vector_database/<engine>/<command>/<datetime>/" in help_text
+
+
+class TestDiscoverScanRoots:
+    """Issue #599 bug 1+3: discover_scan_roots maps a sentinel-bearing
+    submission root + (orgname, systemname) to the per-mode results slices
+    that actually contain runs — so reportgen validates and walks only the
+    requested system's subtree under the canonical layout that
+    `mlpstorage init` / `<bench> run` / `validate` produce.
+
+    Without orgname or systemname the helper passes the input path through
+    unchanged so legacy flat-layout callers continue to work."""
+
+    def _make_canonical_slice(self, tmp_path: Path, mode: str,
+                              orgname: str, systemname: str) -> Path:
+        """Create <tmp_path>/<mode>/<org>/results/<system>/training/... with
+        one valid run inside, mirroring what `mlpstorage <bench> run`
+        actually writes."""
+        slice_root = tmp_path / mode / orgname / "results" / systemname
+        run_dir = slice_root / "training" / "unet3d" / "run" / "20260123_120000"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "training_unet3d_metadata.json").write_text("{}")
+        (run_dir / "summary.json").write_text("{}")
+        return slice_root
+
+    def test_returns_results_dir_when_orgname_missing(self, tmp_path):
+        """No orgname → no canonical probing (cannot construct the candidate
+        path); flat layout passthrough."""
+        roots = discover_scan_roots(str(tmp_path), orgname=None,
+                                    systemname="sysA")
+        assert roots == [str(tmp_path)]
+
+    def test_returns_results_dir_when_systemname_missing(self, tmp_path):
+        """No systemname → same flat-layout passthrough."""
+        roots = discover_scan_roots(str(tmp_path), orgname="Acme",
+                                    systemname=None)
+        assert roots == [str(tmp_path)]
+
+    def test_returns_results_dir_when_canonical_slice_absent(self, tmp_path):
+        """Orgname + systemname supplied but the canonical layout does not
+        exist on disk → fall back to flat layout. Lets legacy users keep
+        running reportgen against trees that pre-date `init`."""
+        roots = discover_scan_roots(str(tmp_path), orgname="Acme",
+                                    systemname="sysA")
+        assert roots == [str(tmp_path)]
+
+    def test_returns_closed_slice_when_only_closed_exists(self, tmp_path):
+        slice_root = self._make_canonical_slice(
+            tmp_path, "closed", "Acme", "sysA"
+        )
+        roots = discover_scan_roots(str(tmp_path), orgname="Acme",
+                                    systemname="sysA")
+        assert roots == [str(slice_root)]
+
+    def test_returns_open_slice_when_only_open_exists(self, tmp_path):
+        slice_root = self._make_canonical_slice(
+            tmp_path, "open", "Acme", "sysA"
+        )
+        roots = discover_scan_roots(str(tmp_path), orgname="Acme",
+                                    systemname="sysA")
+        assert roots == [str(slice_root)]
+
+    def test_returns_both_slices_when_both_exist(self, tmp_path):
+        """A submitter who staged a tree with both closed/ and open/
+        subtrees (uncommon but legal) gets both slices scanned."""
+        closed_root = self._make_canonical_slice(
+            tmp_path, "closed", "Acme", "sysA"
+        )
+        open_root = self._make_canonical_slice(
+            tmp_path, "open", "Acme", "sysA"
+        )
+        roots = discover_scan_roots(str(tmp_path), orgname="Acme",
+                                    systemname="sysA")
+        # Order is closed, open (matches _CANONICAL_MODES iteration).
+        assert roots == [str(closed_root), str(open_root)]
+
+    def test_filters_to_requested_system_only(self, tmp_path):
+        """Issue #599 bug 3: a multi-system tree must yield only the
+        requested system's slice, not every system's subtree mashed into
+        one. Pre-fix, get_runs_files walked every system's runs and
+        labelled them all with the requested --systemname."""
+        wanted = self._make_canonical_slice(
+            tmp_path, "closed", "Acme", "sysA"
+        )
+        # Sibling system that must NOT be returned.
+        self._make_canonical_slice(tmp_path, "closed", "Acme", "sysB")
+        roots = discover_scan_roots(str(tmp_path), orgname="Acme",
+                                    systemname="sysA")
+        assert roots == [str(wanted)]
+
+    def test_filters_to_requested_orgname_only(self, tmp_path):
+        """Defense-in-depth: a tree with two orgnames under the same
+        results-dir yields only the requested org's slice."""
+        wanted = self._make_canonical_slice(
+            tmp_path, "closed", "Acme", "sysA"
+        )
+        self._make_canonical_slice(tmp_path, "closed", "OtherOrg", "sysA")
+        roots = discover_scan_roots(str(tmp_path), orgname="Acme",
+                                    systemname="sysA")
+        assert roots == [str(wanted)]
+
+    def test_non_directory_canonical_path_does_not_count(self, tmp_path):
+        """If the canonical path exists as a file (broken tree), the helper
+        must not treat it as a scan root — fall back to flat layout."""
+        bogus = (tmp_path / "closed" / "Acme" / "results")
+        bogus.mkdir(parents=True)
+        # Make systemname-level entry a FILE, not a directory.
+        (bogus / "sysA").write_text("not a dir")
+        roots = discover_scan_roots(str(tmp_path), orgname="Acme",
+                                    systemname="sysA")
+        assert roots == [str(tmp_path)]

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -528,3 +528,240 @@ class TestReportGeneratorIntegration:
         # Check files were created
         assert os.path.exists(os.path.join(results_dir, 'results.json'))
         assert os.path.exists(os.path.join(results_dir, 'results.csv'))
+
+
+# ---------------------------------------------------------------------------
+# Issue #599 regression tests — canonical-tree support, --output-dir, and
+# --systemname filtering. See the issue body for the full reproduction.
+# ---------------------------------------------------------------------------
+
+
+def _write_canonical_run(tmp_path, mode, orgname, systemname,
+                         benchmark="training", model="unet3d",
+                         timestamp="20260123_120000"):
+    """Create one fake run under the canonical layout that `mlpstorage init`
+    + `<bench> run` actually produces, and return the run dir."""
+    run_dir = (
+        tmp_path / mode / orgname / "results" / systemname
+        / benchmark / model / "run" / timestamp
+    )
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / f"{benchmark}_{model}_metadata.json").write_text("{}")
+    (run_dir / "summary.json").write_text("{}")
+    return run_dir
+
+
+def _make_generator(results_dir, *, args=None, validate_structure=False):
+    """Build a ReportGenerator with the heavy stages stubbed out so the
+    init constructor lands on `self` without touching real result files."""
+    with patch.object(ReportGenerator, 'accumulate_results'), \
+         patch.object(ReportGenerator, 'print_results'):
+        return ReportGenerator(
+            str(results_dir), args=args,
+            validate_structure=validate_structure,
+        )
+
+
+class TestIssue599OutputDirHonored:
+    """Bug 2: `--output-dir` was parsed but never used — results.csv /
+    results.json always landed in `--results-dir`, polluting the input
+    tree. After the fix, both writers land in args.output_dir when set
+    and still fall back to results_dir otherwise."""
+
+    def test_write_json_lands_in_output_dir_when_set(self, tmp_path):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        output_dir = tmp_path / "reports" / "sysA"
+        # Deliberately do NOT create output_dir — the fix must mkdir it
+        # so a fresh --output-dir works on first use.
+        args = Namespace(debug=False, output_dir=str(output_dir))
+        gen = _make_generator(results_dir, args=args)
+
+        gen.write_json_file([{'run_id': 'r1'}])
+
+        assert (output_dir / "results.json").exists()
+        assert not (results_dir / "results.json").exists(), \
+            "results.json must NOT be written into --results-dir when " \
+            "--output-dir is set (issue #599 bug 2)"
+
+    def test_write_csv_lands_in_output_dir_when_set(self, tmp_path):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        output_dir = tmp_path / "reports" / "sysA"
+        args = Namespace(debug=False, output_dir=str(output_dir))
+        gen = _make_generator(results_dir, args=args)
+
+        gen.write_csv_file([{'run_id': 'r1', 'throughput': 1.0}])
+
+        assert (output_dir / "results.csv").exists()
+        assert not (results_dir / "results.csv").exists()
+
+    def test_write_falls_back_to_results_dir_when_output_dir_unset(
+        self, tmp_path,
+    ):
+        """Backward-compat: with no --output-dir, behaviour is unchanged —
+        artifacts still land next to --results-dir."""
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        args = Namespace(debug=False, output_dir=None)
+        gen = _make_generator(results_dir, args=args)
+
+        gen.write_json_file([{'k': 'v'}])
+        gen.write_csv_file([{'k': 'v'}])
+
+        assert (results_dir / "results.json").exists()
+        assert (results_dir / "results.csv").exists()
+
+    def test_write_falls_back_to_results_dir_when_no_args(self, tmp_path):
+        """Same fallback when args itself is None (used by some
+        programmatic callers and the existing test fixtures)."""
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        gen = _make_generator(results_dir, args=None)
+
+        gen.write_json_file([{'k': 'v'}])
+
+        assert (results_dir / "results.json").exists()
+
+    def test_output_dir_is_created_if_missing(self, tmp_path):
+        """The fix must create --output-dir before writing — the issue's
+        reproduction has the user pointing at a fresh nested path that
+        does not yet exist (`/path/to/sweep/reports/system`)."""
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        deep = tmp_path / "a" / "b" / "c"
+        assert not deep.exists()
+        args = Namespace(debug=False, output_dir=str(deep))
+        gen = _make_generator(results_dir, args=args)
+
+        gen.write_json_file([{'k': 'v'}])
+
+        assert deep.is_dir()
+        assert (deep / "results.json").exists()
+
+
+class TestIssue599CanonicalTreeAccepted:
+    """Bug 1: the validator rejected the canonical
+    `<results-dir>/<closed|open>/<orgname>/results/<systemname>/<bench>/...`
+    layout that the rest of the toolchain produces. After the fix,
+    ReportGenerator discovers the canonical slice via discover_scan_roots
+    and validates that slice, accepting the tree the user already has."""
+
+    def test_canonical_closed_tree_is_accepted_and_walked(self, tmp_path):
+        """The validator must pass and accumulate_results must walk the
+        closed slice for the requested system. Pre-fix this raised
+        SystemExit at validation time."""
+        _write_canonical_run(
+            tmp_path, "closed", "Acme", "sysA",
+            benchmark="training", model="unet3d",
+        )
+
+        args = Namespace(
+            debug=False, output_dir=None,
+            orgname="Acme", systemname="sysA",
+        )
+
+        # Intercept get_runs_files so we can assert it was called with the
+        # canonical slice path (NOT the bare tmp_path) — that's the key
+        # post-fix contract.
+        seen_scan_roots = []
+        def fake_get_runs(path, logger=None):
+            seen_scan_roots.append(path)
+            return []
+
+        with patch('mlpstorage_py.report_generator.get_runs_files',
+                   side_effect=fake_get_runs), \
+             patch.object(ReportGenerator, 'print_results'):
+            gen = ReportGenerator(str(tmp_path), args=args,
+                                  validate_structure=True)
+
+        expected_slice = str(
+            tmp_path / "closed" / "Acme" / "results" / "sysA"
+        )
+        assert seen_scan_roots == [expected_slice], (
+            f"accumulate_results must walk the canonical slice, "
+            f"not the bare results-dir. Saw: {seen_scan_roots!r}"
+        )
+        assert gen.scan_roots == [expected_slice]
+
+    def test_canonical_tree_does_not_aggregate_other_systems(self, tmp_path):
+        """Bug 3: a multi-system tree must aggregate ONLY the requested
+        system. Pre-fix, get_runs_files walked everything under
+        --results-dir and tagged every run with the requested
+        --systemname, mashing systems together."""
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysA")
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysB")
+
+        args = Namespace(
+            debug=False, output_dir=None,
+            orgname="Acme", systemname="sysA",
+        )
+        seen_scan_roots = []
+        def fake_get_runs(path, logger=None):
+            seen_scan_roots.append(path)
+            return []
+
+        with patch('mlpstorage_py.report_generator.get_runs_files',
+                   side_effect=fake_get_runs), \
+             patch.object(ReportGenerator, 'print_results'):
+            ReportGenerator(str(tmp_path), args=args,
+                            validate_structure=True)
+
+        # Only sysA's slice may be scanned.
+        assert seen_scan_roots == [
+            str(tmp_path / "closed" / "Acme" / "results" / "sysA")
+        ], seen_scan_roots
+        # And definitely NOT sysB's.
+        assert not any(
+            "sysB" in p for p in seen_scan_roots
+        ), seen_scan_roots
+
+    def test_canonical_both_modes_walked(self, tmp_path):
+        """When the submitter has staged both closed/ and open/ subtrees
+        for the same system, both slices are walked."""
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysA")
+        _write_canonical_run(tmp_path, "open", "Acme", "sysA")
+
+        args = Namespace(
+            debug=False, output_dir=None,
+            orgname="Acme", systemname="sysA",
+        )
+        seen_scan_roots = []
+        def fake_get_runs(path, logger=None):
+            seen_scan_roots.append(path)
+            return []
+
+        with patch('mlpstorage_py.report_generator.get_runs_files',
+                   side_effect=fake_get_runs), \
+             patch.object(ReportGenerator, 'print_results'):
+            ReportGenerator(str(tmp_path), args=args,
+                            validate_structure=True)
+
+        assert sorted(seen_scan_roots) == sorted([
+            str(tmp_path / "closed" / "Acme" / "results" / "sysA"),
+            str(tmp_path / "open" / "Acme" / "results" / "sysA"),
+        ])
+
+    def test_flat_layout_still_works_without_orgname(self, tmp_path):
+        """Backward-compat: without orgname/systemname (programmatic
+        callers, the existing test fixtures, pre-LAY-03 trees), reportgen
+        still walks --results-dir directly."""
+        # Build a flat tree (no closed/open wrapper).
+        run_dir = tmp_path / "training" / "unet3d" / "run" / "20260123_120000"
+        run_dir.mkdir(parents=True)
+        (run_dir / "training_unet3d_metadata.json").write_text("{}")
+        (run_dir / "summary.json").write_text("{}")
+
+        seen_scan_roots = []
+        def fake_get_runs(path, logger=None):
+            seen_scan_roots.append(path)
+            return []
+
+        with patch('mlpstorage_py.report_generator.get_runs_files',
+                   side_effect=fake_get_runs), \
+             patch.object(ReportGenerator, 'print_results'):
+            # No args — exercises the no-orgname/no-systemname fallback.
+            ReportGenerator(str(tmp_path), args=None,
+                            validate_structure=True)
+
+        assert seen_scan_roots == [str(tmp_path)]


### PR DESCRIPTION
## Summary

Closes #599.

Three bugs in `mlpstorage reports reportgen` left it unusable against the directory layout the rest of the toolchain produces:

1. **Layout rejected.** `ResultsDirectoryValidator` looked for benchmark-type dirs at the top level of `--results-dir`, but the canonical tree written by `mlpstorage init` + `<bench> run` + accepted by `mlpstorage validate` places them five levels down at `<results-dir>/<closed|open>/<orgname>/results/<systemname>/<bench>/<model>/<command>/<datetime>/`. Reportgen refused the same tree everything else accepts.
2. **`--output-dir` parsed but ignored.** `write_json_file` / `write_csv_file` hard-coded `self.results_dir`, so artifacts always polluted the input tree regardless of `--output-dir`.
3. **`--systemname` required + sentinel-validated but never propagated to the run-walker.** A multi-system tree got aggregated into one report tagged with the requested systemname — the only systemname information visible was a label everyone got, not a filter.

## Approach

Bugs 1 and 3 share a single mechanism. A new helper

```python
discover_scan_roots(results_dir, orgname, systemname, logger=None)
```

in `mlpstorage_py/reporting/directory_validator.py` probes `<results-dir>/<closed|open>/<orgname>/results/<systemname>/` against the sentinel-resolved `args.orgname` (pinned by the LAY-03 gate in `main.py`) and the required `args.systemname`. When matching canonical slices exist, the helper returns them as the effective scan roots; otherwise it returns `[results_dir]` so legacy flat layouts keep working unchanged.

`ReportGenerator.__init__` resolves `self.scan_roots` once. `_validate_directory_structure` and `accumulate_results` iterate over the scan roots — validating each as a flat-layout root and walking each with `get_runs_files` — so the canonical-aware behaviour and the flat-layout behaviour share one code path.

Bug 2 fix: `__init__` also resolves `self.output_dir` from `args.output_dir` (falling back to `self.results_dir` when unset, for backward compat). A new `_ensure_output_dir()` runs `os.makedirs(self.output_dir, exist_ok=True)` before each write — the issue's reproduction has the user pointing at a fresh nested path that does not yet exist (`/path/to/sweep/reports/system`), and the expected behaviour is that mlpstorage creates it.

`get_expected_structure_help()` updated to document the canonical layout above the flat layout — when validation does fail, the error message points at the right shape.

## Behaviour matrix

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| Canonical tree at `<results-dir>/<mode>/<org>/results/<sys>/...` (the one `mlpstorage init` produces) | Validator rejects with `No benchmark type directories found` | Validator and walker target the per-mode slice; only the requested system is aggregated |
| Multi-system tree | Walker visits every system's runs; all get the requested `--systemname` label | Walker only visits the requested system's slice |
| Both closed/ and open/ subtrees present for the same system | Same rejection | Both slices walked; runs aggregated together |
| Flat layout (legacy/programmatic callers) | Worked | Still works — `[results_dir]` fallback |
| `--output-dir /path/to/reports/sysA` (path does not exist) | `results.{csv,json}` written into `--results-dir` | Created on first write, artifacts land there |
| `--output-dir` unset | `results.{csv,json}` in `--results-dir` | Same — fallback preserved |

## Tests

18 new:

- `tests/unit/test_directory_validator.py::TestDiscoverScanRoots` (9):
  - missing orgname → flat fallback
  - missing systemname → flat fallback
  - canonical slice absent on disk → flat fallback
  - closed-only present → closed slice
  - open-only present → open slice
  - both present → both slices in `_CANONICAL_MODES` order
  - sibling system on disk → only requested system's slice returned (bug 3)
  - sibling orgname on disk → only requested org's slice returned (defense in depth)
  - canonical path exists but as a non-directory → flat fallback
- `tests/unit/test_reporting.py`:
  - `TestIssue599OutputDirHonored` (5): JSON / CSV land in `--output-dir`; fallback when unset; fallback when `args=None`; deep nested `--output-dir` auto-created
  - `TestIssue599CanonicalTreeAccepted` (4): canonical closed tree validated and walked at the correct slice; multi-system tree filtered to one system; both-modes case walks both; flat-layout passthrough

## Test plan

- [x] `tests/` — 2453 passed, 13 deselected
- [x] `mlpstorage_py/tests/` — 780 passed, 1 xfailed (pre-existing)
- [x] `kv_cache_benchmark/tests/` — 238 passed, 2 deselected
- [x] `vdb_benchmark/tests/tests/` — 144 passed
- [x] Total: 3615 passed
- [ ] Reviewer to verify with the issue's reproduction recipe:
  ```bash
  mlpstorage init Acme /path/to/sweep
  mlpstorage closed training run --results-dir /path/to/sweep --systemname sysA ...
  mlpstorage reports reportgen --results-dir /path/to/sweep --systemname sysA --output-dir /tmp/reports/sysA
  # results.{csv,json} land under /tmp/reports/sysA, not inside /path/to/sweep
  # only sysA's runs are aggregated
  ```