### PR TITLE
Fix report generation to avoid all results grouped in same JSON

### DIFF
--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -83,13 +83,10 @@ class ReportGenerator:
         # No-op when --results-dir already points at a flat benchmark-type root.
         self.results_dir = self._resolve_effective_results_dir(self.results_dir)
 
-        # Honor --output-dir for write_{json,csv}_file (falls back to results_dir).
-        output_dir = None
-        if self.args is not None:
-            output_dir = getattr(self.args, 'output_dir', None)
-        self.output_dir = output_dir or self.results_dir
-        if self.output_dir and self.output_dir != self.results_dir:
-            os.makedirs(self.output_dir, exist_ok=True)
+        # NOTE: results.json / results.csv are written into each discovered
+        # <...>/run/ folder, one rollup per run/ folder containing only the
+        # timestamps inside that folder. --output-dir is intentionally not
+        # honored — the rollup location is dictated by the on-disk layout.
 
         # Initialize formatters
         self.msg_formatter = ValidationMessageFormatter(use_colors=use_colors)
@@ -197,15 +194,39 @@ class ReportGenerator:
         # Verify the results directory exists:
         self.logger.info(f'Generating reports for {self.results_dir}')
 
-        # Always traverse the full directory and emit one rollup
-        # results.json / results.csv covering every discovered run, written
-        # to self.output_dir (which defaults to self.results_dir when
-        # --output-dir is not supplied).
-        run_result_dicts = [
-            report.benchmark_run.as_dict() for report in self.run_results.values()
-        ]
-        self.write_csv_file(run_result_dicts)
-        self.write_json_file(run_result_dicts)
+        # Group accumulated runs by their parent `run/` folder. Each leaf
+        # `benchmark_run.result_dir` is `<...>/<benchmark>/<model>/run/<timestamp>/`;
+        # the rollup is written INSIDE the parent `<...>/<benchmark>/<model>/run/`
+        # directory and contains only the timestamps that live in that
+        # specific `run/` folder. One results.json + one results.csv per
+        # run/ folder; nothing is written elsewhere in the tree.
+        groups: Dict[str, List[dict]] = {}
+        skipped = 0
+        for result in self.run_results.values():
+            leaf = getattr(result.benchmark_run, 'result_dir', None)
+            if not leaf:
+                self.logger.warning(
+                    "Run %s has no result_dir on its BenchmarkRun; "
+                    "cannot place a rollup next to it. Skipping.",
+                    result.benchmark_run.run_id,
+                )
+                skipped += 1
+                continue
+            run_folder = os.path.dirname(os.path.abspath(leaf))
+            groups.setdefault(run_folder, []).append(
+                result.benchmark_run.as_dict()
+            )
+
+        if not groups:
+            self.logger.warning(
+                "No run/ folders to write rollups for (skipped %d runs without result_dir).",
+                skipped,
+            )
+            return EXIT_CODE.SUCCESS
+
+        for run_folder, run_dicts in sorted(groups.items()):
+            self.write_json_file(run_dicts, target_dir=run_folder)
+            self.write_csv_file(run_dicts, target_dir=run_folder)
 
         return EXIT_CODE.SUCCESS
 
@@ -490,14 +511,16 @@ class ReportGenerator:
                 print(f"\n    {checklist}")
 
 
-    def write_json_file(self, results):
-        json_file = os.path.join(self.output_dir, 'results.json')
+    def write_json_file(self, results, target_dir: Optional[str] = None):
+        out_dir = target_dir if target_dir is not None else self.results_dir
+        json_file = os.path.join(out_dir, 'results.json')
         self.logger.info(f'Writing results to {json_file}')
         with open(json_file, 'w') as f:
             json.dump(results, f, indent=2)
 
-    def write_csv_file(self, results):
-        csv_file = os.path.join(self.output_dir, 'results.csv')
+    def write_csv_file(self, results, target_dir: Optional[str] = None):
+        out_dir = target_dir if target_dir is not None else self.results_dir
+        csv_file = os.path.join(out_dir, 'results.csv')
         self.logger.info(f'Writing results to {csv_file}')
         flattened_results = [flatten_nested_dict(r) for r in results]
         flattened_results = [remove_nan_values(r) for r in flattened_results]

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -212,12 +212,20 @@ class TestReportGeneratorGenerateReports:
         results_dir = tmp_path / "results"
         results_dir.mkdir()
 
+        # The per-run-folder rollup lives at `<parent of leaf result_dir>/`,
+        # so the mock run must expose a real path that os.path.dirname can
+        # resolve. Use the canonical shape `<results>/<bench>/<model>/run/<ts>/`.
+        self._run_folder = results_dir / "training" / "unet3d" / "run"
+        leaf = self._run_folder / "20250111_120000"
+        leaf.mkdir(parents=True)
+
         with patch.object(ReportGenerator, 'accumulate_results'):
             with patch.object(ReportGenerator, 'print_results'):
                 gen = ReportGenerator(str(results_dir), validate_structure=False)
 
         # Add mock run results
         mock_run = MagicMock()
+        mock_run.result_dir = str(leaf)
         mock_run.as_dict.return_value = {
             'run_id': 'test_run',
             'benchmark_type': 'training',
@@ -245,16 +253,20 @@ class TestReportGeneratorGenerateReports:
         assert result == EXIT_CODE.SUCCESS
 
     def test_creates_json_file(self, generator):
-        """Should create results.json."""
+        """Should create results.json inside the parent run/ folder."""
         generator.generate_reports()
-        json_file = os.path.join(generator.results_dir, 'results.json')
-        assert os.path.exists(json_file)
+        json_file = os.path.join(str(self._run_folder), 'results.json')
+        assert os.path.exists(json_file), (
+            f"Expected per-run-folder rollup at {json_file}"
+        )
 
     def test_creates_csv_file(self, generator):
-        """Should create results.csv."""
+        """Should create results.csv inside the parent run/ folder."""
         generator.generate_reports()
-        csv_file = os.path.join(generator.results_dir, 'results.csv')
-        assert os.path.exists(csv_file)
+        csv_file = os.path.join(str(self._run_folder), 'results.csv')
+        assert os.path.exists(csv_file), (
+            f"Expected per-run-folder rollup at {csv_file}"
+        )
 
 
 class TestReportGeneratorPrintResults:
@@ -493,6 +505,12 @@ class TestReportGeneratorIntegration:
         results_dir = tmp_path / "results"
         results_dir.mkdir()
 
+        # Per-run-folder rollups land at `<parent of leaf result_dir>/`, so
+        # the mock leaf must be a real path under results_dir.
+        run_folder = results_dir / "training" / "unet3d" / "run"
+        leaf = run_folder / "20250111_120000"
+        leaf.mkdir(parents=True)
+
         # Create mock benchmark run
         mock_run = MagicMock()
         mock_run.run_id = "training_run_20250111"
@@ -500,6 +518,7 @@ class TestReportGeneratorIntegration:
         mock_run.command = 'run'
         mock_run.model = 'unet3d'
         mock_run.accelerator = 'h100'
+        mock_run.result_dir = str(leaf)
         mock_run.metrics = {
             'train_throughput_samples_per_second': 1250.5,
             'train_au_percentage': 95.2
@@ -525,6 +544,6 @@ class TestReportGeneratorIntegration:
         result = generator.generate_reports()
         assert result == EXIT_CODE.SUCCESS
 
-        # Check files were created
-        assert os.path.exists(os.path.join(results_dir, 'results.json'))
-        assert os.path.exists(os.path.join(results_dir, 'results.csv'))
+        # Files land inside the parent run/ folder, not the results_dir root
+        assert os.path.exists(os.path.join(str(run_folder), 'results.json'))
+        assert os.path.exists(os.path.join(str(run_folder), 'results.csv'))


### PR DESCRIPTION
This pull request refactors the report generation logic so that summary files (`results.json` and `results.csv`) are now written inside each discovered `run/` folder, rather than in a global output directory. The tests and file-writing methods have been updated to reflect this new per-run-folder rollup behavior.

**Report generation changes:**

* The `ReportGenerator` now writes `results.json` and `results.csv` files into each `run/` folder containing benchmark run results, rather than honoring the `--output-dir` flag or writing to a global directory. This ensures that rollups are colocated with their respective runs and only include the timestamps present in each folder. (`mlpstorage_py/report_generator.py`) [[1]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381L86-R89) [[2]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381L200-R229)
* The `write_json_file` and `write_csv_file` methods now accept an optional `target_dir` argument to specify the output directory, defaulting to the per-run-folder location. (`mlpstorage_py/report_generator.py`)

**Test updates:**

* Unit tests have been updated to create mock run directories that match the expected on-disk layout, and assertions now check for rollup files inside the appropriate `run/` folders rather than at the root. (`tests/unit/test_reporting.py`) [[1]](diffhunk://#diff-ad70d771bd9b2ade956b089d909d711788cba84d4a4690d019ad4006b3ade965R215-R228) [[2]](diffhunk://#diff-ad70d771bd9b2ade956b089d909d711788cba84d4a4690d019ad4006b3ade965L248-R269) [[3]](diffhunk://#diff-ad70d771bd9b2ade956b089d909d711788cba84d4a4690d019ad4006b3ade965R508-R521) [[4]](diffhunk://#diff-ad70d771bd9b2ade956b089d909d711788cba84d4a4690d019ad4006b3ade965L528-R549)