### PR TITLE
fix(#608): rule 3.3.1 reads real datasize/datagen metadata, warn-only

### DIFF
--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -254,72 +254,218 @@ class TrainingCheck(BaseCheck):
     
     @rule("3.3.1", "trainingRunDataMatchesDatasize")
     def run_data_matches_datasize(self):
-        """
-        Verify that run data matches the calculated datasize exactly.
+        """Verify run.num_files_train is in [datasize, datagen] per --data-dir.
+
+        Issue #608: prior versions compared against
+        ``NUM_DATASET_TRAIN_FILES`` placeholder constants tagged
+        ``# TODO: Ask for correct values``. Real submissions easily
+        exceed the placeholder (UNet3D at 3 nodes × B200 / 768 GiB
+        needs 84,375 files, not 14,000), so every conforming
+        submission failed unconditionally. This rewrite reads the
+        actual values that the ``datasize/`` and ``datagen/`` phases
+        wrote for THIS submission.
+
+        Two bounds:
+
+        * Upper: ``run.num_files_train > datagen.num_files_train`` →
+          ``[3.3.1 DATAGEN-OVERRUN]`` warning. The run consumed more
+          data than datagen produced — physically impossible against
+          the recorded --data-dir, or sweep config mismatch.
+        * Lower: ``run.num_files_train < datasize.num_files_train`` →
+          ``[3.3.1 DATASIZE-UNDERRUN]`` warning. The run consumed
+          less than the minimum prescribed for a representative
+          benchmark.
+
+        Datasize→run matching: pair the run with the datasize phase
+        whose ``args.data_dir`` matches the run's ``args.data_dir``.
+        If exactly one matches, use it. If multiple datasize phases
+        target the same --data-dir, emit ``[3.3.1 DATASIZE-REUSED]``
+        — the --data-dir has been reused and we cannot determine
+        authoritatively what it contains. If no match exists, emit
+        ``[3.3.1 DATADIR-MISMATCH]``.
+
+        All violations are warnings (``warn_violation``) — mid
+        submission-window, do not invalidate work already on disk.
+        After the window closes the appropriate violations may be
+        promoted to errors; the stable bracketed tokens
+        (``[3.3.1 DATAGEN-OVERRUN]``, etc.) give submitter CI a
+        grep-stable suppression surface in the meantime.
+
+        Missing datasize/datagen phases emit ``[3.3.1 DATASIZE-MISSING]``
+        / ``[3.3.1 DATAGEN-MISSING]`` warnings rather than silent skip.
+
+        See `.planning/BACKLOG.md` B-04 for the post-window manifest
+        extension that closes the "but is the data really on disk?"
+        loop without paying object-store LIST cost.
+
         (Rules.md 3.3.1)
         """
-        # Question: Subfolders?
-        # What are the true values of the dataset
         valid = True
         if self.mode != "training":
             return valid
 
-        # Resolve expected dataset cardinalities up front. Returns None if
-        # the workload directory name does not match a known model
-        # ({unet3d, retinanet}); 2.1.11 trainingWorkloads already
-        # flags the structural complaint for the non-conforming name, so
-        # skip the cardinality cross-check rather than crash on the dict
-        # lookup or on a None comparison below.
-        expected_train = self.config.get_num_train_files(self.model)
-        expected_eval = self.config.get_num_eval_files(self.model)
-        if expected_train is None or expected_eval is None:
-            self.log.info(
-                "[3.3.1 trainingRunDataMatchesDatasize] %s: skipping "
-                "cardinality cross-check — workload %r is not in known "
-                "models {unet3d, retinanet}; see 2.1.11 violation "
-                "for the structural complaint",
-                self.path, self.model,
+        datasize_files = self.submissions_logs.datasize_files or []
+        datagen_files = self.submissions_logs.datagen_files or []
+
+        # Pre-resolve --data-dir → datasize-record mapping for reuse detection.
+        # Each datasize_files entry is (summary=None, metadata_dict, timestamp_str).
+        datasize_by_dir = self._group_datasize_by_data_dir(datasize_files)
+
+        # Pre-resolve the single most-recent datagen metadata (we treat datagen
+        # as one-per-submission; sweep workflows generate once for the largest
+        # size and run multiple smaller configs against it).
+        datagen_num_files_train, datagen_data_dir = self._extract_latest_datagen_cardinality(datagen_files)
+
+        if not datasize_files:
+            self.warn_violation(
+                "3.3.1", "trainingRunDataMatchesDatasize", self.path,
+                "[3.3.1 DATASIZE-MISSING] no datasize/ phase found; "
+                "rule 3.3.1 cross-check skipped",
             )
-            return valid
+        if not datagen_files:
+            self.warn_violation(
+                "3.3.1", "trainingRunDataMatchesDatasize", self.path,
+                "[3.3.1 DATAGEN-MISSING] no datagen/ phase found; "
+                "upper-bound check skipped",
+            )
+
+        # Warn once per reused --data-dir, regardless of how many runs reference it.
+        for data_dir, records in datasize_by_dir.items():
+            if len(records) > 1:
+                self.warn_violation(
+                    "3.3.1", "trainingRunDataMatchesDatasize", self.path,
+                    "[3.3.1 DATASIZE-REUSED] %d datasize/ phases target --data-dir %r; "
+                    "cannot determine authoritative cardinality",
+                    len(records), data_dir,
+                )
 
         for summary, metadata, ts in self.submissions_logs.run_files:
-            if summary is None:
-                self.log.debug(
-                    "[3.3.1] %s/%s: skipping (summary not loaded; "
-                    "missing summary.json reported under 2.1.19)",
-                    self.path, ts,
-                )
+            if summary is None or metadata is None:
+                # 2.1.19 already flags missing summary; do not double-fire here.
                 continue
-            num_files_train = summary.get("num_files_train", None)
-            num_files_eval = summary.get("num_files_eval", None)
 
-            if num_files_train is None:
-                self.log_violation(
-                    "3.3.1", "trainingRunDataMatchesDatasize", self.path,
-                    "num_files_train not set",
-                )
-                valid = False
-            elif num_files_train > expected_train:
-                self.log_violation(
-                    "3.3.1", "trainingRunDataMatchesDatasize", self.path,
-                    "num_files_train should be lower than in dataset",
-                )
-                valid = False
+            run_num_files_train = summary.get("num_files_train")
+            run_num_files_eval = summary.get("num_files_eval")
+            run_data_dir = metadata.get("args", {}).get("data_dir")
 
-            if num_files_eval is None:
-                self.log_violation(
-                    "3.3.1", "trainingRunDataMatchesDatasize", self.path,
-                    "num_files_eval not set",
-                )
-                valid = False
-            elif num_files_eval > expected_eval:
-                self.log_violation(
-                    "3.3.1", "trainingRunDataMatchesDatasize", self.path,
-                    "num_files_eval should be lower than in dataset",
-                )
-                valid = False
+            # Resolve the datasize record that matches this run's --data-dir.
+            datasize_record = self._match_datasize_for_run(
+                run_data_dir, datasize_by_dir, ts,
+            )
 
+            if datasize_record is not None:
+                ds_num_files_train, ds_data_dir = datasize_record
+                if (ds_num_files_train is not None
+                        and run_num_files_train is not None
+                        and run_num_files_train < ds_num_files_train):
+                    self.warn_violation(
+                        "3.3.1", "trainingRunDataMatchesDatasize", self.path,
+                        "[3.3.1 DATASIZE-UNDERRUN] run/%s num_files_train (%s) < "
+                        "datasize num_files_train (%s); representative-benchmark "
+                        "floor not met",
+                        ts, run_num_files_train, ds_num_files_train,
+                    )
+            elif datasize_files and run_data_dir is not None:
+                # We had datasize records, but none matched this run's --data-dir.
+                self.warn_violation(
+                    "3.3.1", "trainingRunDataMatchesDatasize", self.path,
+                    "[3.3.1 DATADIR-MISMATCH] run/%s --data-dir %r has no matching "
+                    "datasize/ phase; lower-bound check skipped",
+                    ts, run_data_dir,
+                )
+
+            # Upper bound against datagen.
+            if (datagen_num_files_train is not None
+                    and run_num_files_train is not None
+                    and run_num_files_train > datagen_num_files_train):
+                self.warn_violation(
+                    "3.3.1", "trainingRunDataMatchesDatasize", self.path,
+                    "[3.3.1 DATAGEN-OVERRUN] run/%s num_files_train (%s) > "
+                    "datagen num_files_train (%s); run consumed more data than "
+                    "datagen produced",
+                    ts, run_num_files_train, datagen_num_files_train,
+                )
+
+            # num_files_eval mirror — absent-key is a warning, NOT silent skip
+            # (issue #608 WRT 4). Models without an eval phase will warn once
+            # per run; the stable token lets submitter CI suppress per-model.
+            if run_num_files_eval is None:
+                self.warn_violation(
+                    "3.3.1", "trainingRunDataMatchesDatasize", self.path,
+                    "[3.3.1 EVAL-FIELD-MISSING] run/%s summary has no "
+                    "num_files_eval field; eval cross-check skipped",
+                    ts,
+                )
+
+        # Warn-only invariant: rule passes regardless of warnings recorded.
         return valid
+
+    @staticmethod
+    def _group_datasize_by_data_dir(datasize_files):
+        """Group loaded datasize tuples by ``args.data_dir`` value.
+
+        Returns ``{data_dir: [(num_files_train, timestamp), ...]}``.
+        Entries with missing metadata or missing num_files_train still
+        appear in the dict (with value ``None``) so reuse detection
+        does not silently drop them.
+        """
+        grouped: dict = {}
+        for _summary, metadata, ts in datasize_files:
+            if metadata is None:
+                continue
+            data_dir = metadata.get("args", {}).get("data_dir")
+            params = metadata.get("parameters", {}) or {}
+            dataset_params = params.get("dataset", {}) or {}
+            num_files_train = dataset_params.get("num_files_train")
+            grouped.setdefault(data_dir, []).append((num_files_train, ts))
+        return grouped
+
+    @staticmethod
+    def _extract_latest_datagen_cardinality(datagen_files):
+        """Return (num_files_train, data_dir) from the most-recent datagen phase.
+
+        Uses timestamp string ordering — datasize/datagen/run timestamps
+        sort lexically as long as they share the canonical
+        ``YYYYMMDD_HHmmss`` format that mlpstorage emits.
+        """
+        latest_ts = None
+        latest_metadata = None
+        for _summary, metadata, ts in datagen_files:
+            if metadata is None:
+                continue
+            if latest_ts is None or ts > latest_ts:
+                latest_ts = ts
+                latest_metadata = metadata
+        if latest_metadata is None:
+            return None, None
+        params = latest_metadata.get("parameters", {}) or {}
+        dataset_params = params.get("dataset", {}) or {}
+        num_files_train = dataset_params.get("num_files_train")
+        data_dir = latest_metadata.get("args", {}).get("data_dir")
+        return num_files_train, data_dir
+
+    @staticmethod
+    def _match_datasize_for_run(run_data_dir, datasize_by_dir, run_ts):
+        """Return (num_files_train, data_dir) for the datasize record matching this run.
+
+        Match priority:
+          1. Exact ``args.data_dir`` equality between datasize and run.
+             If multiple datasize phases target the same --data-dir
+             (reuse case), pick the most-recent one before ``run_ts``.
+          2. No match → return ``None`` so the caller emits
+             ``[3.3.1 DATADIR-MISMATCH]``.
+        """
+        if run_data_dir is None:
+            return None
+        records = datasize_by_dir.get(run_data_dir)
+        if not records:
+            return None
+        # Pick the latest datasize timestamp that is <= the run timestamp;
+        # falls through to the latest overall if none are <= run_ts.
+        eligible = [(num, ts) for (num, ts) in records if ts <= run_ts] or records
+        eligible_sorted = sorted(eligible, key=lambda r: r[1])
+        chosen_num, _chosen_ts = eligible_sorted[-1]
+        return chosen_num, run_data_dir
     
     @rule("3.3.2", "trainingAcceleratorUtilizationCheck")
     def accelerator_utilization_check(self):

--- a/mlpstorage_py/submission_checker/configuration/configuration.py
+++ b/mlpstorage_py/submission_checker/configuration/configuration.py
@@ -35,17 +35,10 @@ class Config:
     def get_checkpoint_required_folders(self):
         return CHECKPOINT_REQUIRED_FOLDERS[self.version]
     
-    def get_num_train_files(self, model):
-        # .get returns None for unknown model names — the caller decides
-        # whether the per-model lookup is critical (skip with a diagnostic)
-        # or expected to always resolve. Non-conforming workload directory
-        # names (e.g. "unet3d_a100", "retinanet-20N-6PPN-A100") flagged by
-        # 2.1.11 trainingWorkloads would otherwise crash this dict lookup.
-        return NUM_DATASET_TRAIN_FILES.get(model)
-
-    def get_num_eval_files(self, model):
-        # See get_num_train_files: .get over [] for None-on-miss semantics.
-        return NUM_DATASET_EVAL_FILES.get(model)
+    # Issue #608: get_num_train_files / get_num_eval_files were deleted —
+    # they only ever returned values from the NUM_DATASET_*_FILES placeholder
+    # dicts (`# TODO: Ask for correct values`) that are also gone. Rule 3.3.1
+    # now reads per-submission datasize metadata instead.
 
     def get_checkpoint_file(self, model):
         # See get_num_train_files: .get over [] for None-on-miss semantics.

--- a/mlpstorage_py/submission_checker/constants.py
+++ b/mlpstorage_py/submission_checker/constants.py
@@ -97,26 +97,12 @@ CHECKPOINT_REQUIRED_FOLDERS = {
     "default": ["dlio_config"],
 }
 
-# TODO: Ask for correct values
-NUM_DATASET_TRAIN_FILES = {
-    "unet3d": 14000,
-    "retinanet": 0
-}
-
-NUM_DATASET_EVAL_FILES = {
-    "unet3d": 0,
-    "retinanet": 0
-}
-
-NUM_DATASET_TRAIN_FOLDERS = {
-    "unet3d": 0,
-    "retinanet": 0
-}
-
-NUM_DATASET_EVAL_FOLDERS = {
-    "unet3d": 0,
-    "retinanet": 0
-}
+# Issue #608: NUM_DATASET_TRAIN_FILES / NUM_DATASET_EVAL_FILES /
+# NUM_DATASET_TRAIN_FOLDERS / NUM_DATASET_EVAL_FOLDERS placeholder dicts
+# (`# TODO: Ask for correct values`) were deleted here. Rule 3.3.1 now
+# reads the per-submission `datasize/<ts>/training_<ts>_metadata.json`
+# instead, which is the value the datasize phase actually wrote and is
+# guaranteed to match the configuration the submitter ran.
 
 CHECKPOINT_FILE_MAP = {
     "llama3-1t": "llama3_1t.yaml",

--- a/mlpstorage_py/submission_checker/loader.py
+++ b/mlpstorage_py/submission_checker/loader.py
@@ -26,6 +26,7 @@ class SubmissionLogs:
     transfer object passed between loading and validation phases.
     """
     datagen_files: list = None
+    datasize_files: list = None
     run_files: list = None
     checkpoint_files: list = None
     system_file: dict = None
@@ -103,13 +104,18 @@ class Loader:
                             loader_metadata = LoaderMetadata(division=division, submitter=submitter, system=system, mode=mode, benchmark=benchmark, folder=benchmark_path)
                             if mode == "training":
                                 datagen_path = os.path.join(benchmark_path, "datagen")
+                                datasize_path = os.path.join(benchmark_path, "datasize")
                                 run_path = os.path.join(benchmark_path, "run")
                                 datagen_files = []
+                                datasize_files = []
                                 run_files = []
-                                # Missing datagen/ or run/ is a structural violation caught by
-                                # SubmissionStructureCheck STRUCT-12 (2.1.12). The loader yields
-                                # empty file lists so the rest of the corpus traversal continues.
+                                # Missing datagen/ / datasize/ / run/ is a structural violation
+                                # caught by SubmissionStructureCheck STRUCT-12 (2.1.12) and by
+                                # rule 3.3.1's DATASIZE-MISSING / DATAGEN-MISSING warnings.
+                                # The loader yields empty file lists so the rest of the corpus
+                                # traversal continues.
                                 datagen_timestamps = list_dir(datagen_path) if os.path.isdir(datagen_path) else []
+                                datasize_timestamps = list_dir(datasize_path) if os.path.isdir(datasize_path) else []
                                 run_timestamps = list_dir(run_path) if os.path.isdir(run_path) else []
                                 for timestamp in datagen_timestamps:
                                     timestamp_path = os.path.join(datagen_path, timestamp)
@@ -119,6 +125,17 @@ class Loader:
                                     datagen_file = self.load_single_log(summary_path, "Summary")
                                     datagen_files.append((datagen_file, metadata_file, timestamp))
 
+                                # Issue #608: walk datasize/<ts>/ so rule 3.3.1 can cross-check
+                                # run.num_files_train against the value the datasize phase
+                                # actually prescribed for this submission. Datasize directories
+                                # carry only a metadata file (no summary.json); the summary slot
+                                # in each tuple is therefore None.
+                                for timestamp in datasize_timestamps:
+                                    timestamp_path = os.path.join(datasize_path, timestamp)
+                                    metadata_path = self.find_metadata_path(timestamp_path)
+                                    metadata_file = self.load_single_log(metadata_path, "Metadata")
+                                    datasize_files.append((None, metadata_file, timestamp))
+
                                 for timestamp in run_timestamps:
                                     timestamp_path = os.path.join(run_path, timestamp)
                                     summary_path = os.path.join(timestamp_path, "summary.json")
@@ -127,8 +144,8 @@ class Loader:
                                     metadata_file = self.load_single_log(metadata_path, "Metadata")
                                     run_file = self.load_single_log(summary_path, "Summary")
                                     run_files.append((run_file, metadata_file, timestamp))
-                                
-                                yield SubmissionLogs(datagen_files, run_files, system_file=system_file, loader_metadata=loader_metadata)
+
+                                yield SubmissionLogs(datagen_files=datagen_files, datasize_files=datasize_files, run_files=run_files, system_file=system_file, loader_metadata=loader_metadata)
                             else:
                                 checkpoint_path = os.path.join(mode_path, benchmark)
                                 checkpoint_files = []

--- a/mlpstorage_py/tests/conftest.py
+++ b/mlpstorage_py/tests/conftest.py
@@ -365,6 +365,12 @@ def build_submission(tmp_path, **overrides) -> Path:
       ``args.checkpoint_folder`` in each checkpoint metadata.json.
     * ``chkpt_results_dir`` (str | None) — CHKPT-06: sets ``args.results_dir``
       in each checkpoint metadata.json.
+    * ``chkpt_summary_checkpoint_size_GB`` (int | float | None) — rule 4.3.1:
+      when non-None, injects ``summary.metric.checkpoint_size_GB`` into each
+      checkpoint summary.json. Required to exercise
+      ``checkpoint_data_size_ratio`` — the code short-circuits when the field
+      is 0/missing, so tests that assert the advisory-warning branch need a
+      positive value here.
     * ``run_data_dir`` (str | None) — TRAIN-02: sets ``args.data_dir`` in each
       run metadata.json.
     * ``run_results_dir`` (str | None) — TRAIN-02: sets ``args.results_dir`` in
@@ -420,6 +426,7 @@ def build_submission(tmp_path, **overrides) -> Path:
     chkpt_simultaneous_flags = overrides.pop("chkpt_simultaneous_flags", None)
     chkpt_checkpoint_folder = overrides.pop("chkpt_checkpoint_folder", None)
     chkpt_results_dir = overrides.pop("chkpt_results_dir", None)
+    chkpt_summary_checkpoint_size_GB = overrides.pop("chkpt_summary_checkpoint_size_GB", None)
     run_data_dir = overrides.pop("run_data_dir", None)
     run_results_dir = overrides.pop("run_results_dir", None)
 
@@ -735,6 +742,11 @@ def build_submission(tmp_path, **overrides) -> Path:
                         chkpt_summary["end"] = ts_end.isoformat()
                         chkpt_summary["start_time"] = ts_start.isoformat()
                         chkpt_summary["end_time"] = ts_end.isoformat()
+
+                if chkpt_summary_checkpoint_size_GB is not None:
+                    metric = dict(chkpt_summary.get("metric", {}))
+                    metric["checkpoint_size_GB"] = chkpt_summary_checkpoint_size_GB
+                    chkpt_summary["metric"] = metric
 
                 (ts_dir / "summary.json").write_text(
                     json.dumps(chkpt_summary), encoding="utf-8"

--- a/mlpstorage_py/tests/test_checkpointing_check_retrofit.py
+++ b/mlpstorage_py/tests/test_checkpointing_check_retrofit.py
@@ -4,12 +4,10 @@ Tests for Plan 03-02 Task 4: CheckpointingCheck @rule retrofit (D-R3).
 Covers:
   - Parametrized assertion that each of the 8 retrofitted (rule_id, method)
     pairs on CheckpointingCheck has __rule_id__ == expected.
-  - 4.3.1 routing pin (xfail under W-03 lock — the conftest
-    build_submission factory does NOT expose a kwarg to inject
-    summary["metric"]["checkpoint_size_GB"], so the warning path inside
-    checkpoint_data_size_ratio is unreachable through the fixture API).
-    The xfail decoration documents the W-03 follow-up; removing it once
-    conftest is extended promotes the test to a passing assertion.
+  - 4.3.1 routing pin — asserts warn_violation (not log_violation) when
+    checkpoint data per node < 3x host memory. Uses the
+    `chkpt_summary_checkpoint_size_GB` conftest kwarg to inject a positive
+    checkpoint_size_GB and reach the advisory branch.
   - 4.4.1 (checkpoint_folder == results_dir) emits prefixed violation.
   - 4.6.3 (closed CLOSED metadata with disallowed yaml_params) emits
     prefixed violation — uses an in-test metadata mutation helper rather
@@ -105,43 +103,23 @@ def test_every_retrofitted_checkpointing_method_has_rule_id_attribute(rule_id, m
 
 
 # ---------------------------------------------------------------------------
-# 4.3.1 routing pin — W-03 lock: xfail until conftest gains
-# summary.metric.checkpoint_size_GB injection kwarg.
+# 4.3.1 routing pin — warn_violation on undersized checkpoint per node.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "conftest build_submission has no kwarg to inject "
-        "summary.metric.checkpoint_size_GB; the 4.3.1 advisory trigger requires "
-        "checkpoint_size_GB > 0. Follow-up: extend conftest in a later phase to "
-        "enable this assertion. Tracking: TODO-W03."
-    ),
-    strict=False,
-)
 def test_4_3_1_undersized_checkpoint_emits_warn_prefix_not_error(tmp_path, mock_logger):
     """4.3.1 routing pin: when checkpoint data per node < 3x host memory,
     checkpoint_data_size_ratio MUST emit a [4.3.1 checkpointDataSizeRatio]
     warning (via warn_violation) and NOT an error (via log_violation).
 
-    Currently xfails because conftest's _DEFAULT_SUMMARY has no
-    metric.checkpoint_size_GB field and build_submission does not expose a
-    kwarg to inject one, so the early `continue` in
-    checkpoint_data_size_ratio (when checkpoint_size_gb == 0) prevents the
-    warn-violation branch from ever executing.
-
-    Once conftest gains a `chkpt_summary_checkpoint_size_GB` kwarg (or
-    equivalent), remove the xfail decoration to promote this to a passing
-    assertion. The structural pin (Task 2 grep that 4.3.1 routes through
-    warn_violation) covers the routing decision at source-code level today.
+    Default fixture has host_memory_GB=[256, 256] and num_hosts=2, so the
+    per-node threshold is 3 * 256 = 768 GiB. Injecting checkpoint_size_GB=100
+    puts data_per_node at 50 GiB — well under threshold — which triggers the
+    warn-violation branch.
     """
     from mlpstorage_py.tests.conftest import build_submission
-    # The default fixture passes through the early-continue guard.
-    # We invoke the method anyway so the test body documents the expected
-    # post-extension behavior.
-    root = build_submission(tmp_path)
+    root = build_submission(tmp_path, chkpt_summary_checkpoint_size_GB=100)
     check = _run_checkpointing_check(root, mock_logger)
     check.checkpoint_data_size_ratio()
-    # Expected behavior (post conftest extension):
     assert any(
         m.startswith("[4.3.1 checkpointDataSizeRatio]")
         for m in mock_logger.warnings
@@ -149,7 +127,6 @@ def test_4_3_1_undersized_checkpoint_emits_warn_prefix_not_error(tmp_path, mock_
         f"expected warning starting with [4.3.1 checkpointDataSizeRatio]; "
         f"got warnings={mock_logger.warnings}"
     )
-    # Expected behavior (post conftest extension): no error-level 4.3.1 record
     assert not any(
         m.startswith("[4.3.1 ")
         for m in mock_logger.errors

--- a/tests/unit/test_submission_checker_run_matches_datasize.py
+++ b/tests/unit/test_submission_checker_run_matches_datasize.py
@@ -144,9 +144,9 @@ def _build_training_tree(
 
 
 def _run_rule(root: Path, caplog):
-    """Instantiate DirectoryCheck and run rule 3.3.1; return (result, log_records)."""
-    from mlpstorage_py.submission_checker.checks.directory_checks import (
-        DirectoryCheck,
+    """Instantiate TrainingCheck and run rule 3.3.1; return (result, log_records)."""
+    from mlpstorage_py.submission_checker.checks.training_checks import (
+        TrainingCheck,
     )
     from mlpstorage_py.submission_checker.configuration.configuration import Config
     from mlpstorage_py.submission_checker.constants import DEFAULT_SPEC_VERSION
@@ -165,10 +165,9 @@ def _run_rule(root: Path, caplog):
     )
 
     log = logging.getLogger("test_submission_checker_run_matches_datasize")
-    check = DirectoryCheck(log=log, config=config, submissions_logs=logs)
+    check = TrainingCheck(log=log, config=config, submissions_logs=logs)
 
-    caplog.set_level(logging.WARNING, logger=log.name)
-    caplog.set_level(logging.ERROR, logger=log.name)
+    caplog.set_level(logging.WARNING)
     result = check.run_data_matches_datasize()
     return result, caplog.records
 
@@ -214,6 +213,8 @@ class TestPositiveCases:
             datasize_num_files=n,
             datagen_num_files=n,
             run_num_files=n,
+            eval_run=0,
+            eval_datasize=0,
         )
         assert result is True, (
             f"rule 3.3.1 must pass when datasize = datagen = run = {n}"
@@ -236,6 +237,8 @@ class TestPositiveCases:
             datasize_num_files=84_375,
             datagen_num_files=450_000,
             run_num_files=84_375,
+            eval_run=0,
+            eval_datasize=0,
         )
         assert result is True
         violation_records = [r for r in records if "[3.3.1" in r.getMessage()]

--- a/tests/unit/test_submission_checker_run_matches_datasize.py
+++ b/tests/unit/test_submission_checker_run_matches_datasize.py
@@ -1,0 +1,425 @@
+"""Tests for `DirectoryCheck.run_data_matches_datasize` (Rules.md 3.3.1).
+
+Pins the substantive contract of rule 3.3.1 against issue #608:
+
+* Reference values come from the ``datasize/`` and ``datagen/`` phases
+  on disk, NOT from a placeholder ``NUM_DATASET_TRAIN_FILES`` dict.
+* Two-bound check: ``datasize <= run.num_files_train <= datagen``.
+* All violations are warnings (``warn_violation``), never errors. We
+  are mid submission-window; do not invalidate already-completed
+  submitter work.
+* Stable bracketed prefix tokens for grep-suppression
+  (``[3.3.1 DATAGEN-OVERRUN]``, ``[3.3.1 DATASIZE-UNDERRUN]``,
+  ``[3.3.1 DATADIR-MISMATCH]``, ``[3.3.1 DATASIZE-REUSED]``,
+  ``[3.3.1 DATASIZE-MISSING]``, ``[3.3.1 DATAGEN-MISSING]``,
+  ``[3.3.1 EVAL-FIELD-MISSING]``).
+
+The check always returns ``True`` because every category is warn-only.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+
+def _write_metadata(
+    timestamp_dir: Path,
+    benchmark: str,
+    timestamp: str,
+    num_files_train: int,
+    data_dir: str,
+    num_files_eval: Optional[int] = None,
+) -> Path:
+    """Write a `<benchmark>_<ts>_metadata.json` matching the producer shape.
+
+    Producer at `mlpstorage_py/benchmarks/base.py:395-453` writes a JSON
+    with `parameters.dataset.num_files_train` (DLIO-merged) and
+    `args.data_dir` (raw CLI namespace). The validator-side rule reads
+    those exact paths.
+    """
+    metadata_path = timestamp_dir / f"{benchmark}_{timestamp}_metadata.json"
+    metadata: dict = {
+        "parameters": {
+            "dataset": {
+                "num_files_train": num_files_train,
+            },
+        },
+        "args": {
+            "data_dir": data_dir,
+        },
+    }
+    if num_files_eval is not None:
+        metadata["parameters"]["dataset"]["num_files_eval"] = num_files_eval
+    metadata_path.write_text(json.dumps(metadata) + "\n")
+    return metadata_path
+
+
+def _write_run_summary(
+    timestamp_dir: Path,
+    num_files_train: int,
+    num_files_eval: Optional[int] = None,
+) -> None:
+    """Write a `summary.json` for a run timestamp directory.
+
+    The run consumer reads `summary.num_files_train` directly.
+    """
+    summary: dict = {
+        "num_files_train": num_files_train,
+        "start": "2026-06-30T12:00:00",
+        "end": "2026-06-30T12:01:00",
+    }
+    if num_files_eval is not None:
+        summary["num_files_eval"] = num_files_eval
+    (timestamp_dir / "summary.json").write_text(json.dumps(summary) + "\n")
+
+
+def _build_training_tree(
+    tmp_path: Path,
+    *,
+    datasize_num_files: int,
+    datagen_num_files: int,
+    run_num_files: int,
+    data_dir_datasize: str = "/data/unet3d",
+    data_dir_datagen: str = "/data/unet3d",
+    data_dir_run: str = "/data/unet3d",
+    datasize_extras: Optional[list[dict]] = None,
+    eval_run: Optional[int] = None,
+    eval_datasize: Optional[int] = None,
+) -> Path:
+    """Build a `<workload>/{datasize,datagen,run}/<ts>/` layout for one model.
+
+    Returns the workload directory path (``<tmp>/training/unet3d``).
+    """
+    workload_dir = tmp_path / "training" / "unet3d"
+    workload_dir.mkdir(parents=True)
+
+    # datasize phase
+    datasize_ts = "20260630_100000"
+    datasize_ts_dir = workload_dir / "datasize" / datasize_ts
+    datasize_ts_dir.mkdir(parents=True)
+    _write_metadata(
+        datasize_ts_dir, "training", datasize_ts,
+        num_files_train=datasize_num_files,
+        data_dir=data_dir_datasize,
+        num_files_eval=eval_datasize,
+    )
+
+    # Optional additional datasize timestamps (sweep / reuse scenarios)
+    for i, extra in enumerate(datasize_extras or []):
+        extra_ts = f"20260630_10{i+1:02d}00"
+        extra_ts_dir = workload_dir / "datasize" / extra_ts
+        extra_ts_dir.mkdir(parents=True)
+        _write_metadata(
+            extra_ts_dir, "training", extra_ts,
+            num_files_train=extra.get("num_files_train", datasize_num_files),
+            data_dir=extra.get("data_dir", data_dir_datasize),
+        )
+
+    # datagen phase
+    datagen_ts = "20260630_110000"
+    datagen_ts_dir = workload_dir / "datagen" / datagen_ts
+    datagen_ts_dir.mkdir(parents=True)
+    _write_metadata(
+        datagen_ts_dir, "training", datagen_ts,
+        num_files_train=datagen_num_files,
+        data_dir=data_dir_datagen,
+    )
+
+    # run phase
+    run_ts = "20260630_120000"
+    run_ts_dir = workload_dir / "run" / run_ts
+    run_ts_dir.mkdir(parents=True)
+    _write_metadata(
+        run_ts_dir, "training", run_ts,
+        num_files_train=run_num_files,
+        data_dir=data_dir_run,
+        num_files_eval=eval_run,
+    )
+    _write_run_summary(run_ts_dir, num_files_train=run_num_files, num_files_eval=eval_run)
+    return workload_dir
+
+
+def _run_rule(root: Path, caplog):
+    """Instantiate DirectoryCheck and run rule 3.3.1; return (result, log_records)."""
+    from mlpstorage_py.submission_checker.checks.directory_checks import (
+        DirectoryCheck,
+    )
+    from mlpstorage_py.submission_checker.configuration.configuration import Config
+    from mlpstorage_py.submission_checker.constants import DEFAULT_SPEC_VERSION
+    from mlpstorage_py.submission_checker.loader import Loader
+
+    config = Config(version=DEFAULT_SPEC_VERSION, submitters=None)
+    loader = Loader(root=str(root), version=DEFAULT_SPEC_VERSION, config=config)
+    submissions = list(loader.load())
+    assert len(submissions) == 1, (
+        f"Expected exactly one submission yielded by Loader; got {len(submissions)}"
+    )
+    logs = submissions[0]
+    # Ensure the loader extension is present.
+    assert hasattr(logs, "datasize_files"), (
+        "SubmissionLogs must expose datasize_files after loader extension"
+    )
+
+    log = logging.getLogger("test_submission_checker_run_matches_datasize")
+    check = DirectoryCheck(log=log, config=config, submissions_logs=logs)
+
+    caplog.set_level(logging.WARNING, logger=log.name)
+    caplog.set_level(logging.ERROR, logger=log.name)
+    result = check.run_data_matches_datasize()
+    return result, caplog.records
+
+
+def _scaffold_division_root(tmp_path: Path, workload_dir: Path) -> Path:
+    """Wrap a workload dir in the canonical ``closed/<org>/results/<sys>/`` shape.
+
+    Returns the submission ROOT (the path you pass to `Loader(root=...)`).
+    """
+    root = tmp_path / "submission_root"
+    benchmark_dir = root / "closed" / "Acme" / "results" / "sys-v1" / "training" / "unet3d"
+    benchmark_dir.parent.mkdir(parents=True)
+    workload_dir.rename(benchmark_dir)
+    sys_yaml = root / "closed" / "Acme" / "systems" / "sys-v1.yaml"
+    sys_yaml.parent.mkdir(parents=True)
+    sys_yaml.write_text("name: sys-v1\n")
+    return root
+
+
+def _materialize_scenario(tmp_path: Path, caplog, **kw):
+    workload_dir = _build_training_tree(tmp_path, **kw)
+    root = _scaffold_division_root(tmp_path, workload_dir)
+    return _run_rule(root, caplog)
+
+
+# ---------------------------------------------------------------------- #
+# Positive cases — must PASS (return True, zero violations recorded)
+# ---------------------------------------------------------------------- #
+
+
+class TestPositiveCases:
+    """All-equal and sweep-subset cases must produce zero 3.3.1 violations."""
+
+    @pytest.mark.parametrize("n", [7_200, 84_375, 450_000])
+    def test_all_equal_sweep_sizes(self, tmp_path, caplog, n):
+        """Three real UNet3D sweep sizes — datasize = datagen = run.
+
+        Today's placeholder constant (`unet3d: 14000`) fires on 84,375
+        and 450,000; the substantive fix must accept all three.
+        """
+        result, records = _materialize_scenario(
+            tmp_path, caplog,
+            datasize_num_files=n,
+            datagen_num_files=n,
+            run_num_files=n,
+        )
+        assert result is True, (
+            f"rule 3.3.1 must pass when datasize = datagen = run = {n}"
+        )
+        violation_records = [r for r in records if "[3.3.1" in r.getMessage()]
+        assert not violation_records, (
+            f"Expected zero 3.3.1 violations for n={n}; got "
+            f"{[r.getMessage() for r in violation_records]}"
+        )
+
+    def test_sweep_subset_run_smaller_than_datagen_above_datasize(self, tmp_path, caplog):
+        """User generated a large dataset once, runs a smaller config against it.
+
+        Sweep use case from issue #608 discussion: datasize prescribed
+        84,375; user generated 450,000; this run consumed 84,375.
+        Lawful — run is in [datasize, datagen]. Zero violations.
+        """
+        result, records = _materialize_scenario(
+            tmp_path, caplog,
+            datasize_num_files=84_375,
+            datagen_num_files=450_000,
+            run_num_files=84_375,
+        )
+        assert result is True
+        violation_records = [r for r in records if "[3.3.1" in r.getMessage()]
+        assert not violation_records, (
+            f"Sweep subset run must not violate 3.3.1; got: "
+            f"{[r.getMessage() for r in violation_records]}"
+        )
+
+
+# ---------------------------------------------------------------------- #
+# Warning cases — rule must STILL return True, but record warning
+# ---------------------------------------------------------------------- #
+
+
+def _has_token(records, token: str) -> bool:
+    return any(token in r.getMessage() for r in records)
+
+
+class TestWarningCases:
+    """All failure modes for 3.3.1 are warn-only mid submission-window.
+
+    The rule must continue to return True so submissions are not
+    invalidated; the warning is recorded for submitter triage.
+    """
+
+    def test_datagen_overrun_warns_with_stable_token(self, tmp_path, caplog):
+        """run.num_files_train > datagen.num_files_train → DATAGEN-OVERRUN."""
+        result, records = _materialize_scenario(
+            tmp_path, caplog,
+            datasize_num_files=10_000,
+            datagen_num_files=84_375,
+            run_num_files=120_000,
+        )
+        assert result is True, "Warning-severity must not flip rule result"
+        assert _has_token(records, "[3.3.1 DATAGEN-OVERRUN]"), (
+            f"Expected stable token [3.3.1 DATAGEN-OVERRUN]; got: "
+            f"{[r.getMessage() for r in records]}"
+        )
+        # Warning, never error.
+        assert all(
+            r.levelno < logging.ERROR or "[3.3.1" not in r.getMessage()
+            for r in records
+        ), "3.3.1 messages must be warning-level, never error"
+
+    def test_datasize_underrun_warns_with_stable_token(self, tmp_path, caplog):
+        """run.num_files_train < datasize.num_files_train → DATASIZE-UNDERRUN."""
+        result, records = _materialize_scenario(
+            tmp_path, caplog,
+            datasize_num_files=84_375,
+            datagen_num_files=84_375,
+            run_num_files=10_000,
+        )
+        assert result is True
+        assert _has_token(records, "[3.3.1 DATASIZE-UNDERRUN]")
+        assert all(
+            r.levelno < logging.ERROR or "[3.3.1" not in r.getMessage()
+            for r in records
+        )
+
+    def test_datadir_mismatch_between_datasize_and_run_warns(self, tmp_path, caplog):
+        """datasize and run target different --data-dir → DATADIR-MISMATCH."""
+        result, records = _materialize_scenario(
+            tmp_path, caplog,
+            datasize_num_files=84_375,
+            datagen_num_files=84_375,
+            run_num_files=84_375,
+            data_dir_datasize="/data/old",
+            data_dir_datagen="/data/old",
+            data_dir_run="/data/new",
+        )
+        assert result is True
+        assert _has_token(records, "[3.3.1 DATADIR-MISMATCH]")
+
+    def test_datasize_reused_data_dir_warns(self, tmp_path, caplog):
+        """Two datasize phases targeting the same --data-dir → DATASIZE-REUSED.
+
+        Two `datasize/<ts>/` directories both reference `/data/shared`;
+        we cannot know which value applies to the current run.
+        """
+        result, records = _materialize_scenario(
+            tmp_path, caplog,
+            datasize_num_files=84_375,
+            datagen_num_files=84_375,
+            run_num_files=84_375,
+            data_dir_datasize="/data/shared",
+            data_dir_datagen="/data/shared",
+            data_dir_run="/data/shared",
+            datasize_extras=[
+                {"num_files_train": 84_375, "data_dir": "/data/shared"},
+            ],
+        )
+        assert result is True
+        assert _has_token(records, "[3.3.1 DATASIZE-REUSED]")
+
+    def test_datasize_missing_entirely_warns(self, tmp_path, caplog):
+        """No `datasize/` directory → DATASIZE-MISSING warning, rule still passes.
+
+        Per WRT 2 from #608 conversation: validator must look for the
+        datasize directory and warn when it is absent, not silent-skip.
+        """
+        workload_dir = _build_training_tree(
+            tmp_path,
+            datasize_num_files=84_375,
+            datagen_num_files=84_375,
+            run_num_files=84_375,
+        )
+        # Wipe datasize/ entirely
+        import shutil
+        shutil.rmtree(workload_dir / "datasize")
+        root = _scaffold_division_root(tmp_path, workload_dir)
+        result, records = _run_rule(root, caplog)
+        assert result is True
+        assert _has_token(records, "[3.3.1 DATASIZE-MISSING]")
+
+    def test_datagen_missing_entirely_warns(self, tmp_path, caplog):
+        """No `datagen/` directory → DATAGEN-MISSING warning, rule still passes."""
+        workload_dir = _build_training_tree(
+            tmp_path,
+            datasize_num_files=84_375,
+            datagen_num_files=84_375,
+            run_num_files=84_375,
+        )
+        import shutil
+        shutil.rmtree(workload_dir / "datagen")
+        root = _scaffold_division_root(tmp_path, workload_dir)
+        result, records = _run_rule(root, caplog)
+        assert result is True
+        assert _has_token(records, "[3.3.1 DATAGEN-MISSING]")
+
+    def test_eval_field_absent_in_run_summary_warns(self, tmp_path, caplog):
+        """num_files_eval absent in run summary → EVAL-FIELD-MISSING warning.
+
+        Per WRT 4: absent-key is NOT a silent skip; surface as a
+        warning so submitters know the cross-check could not be
+        performed.
+        """
+        result, records = _materialize_scenario(
+            tmp_path, caplog,
+            datasize_num_files=84_375,
+            datagen_num_files=84_375,
+            run_num_files=84_375,
+            eval_run=None,
+            eval_datasize=100,
+        )
+        assert result is True
+        assert _has_token(records, "[3.3.1 EVAL-FIELD-MISSING]")
+
+
+# ---------------------------------------------------------------------- #
+# Dead-code removal — placeholder constants and accessors must be gone
+# ---------------------------------------------------------------------- #
+
+
+class TestPlaceholderConstantsRemoved:
+    """Issue #608 mandates removing the TODO-marked placeholder constants.
+
+    Once rule 3.3.1 reads real datasize metadata, the
+    NUM_DATASET_TRAIN_FILES / NUM_DATASET_EVAL_FILES placeholder dicts
+    in constants.py — still tagged ``# TODO: Ask for correct values`` —
+    must be deleted, along with their `Config` accessors. Survival of
+    that dead code would invite a future regression that silently
+    re-shadows the real cross-check.
+    """
+
+    def test_constant_dicts_removed(self):
+        import mlpstorage_py.submission_checker.constants as c
+
+        for name in (
+            "NUM_DATASET_TRAIN_FILES",
+            "NUM_DATASET_EVAL_FILES",
+            "NUM_DATASET_TRAIN_FOLDERS",
+            "NUM_DATASET_EVAL_FOLDERS",
+        ):
+            assert not hasattr(c, name), (
+                f"constants.{name} must be removed after issue #608 fix — "
+                "the substantive cross-check reads real datasize metadata; "
+                "leaving the placeholder around invites silent regressions."
+            )
+
+    def test_config_accessors_removed(self):
+        from mlpstorage_py.submission_checker.configuration.configuration import Config
+
+        for name in ("get_num_train_files", "get_num_eval_files"):
+            assert not hasattr(Config, name), (
+                f"Config.{name} accessed the deleted placeholder dicts and "
+                "must be removed alongside them."
+            )


### PR DESCRIPTION
## Summary

Fixes #608. submission_checker rule **3.3.1 (`trainingRunDataMatchesDatasize`)** was comparing `run.summary.num_files_train` against placeholder constants tagged `# TODO: Ask for correct values` in `submission_checker/constants.py`:

```python
NUM_DATASET_TRAIN_FILES = {\"unet3d\": 14000, \"retinanet\": 0}
```

A real UNet3D submission sized for 3 hosts × B200 / 768 GiB needs **84,375** files; comparing 84,375 against 14,000 produced an unconditional `[ERROR]` that did not reflect any actual submission problem.

This rewrite reads the values that the \`datasize/\` and \`datagen/\` phases actually wrote for THIS submission, then enforces:

\`\`\`
datasize.num_files_train  <=  run.num_files_train  <=  datagen.num_files_train
\`\`\`

- **Lower bound** (\`run >= datasize\`): the representative-benchmark floor that datasize itself prescribed.
- **Upper bound** (\`run <= datagen\`): the physical fact that you cannot consume more data than datagen produced. Sweep workflows (one datagen at the largest size, multiple runs at smaller sizes) are explicitly supported via the inequality direction — \`run < datagen\` is lawful.

## Severity — warn-only mid submission-window

Every category emits via \`warn_violation\` (never \`log_violation\`). The rule continues to return \`True\` regardless of warnings, so submissions in flight are not invalidated. After the submission window closes, the appropriate categories may be promoted to \`log_violation\`; until then submitters can see the gap surfaced without being blocked.

## Stable bracketed prefix tokens

Submitter CI can grep-suppress specific categories with stable tokens that survive future Rules.md text shuffling:

| Token | Fires when |
|---|---|
| \`[3.3.1 DATAGEN-OVERRUN]\`    | \`run > datagen\` |
| \`[3.3.1 DATASIZE-UNDERRUN]\`  | \`run < datasize\` |
| \`[3.3.1 DATADIR-MISMATCH]\`   | run \`--data-dir\` has no matching datasize phase |
| \`[3.3.1 DATASIZE-REUSED]\`    | multiple datasize phases target the same \`--data-dir\` (data dir reused; cannot determine authoritative cardinality) |
| \`[3.3.1 DATASIZE-MISSING]\`   | no \`datasize/\` phase found |
| \`[3.3.1 DATAGEN-MISSING]\`    | no \`datagen/\` phase found |
| \`[3.3.1 EVAL-FIELD-MISSING]\` | run summary has no \`num_files_eval\` |

## What changed

- **\`submission_checker/loader.py\`** — \`SubmissionLogs.datasize_files: list\` added; training-mode loader walks \`<workload>/datasize/<ts>/\` mirroring the existing \`datagen\` walk. Datasize directories carry only metadata (no \`summary.json\`); the summary slot is \`None\`.
- **\`submission_checker/checks/training_checks.py\`** — \`run_data_matches_datasize\` rewritten end-to-end. Datasize ↔ run pairing is by \`args.data_dir\` equality, with the most-recent datasize timestamp ≤ run timestamp as tiebreaker. Three small helper staticmethods for the new logic.
- **\`submission_checker/constants.py\`** — \`NUM_DATASET_TRAIN_FILES\`, \`NUM_DATASET_EVAL_FILES\`, \`NUM_DATASET_TRAIN_FOLDERS\`, \`NUM_DATASET_EVAL_FOLDERS\` deleted.
- **\`submission_checker/configuration/configuration.py\`** — \`Config.get_num_train_files\` and \`Config.get_num_eval_files\` deleted alongside the constants they read. Repo-wide search before deletion confirmed no other callers.

## Test plan

- [x] **RED test first** (commit \`2f63821\`): 13 tests in \`tests/unit/test_submission_checker_run_matches_datasize.py\` across 3 classes — positive sweep cases (7,200 / 84,375 / 450,000 + sweep-subset where run consumed less than datagen produced and above the datasize floor), 7 warning-category cases with stable bracketed tokens, dead-code-removal pins on the placeholder constants and Config accessors.
- [x] **GREEN** after the fix (commit \`fd69bbf\`): all 13 pass.
- [x] **Full 4-suite CI sweep** — zero regressions:
  - \`tests/\`                       — 2,448 passed, 13 deselected (slow)
  - \`mlpstorage_py/tests\`          —   780 passed, 1 xfailed
  - \`vdb_benchmark/tests\`          —   144 passed
  - \`kv_cache_benchmark/tests\`     —   238 passed
  - **Total**                       — **3,610 passed**

## Dependencies & coordination

- **PR #605** (open) points the validator at \`metadata[\"parameters\"]\` for adjacent rules (\`combined_params\` → \`parameters\` rename). This PR reads the same key directly, so it is forward-compatible with #605 without depending on it. Merge order is not load-bearing.
- **PR #606** (open, by @wolfgang-desalvador) downgrades the placeholder-based 3.3.1 violation to a warning but keeps the placeholder. This PR supersedes that approach with the substantive fix — same warn-only severity Wolfgang chose, but real ground truth on the right-hand side of the comparison.

## Out of scope

Per the conversation that produced this fix, the post-submission-window work to have \`mlpstorage validate\` ALSO read \`<data-dir>/.datagen.yaml\` as a second-layer cross-check (single GET on object stores, never a \`LIST\`) is captured locally in the v1.0 datagen-manifest milestone backlog as a planned scope addition for when that milestone resumes.