### PR TITLE
fix(#612): align submission checker with on-disk vdb / kvcache directory names

### DIFF
--- a/mlpstorage_py/submission_checker/checks/submission_structure_checks.py
+++ b/mlpstorage_py/submission_checker/checks/submission_structure_checks.py
@@ -74,8 +74,19 @@ _REQUIRED_SUBMITTER_SUBDIRS_OPEN = frozenset({"results", "systems"})
 # Legacy alias for CLOSED — see _REQUIRED_SUBMITTER_SUBDIRS_CLOSED.
 _REQUIRED_SUBMITTER_SUBDIRS = _REQUIRED_SUBMITTER_SUBDIRS_CLOSED
 
-# Valid workload categories under results/<system>/
-_VALID_WORKLOAD_CATEGORIES = frozenset({"training", "checkpointing"})
+# Valid workload categories under results/<system>/. These are the on-disk
+# directory names produced by `BENCHMARK_TYPES.name` in
+# `mlpstorage_py/rules/utils.py::generate_output_location` — `vector_database`
+# and `kv_cache` carry underscores, NOT the `vectordb` / `kvcache` short forms
+# used elsewhere in the CLI. Pre-fix this set excluded both, so every vdb /
+# kvcache submission tripped a `[2.1.10 workloadCategories] unexpected
+# workload category` error (issue #612).
+_VALID_WORKLOAD_CATEGORIES = frozenset({
+    "training",
+    "checkpointing",
+    "vector_database",
+    "kv_cache",
+})
 
 # Valid training workload names under training/
 _VALID_TRAINING_WORKLOADS = frozenset({"unet3d", "retinanet"})
@@ -849,8 +860,13 @@ class SubmissionStructureCheck(BaseCheck):
 
     @rule("2.1.10", "workloadCategories")
     def workload_categories_check(self):
-        """STRUCT-10: results/<system>/ must contain only {training, checkpointing}."""
+        """STRUCT-10: results/<system>/ must contain only categories drawn
+        from ``_VALID_WORKLOAD_CATEGORIES`` (training, checkpointing,
+        vector_database, kv_cache — the on-disk directory names produced
+        by ``BENCHMARK_TYPES.name``)."""
         valid = True
+        # Sorted list rendered once for stable, deterministic error messages.
+        allowed_list = sorted(_VALID_WORKLOAD_CATEGORIES)
         for _division, _submitter, sub_path in self._iter_submitter_dirs():
             results_path = os.path.join(sub_path, "results")
             if not os.path.isdir(results_path):
@@ -865,8 +881,8 @@ class SubmissionStructureCheck(BaseCheck):
                         "2.1.10", "workloadCategories",
                         os.path.join(sys_path, cat),
                         "unexpected workload category %r in results/%s/ "
-                        "(only 'training' and 'checkpointing' allowed)",
-                        cat, sys_name,
+                        "(allowed: %s)",
+                        cat, sys_name, allowed_list,
                     )
                     valid = False
 
@@ -874,8 +890,9 @@ class SubmissionStructureCheck(BaseCheck):
                     self.log_violation(
                         "2.1.10", "workloadCategories",
                         sys_path,
-                        "results/%s/ contains neither 'training' nor 'checkpointing'",
-                        sys_name,
+                        "results/%s/ contains no recognized workload "
+                        "category (allowed: %s)",
+                        sys_name, allowed_list,
                     )
                     valid = False
 

--- a/mlpstorage_py/submission_checker/loader.py
+++ b/mlpstorage_py/submission_checker/loader.py
@@ -80,6 +80,33 @@ class Loader:
             self.logger.warning("More than one metadata file found at %s", path)
         return os.path.join(path, files[0])
 
+    def _collect_timestamped_logs(self, command_path):
+        """Walk a command directory (.../{datagen,run,datasize}/) and load each
+        <datetime>/{summary.json,*_metadata.json} pair.
+
+        Returns ``[(summary_dict, metadata_dict, timestamp_str), ...]`` —
+        the tuple shape every downstream rule iterates over
+        (`_iter_run_files` / `_iter_datagen_files` in vdb_checks,
+        DirectoryCheck.datagen_files_check in directory_checks, etc.).
+
+        Missing ``command_path`` is a STRUCT-12 structural violation handled
+        elsewhere; this helper returns an empty list so corpus traversal
+        continues.
+        """
+        out = []
+        if not os.path.isdir(command_path):
+            return out
+        for timestamp in list_dir(command_path):
+            timestamp_path = os.path.join(command_path, timestamp)
+            summary_path = os.path.join(timestamp_path, "summary.json")
+            # BUG-01 (D-E1): refresh per-run metadata; do NOT reuse a
+            # previously-looked-up metadata_path across timestamps.
+            metadata_path = self.find_metadata_path(timestamp_path)
+            metadata_file = self.load_single_log(metadata_path, "Metadata")
+            summary_file = self.load_single_log(summary_path, "Summary")
+            out.append((summary_file, metadata_file, timestamp))
+        return out
+
     def load(self) -> Generator[SubmissionLogs, None, None]:
         # Iterate over submission folder.
         # Division -> submitter -> system -> benchmark -> runs
@@ -102,45 +129,67 @@ class Loader:
                             benchmark_path = os.path.join(mode_path, benchmark)
                             loader_metadata = LoaderMetadata(division=division, submitter=submitter, system=system, mode=mode, benchmark=benchmark, folder=benchmark_path)
                             if mode == "training":
+                                # training/<model>/{datagen,run}/<datetime>/
                                 datagen_path = os.path.join(benchmark_path, "datagen")
                                 run_path = os.path.join(benchmark_path, "run")
-                                datagen_files = []
-                                run_files = []
-                                # Missing datagen/ or run/ is a structural violation caught by
-                                # SubmissionStructureCheck STRUCT-12 (2.1.12). The loader yields
-                                # empty file lists so the rest of the corpus traversal continues.
-                                datagen_timestamps = list_dir(datagen_path) if os.path.isdir(datagen_path) else []
-                                run_timestamps = list_dir(run_path) if os.path.isdir(run_path) else []
-                                for timestamp in datagen_timestamps:
-                                    timestamp_path = os.path.join(datagen_path, timestamp)
-                                    summary_path = os.path.join(timestamp_path, "summary.json")
-                                    metadata_path = self.find_metadata_path(timestamp_path)
-                                    metadata_file = self.load_single_log(metadata_path, "Metadata")
-                                    datagen_file = self.load_single_log(summary_path, "Summary")
-                                    datagen_files.append((datagen_file, metadata_file, timestamp))
-
-                                for timestamp in run_timestamps:
-                                    timestamp_path = os.path.join(run_path, timestamp)
-                                    summary_path = os.path.join(timestamp_path, "summary.json")
-                                    # BUG-01 (D-E1): refresh per-run metadata; do NOT reuse datagen-loop metadata_path.
-                                    metadata_path = self.find_metadata_path(timestamp_path)
-                                    metadata_file = self.load_single_log(metadata_path, "Metadata")
-                                    run_file = self.load_single_log(summary_path, "Summary")
-                                    run_files.append((run_file, metadata_file, timestamp))
-                                
+                                datagen_files = self._collect_timestamped_logs(datagen_path)
+                                run_files = self._collect_timestamped_logs(run_path)
                                 yield SubmissionLogs(datagen_files, run_files, system_file=system_file, loader_metadata=loader_metadata)
-                            else:
-                                checkpoint_path = os.path.join(mode_path, benchmark)
-                                checkpoint_files = []
-                                checkpoint_timestamps = list_dir(checkpoint_path) if os.path.isdir(checkpoint_path) else []
-                                for timestamp in checkpoint_timestamps:
-                                    timestamp_path = os.path.join(checkpoint_path, timestamp)
-                                    summary_path = os.path.join(timestamp_path, "summary.json")
-                                    metadata_path = self.find_metadata_path(timestamp_path)
-                                    metadata_file = self.load_single_log(metadata_path, "Metadata")
-                                    checkpoint_file = self.load_single_log(summary_path, "Summary")
-                                    checkpoint_files.append((checkpoint_file, metadata_file, timestamp))
+                            elif mode == "checkpointing":
+                                # checkpointing/<model>/<datetime>/   (no <command> segment)
+                                checkpoint_files = self._collect_timestamped_logs(benchmark_path)
                                 yield SubmissionLogs(checkpoint_files=checkpoint_files, system_file=system_file, loader_metadata=loader_metadata)
+                            elif mode == "kv_cache":
+                                # kv_cache/<model>/{datagen,run,datasize}/<datetime>/
+                                # (issue #612: pre-fix this branch was the shared
+                                # `else` and treated <command> dirs as timestamps —
+                                # missed the command layer, so metadata.json was
+                                # looked for one level too high and never found.)
+                                datagen_path = os.path.join(benchmark_path, "datagen")
+                                run_path = os.path.join(benchmark_path, "run")
+                                datagen_files = self._collect_timestamped_logs(datagen_path)
+                                run_files = self._collect_timestamped_logs(run_path)
+                                yield SubmissionLogs(datagen_files, run_files, system_file=system_file, loader_metadata=loader_metadata)
+                            elif mode == "vector_database":
+                                # vector_database/<engine>/<index>/{datagen,run,datasize}/<datetime>/
+                                # (issue #612: pre-fix this branch was the shared
+                                # `else` and treated <index> dirs as timestamps —
+                                # missed both the index AND command layers.)
+                                # `benchmark` is the <engine> segment; yield once
+                                # per (engine, index) pair so VdbCheck.path lands
+                                # on the index dir (vdb_closed_index_types reads
+                                # os.path.basename(self.path) and expects the
+                                # index token, e.g. DISKANN).
+                                if not os.path.isdir(benchmark_path):
+                                    continue
+                                for index_name in list_dir(benchmark_path):
+                                    index_path = os.path.join(benchmark_path, index_name)
+                                    if not os.path.isdir(index_path):
+                                        continue
+                                    datagen_path = os.path.join(index_path, "datagen")
+                                    run_path = os.path.join(index_path, "run")
+                                    datagen_files = self._collect_timestamped_logs(datagen_path)
+                                    run_files = self._collect_timestamped_logs(run_path)
+                                    # Per-index loader_metadata: folder points at
+                                    # <engine>/<index> so VdbCheck's self.path is
+                                    # the index dir (NOT the engine dir).
+                                    index_metadata = LoaderMetadata(
+                                        division=division, submitter=submitter,
+                                        system=system, mode=mode,
+                                        benchmark=benchmark, folder=index_path,
+                                    )
+                                    yield SubmissionLogs(
+                                        datagen_files=datagen_files,
+                                        run_files=run_files,
+                                        system_file=system_file,
+                                        loader_metadata=index_metadata,
+                                    )
+                            else:
+                                # Unknown mode — yield an empty SubmissionLogs so
+                                # main.py's MODE_TO_CHECKERS.get(mode) is None
+                                # branch fires its locked [2.1.10] message with
+                                # the right `folder` context attached.
+                                yield SubmissionLogs(system_file=system_file, loader_metadata=loader_metadata)
 
                             
                             

--- a/mlpstorage_py/submission_checker/main.py
+++ b/mlpstorage_py/submission_checker/main.py
@@ -49,10 +49,18 @@ log = logging.getLogger("main")
 # "...main.MODE_TO_CHECKERS", {...}) injection of mock checkers, mirroring
 # the STUB_COVERAGE/OUT_OF_SCOPE_RULES pattern in test_rules_coverage.py.
 MODE_TO_CHECKERS = {
-    "training":      [DirectoryCheck, TrainingCheck],
-    "checkpointing": [DirectoryCheck, CheckpointingCheck],
-    "vectordb":      [VdbCheck],
-    "kvcache":       [KVCacheCheck],
+    "training":         [DirectoryCheck, TrainingCheck],
+    "checkpointing":    [DirectoryCheck, CheckpointingCheck],
+    # Keys must match the on-disk directory names produced by
+    # ``mlpstorage_py.rules.utils.generate_output_location`` —
+    # ``BENCHMARK_TYPES.name`` for vdb / kvcache is ``vector_database`` /
+    # ``kv_cache``. Pre-fix these were keyed ``vectordb`` / ``kvcache``,
+    # so the loader's ``mode = list_dir(system_path)[i]`` (which yields
+    # the disk-canonical name) never matched and every vdb / kvcache
+    # submission tripped the [2.1.10 workloadCategories] unrecognized-mode
+    # error at line 174 below (issue #612).
+    "vector_database":  [VdbCheck],
+    "kv_cache":         [KVCacheCheck],
 }
 
 def get_args():

--- a/mlpstorage_py/tests/test_loader_missing_optional_dirs.py
+++ b/mlpstorage_py/tests/test_loader_missing_optional_dirs.py
@@ -122,3 +122,150 @@ def test_bug_t1_traversal_continues_to_later_submitters(tmp_path):
     assert by_submitter["AcmeA"][0].run_files == []
     assert len(by_submitter["AcmeB"][0].datagen_files) == 1
     assert len(by_submitter["AcmeB"][0].run_files) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #612 — Loader.load() must understand kv_cache and vector_database
+# layouts (not just training and checkpointing). Pre-fix the `else`-branch
+# was modelled after checkpointing's `<bench>/<datetime>/` shape, so the
+# walker landed one (kvcache) or two (vdb) levels too shallow.
+# ---------------------------------------------------------------------------
+
+
+def test_issue_612_kvcache_layout_walks_command_then_timestamp(tmp_path):
+    """kv_cache writes to ``kv_cache/<model>/<command>/<datetime>/`` per
+    ``generate_output_location()``. The loader must descend through the
+    ``<command>`` (datagen/run) level and surface per-timestamp logs in
+    ``datagen_files`` / ``run_files`` so future KVCacheCheck rules can
+    introspect them. Pre-fix this branch was the shared ``else`` and
+    treated ``<command>`` dirs as timestamps — metadata.json was sought
+    one level too high and never found."""
+    base = (
+        tmp_path / "closed" / "Acme" / "results" / "sys-v1"
+        / "kv_cache" / "llama3.1-8b"
+    )
+    dg_dir = base / "datagen" / "20250101_120000"
+    run_dir = base / "run" / "20250101_130001"
+    _write_json(str(dg_dir / "metadata.json"), {"args": {}})
+    _write_json(str(dg_dir / "summary.json"), {})
+    _write_json(str(run_dir / "metadata.json"), {"args": {}})
+    _write_json(str(run_dir / "summary.json"), {})
+    _write_systems_yaml(tmp_path, "Acme", "sys-v1")
+
+    config = Config(version="v2.0", submitters=["Acme"], skip_output_file=True)
+    loader = Loader(root=str(tmp_path), version="v2.0", config=config)
+
+    kv = [l for l in loader.load() if l.loader_metadata.mode == "kv_cache"]
+    assert len(kv) == 1, (
+        f"expected exactly one kv_cache SubmissionLogs; got {len(kv)}"
+    )
+    assert len(kv[0].datagen_files) == 1, (
+        f"datagen layer must surface 1 timestamped log; got "
+        f"{kv[0].datagen_files!r}"
+    )
+    assert len(kv[0].run_files) == 1, (
+        f"run layer must surface 1 timestamped log; got {kv[0].run_files!r}"
+    )
+    # Sanity: the timestamp string in the tuple matches the dir name.
+    assert kv[0].run_files[0][2] == "20250101_130001"
+
+
+def test_issue_612_vector_database_yields_one_logs_per_engine_index(tmp_path):
+    """vdb writes to ``vector_database/<engine>/<index>/<command>/<datetime>/``
+    (4 path levels below ``<system>``). The loader must descend through
+    both ``<engine>`` and ``<index>`` and yield ONE SubmissionLogs per
+    (engine, index) pair with ``folder`` pointing at the index dir — so
+    ``VdbCheck.path = loader_metadata.folder`` lands on the index dir
+    (``vdb_closed_index_types`` reads ``os.path.basename(self.path)`` and
+    expects the index token, e.g. ``DISKANN``)."""
+    base = tmp_path / "closed" / "Acme" / "results" / "sys-v1" / "vector_database"
+    # Two indexes under one engine (milvus).
+    for index in ("DISKANN", "HNSW"):
+        dg_dir = base / "milvus" / index / "datagen" / "20250101_120000"
+        run_dir = base / "milvus" / index / "run" / "20250101_130001"
+        _write_json(str(dg_dir / "metadata.json"), {})
+        _write_json(str(dg_dir / "summary.json"), {})
+        _write_json(str(run_dir / "metadata.json"), {})
+        _write_json(str(run_dir / "summary.json"), {})
+    _write_systems_yaml(tmp_path, "Acme", "sys-v1")
+
+    config = Config(version="v2.0", submitters=["Acme"], skip_output_file=True)
+    loader = Loader(root=str(tmp_path), version="v2.0", config=config)
+
+    vdb = [l for l in loader.load() if l.loader_metadata.mode == "vector_database"]
+    assert len(vdb) == 2, (
+        f"expected one SubmissionLogs per (engine, index); got "
+        f"{len(vdb)} from {[l.loader_metadata.folder for l in vdb]!r}"
+    )
+
+    # folder must point at the <engine>/<index> dir so VdbCheck.path =
+    # folder, then basename(folder) yields the index token.
+    folders = sorted(l.loader_metadata.folder for l in vdb)
+    assert folders[0].endswith(os.path.join("milvus", "DISKANN")), folders
+    assert folders[1].endswith(os.path.join("milvus", "HNSW")), folders
+
+    # Each yielded SubmissionLogs must have its own datagen + run leaves.
+    for logs in vdb:
+        assert len(logs.datagen_files) == 1, logs.loader_metadata.folder
+        assert len(logs.run_files) == 1, logs.loader_metadata.folder
+
+
+def test_issue_612_vector_database_missing_index_dir_does_not_crash(tmp_path):
+    """An empty ``<engine>/`` (no index dirs) must not raise — it simply
+    yields nothing for that engine. Mirrors the BUG-T1 defensive pattern
+    for the training/checkpointing branches."""
+    # Just engine dir with no children.
+    (tmp_path / "closed" / "Acme" / "results" / "sys-v1"
+     / "vector_database" / "milvus").mkdir(parents=True, exist_ok=True)
+    _write_systems_yaml(tmp_path, "Acme", "sys-v1")
+
+    config = Config(version="v2.0", submitters=["Acme"], skip_output_file=True)
+    loader = Loader(root=str(tmp_path), version="v2.0", config=config)
+
+    # Must not raise.
+    list(loader.load())
+
+
+def test_issue_612_kvcache_missing_command_dirs_does_not_crash(tmp_path):
+    """An empty ``<model>/`` under kv_cache must not raise. Mirrors the
+    BUG-T1 pattern for the training/checkpointing branches."""
+    (tmp_path / "closed" / "Acme" / "results" / "sys-v1"
+     / "kv_cache" / "llama3.1-8b").mkdir(parents=True, exist_ok=True)
+    _write_systems_yaml(tmp_path, "Acme", "sys-v1")
+
+    config = Config(version="v2.0", submitters=["Acme"], skip_output_file=True)
+    loader = Loader(root=str(tmp_path), version="v2.0", config=config)
+
+    kv = [l for l in loader.load() if l.loader_metadata.mode == "kv_cache"]
+    assert len(kv) == 1
+    assert kv[0].datagen_files == []
+    assert kv[0].run_files == []
+
+
+def test_issue_612_checkpointing_branch_preserved(tmp_path):
+    """Regression guard: the existing checkpointing shape
+    (``<model>/<datetime>/`` — no command segment) must still load
+    ``checkpoint_files`` after the loader split. Pre-fix this lived in
+    the shared ``else``-branch; now it has its own ``elif``."""
+    base = (
+        tmp_path / "closed" / "Acme" / "results" / "sys-v1"
+        / "checkpointing" / "llama3-8b"
+    )
+    ts_dir = base / "20250101_140000"
+    _write_json(str(ts_dir / "metadata.json"), {})
+    _write_json(str(ts_dir / "summary.json"), {})
+    _write_systems_yaml(tmp_path, "Acme", "sys-v1")
+
+    config = Config(version="v2.0", submitters=["Acme"], skip_output_file=True)
+    loader = Loader(root=str(tmp_path), version="v2.0", config=config)
+
+    chk = [
+        l for l in loader.load() if l.loader_metadata.mode == "checkpointing"
+    ]
+    assert len(chk) == 1
+    assert len(chk[0].checkpoint_files) == 1
+    # The checkpointing checker reads checkpoint_files (NOT
+    # run_files/datagen_files) — confirm the loader still populates that
+    # slot post-split.
+    assert chk[0].run_files is None
+    assert chk[0].datagen_files is None

--- a/mlpstorage_py/tests/test_submission_checker_structure.py
+++ b/mlpstorage_py/tests/test_submission_checker_structure.py
@@ -1329,6 +1329,136 @@ class TestStruct10_WorkloadCategories:
         assert any("[2.1.10 workloadCategories]" in m for m in mock_logger.errors)
 
 
+class TestIssue612WorkloadCategoriesAcceptsAllFour:
+    """Issue #612: _VALID_WORKLOAD_CATEGORIES must include the on-disk
+    directory names produced by ``BENCHMARK_TYPES.name`` —
+    ``vector_database`` and ``kv_cache`` with underscores, not the short
+    forms ``vectordb`` / ``kvcache``. Pre-fix every vdb / kvcache
+    submission tripped a [2.1.10 workloadCategories] error."""
+
+    @staticmethod
+    def _add_workload_category_dir(root, sys_name, category):
+        """Drop a bare <category>/ dir into the system's results subtree."""
+        from pathlib import Path
+        path = (
+            Path(root) / "closed" / "Acme" / "results"
+            / sys_name / category
+        )
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def test_vector_database_category_accepted(self, tmp_path, mock_logger):
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(tmp_path)
+        # Determine the default systemname from the fixture.
+        from pathlib import Path
+        sys_name = next(
+            (Path(root) / "closed" / "Acme" / "results").iterdir()
+        ).name
+        self._add_workload_category_dir(root, sys_name, "vector_database")
+        check = _make_check(root, mock_logger)
+        result = run_one_check(check, "workload_categories_check", mock_logger)
+        assert result is True, (
+            "vector_database must be a recognized workload category; "
+            f"errors: {mock_logger.errors!r}"
+        )
+        assert mock_logger.errors == []
+
+    def test_kv_cache_category_accepted(self, tmp_path, mock_logger):
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(tmp_path)
+        from pathlib import Path
+        sys_name = next(
+            (Path(root) / "closed" / "Acme" / "results").iterdir()
+        ).name
+        self._add_workload_category_dir(root, sys_name, "kv_cache")
+        check = _make_check(root, mock_logger)
+        result = run_one_check(check, "workload_categories_check", mock_logger)
+        assert result is True, (
+            "kv_cache must be a recognized workload category; "
+            f"errors: {mock_logger.errors!r}"
+        )
+        assert mock_logger.errors == []
+
+    def test_short_form_vectordb_still_flagged(self, tmp_path, mock_logger):
+        """Defense in depth: the SHORT form ``vectordb`` (without
+        underscore) is NOT the canonical on-disk name and must be flagged
+        as unexpected — submissions that get this name on disk indicate
+        a writer-side regression, not a tolerable variant."""
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(tmp_path, extra_workload_category="vectordb")
+        check = _make_check(root, mock_logger)
+        result = run_one_check(check, "workload_categories_check", mock_logger)
+        assert result is False
+        assert any("[2.1.10 workloadCategories]" in m for m in mock_logger.errors)
+
+    def test_short_form_kvcache_still_flagged(self, tmp_path, mock_logger):
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(tmp_path, extra_workload_category="kvcache")
+        check = _make_check(root, mock_logger)
+        result = run_one_check(check, "workload_categories_check", mock_logger)
+        assert result is False
+        assert any("[2.1.10 workloadCategories]" in m for m in mock_logger.errors)
+
+    def test_error_message_enumerates_all_four_categories(self, tmp_path, mock_logger):
+        """When a truly bogus category lands on disk, the violation
+        message must enumerate all four allowed names so the user sees
+        the canonical set — pre-fix it hardcoded 'only training and
+        checkpointing allowed', misleading vdb / kvcache submitters."""
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(tmp_path, extra_workload_category="foo")
+        check = _make_check(root, mock_logger)
+        run_one_check(check, "workload_categories_check", mock_logger)
+        joined = " ".join(mock_logger.errors)
+        for category in ("training", "checkpointing", "vector_database", "kv_cache"):
+            assert category in joined, (
+                f"violation message must enumerate {category!r}; "
+                f"got: {joined!r}"
+            )
+
+
+class TestIssue612ModeToCheckersKeys:
+    """The MODE_TO_CHECKERS keys must match the on-disk directory names —
+    ``vector_database`` and ``kv_cache``, NOT the short forms. Pre-fix
+    the dict was keyed on the short forms so every vdb / kvcache
+    submission flowed into the unrecognized-mode error branch at
+    main.py:174."""
+
+    def test_keys_are_disk_canonical(self):
+        from mlpstorage_py.submission_checker.main import MODE_TO_CHECKERS
+        assert "vector_database" in MODE_TO_CHECKERS, (
+            f"MODE_TO_CHECKERS must key vdb under the disk name "
+            f"'vector_database'; got keys {sorted(MODE_TO_CHECKERS.keys())!r}"
+        )
+        assert "kv_cache" in MODE_TO_CHECKERS, (
+            f"MODE_TO_CHECKERS must key kvcache under the disk name "
+            f"'kv_cache'; got keys {sorted(MODE_TO_CHECKERS.keys())!r}"
+        )
+
+    def test_short_form_keys_are_absent(self):
+        """The short forms 'vectordb' / 'kvcache' would never match the
+        loader's mode (the disk-canonical name). Their absence keeps the
+        unrecognized-mode error branch firing for genuinely misnamed
+        submissions instead of silently routing to a non-matching checker."""
+        from mlpstorage_py.submission_checker.main import MODE_TO_CHECKERS
+        assert "vectordb" not in MODE_TO_CHECKERS
+        assert "kvcache" not in MODE_TO_CHECKERS
+
+    def test_keys_align_with_benchmark_types_enum(self):
+        """Round-trip: every BENCHMARK_TYPES.name must be a MODE_TO_CHECKERS
+        key. This pins the writer↔consumer contract — if either side ever
+        drifts (e.g. a future rename of the enum), this test fires."""
+        from mlpstorage_py.config import BENCHMARK_TYPES
+        from mlpstorage_py.submission_checker.main import MODE_TO_CHECKERS
+        for member in BENCHMARK_TYPES:
+            assert member.name in MODE_TO_CHECKERS, (
+                f"BENCHMARK_TYPES.{member.name} produces directories "
+                f"named {member.name!r} on disk but MODE_TO_CHECKERS has "
+                f"no entry for it; keys are "
+                f"{sorted(MODE_TO_CHECKERS.keys())!r}"
+            )
+
+
 # ---------------------------------------------------------------------------
 # TestStruct11_TrainingWorkloads  (STRUCT-11, rule 2.1.11)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #612.

`mlpstorage validate` could not validate vector_database or kv_cache submissions because three coupled bugs in `submission_checker/` disagreed with the canonical on-disk layout written by `generate_output_location()`. All three are fixed here.

The root cause is naming divergence: the writer uses `BENCHMARK_TYPES.name` (`vector_database`, `kv_cache` — with underscores), while the checker side used the short forms `vectordb` / `kvcache` for lookups, allowlists, and layout assumptions.

## Bugs fixed

### Bug 1 — `MODE_TO_CHECKERS` key naming (`submission_checker/main.py:51`)

```diff
 MODE_TO_CHECKERS = {
     "training":      [DirectoryCheck, TrainingCheck],
     "checkpointing": [DirectoryCheck, CheckpointingCheck],
-    "vectordb":      [VdbCheck],
-    "kvcache":       [KVCacheCheck],
+    "vector_database":  [VdbCheck],
+    "kv_cache":         [KVCacheCheck],
 }
```

The loader's `mode` value is `list_dir(<system_path>)[i]` — the on-disk directory name. Pre-fix this never matched the short-form keys, so every vdb / kvcache submission tripped the `[2.1.10 workloadCategories] unrecognized mode directory` error at `main.py:174-181` and skipped every per-rule check. The check classes themselves were already aligned with the disk format (`vdb_checks.py:811` guards on `self.mode != "vector_database"`).

### Bug 2 — `_VALID_WORKLOAD_CATEGORIES` exclusion (`submission_structure_checks.py:78`)

Extended the allowlist to all four categories. The violation message text was hardcoded to `"only 'training' and 'checkpointing' allowed"` — now it enumerates the four allowed names from the set, so the error message stays in sync with the allowlist automatically.

### Bug 3 — Loader assumed checkpointing-style layout for everything non-training (`loader.py:132-143`)

Pre-fix the `else`-branch modelled only the checkpointing shape `<benchmark>/<datetime>/`. The four real shapes per `generate_output_location()`:

| Mode | Layout |
|---|---|
| `training` | `training/<model>/{datagen,run}/<datetime>/` |
| `checkpointing` | `checkpointing/<model>/<datetime>/` |
| `kv_cache` | `kv_cache/<model>/<command>/<datetime>/` |
| `vector_database` | `vector_database/<engine>/<index>/<command>/<datetime>/` |

The shared `else` walked one level too shallow for kvcache (treated `<command>` as `<timestamp>`) and two levels too shallow for vdb (treated `<index>` as `<timestamp>`). Even after fixing bugs 1+2, every per-rule check would have received empty / mis-pathed log handles.

Split into four mode-specific branches plus a `_collect_timestamped_logs(command_path)` helper that walks a command directory and returns the `(summary, metadata, timestamp)` tuple list every downstream rule iterates over (the existing `_iter_run_files` / `_iter_datagen_files` helpers in `vdb_checks.py`, `DirectoryCheck.datagen_files_check`, etc).

For `vector_database`, yields **one `SubmissionLogs` per `(engine, index)` pair** with `folder` pointing at the index dir — so `VdbCheck.path` lands on the index dir (necessary because `vdb_closed_index_types` does `os.path.basename(self.path)` and expects the index token, e.g. `DISKANN`).

## Coupling

All three bugs stack on the same submission. Fixing only #1 still trips #2 (`unexpected workload category`). Fixing only #1+#2 still trips #3 (the per-rule checks see empty `run_files` because the walker landed at the wrong layer). All three must land together for a vdb or kvcache submission to validate end-to-end.

## Tests (13 new)

### `mlpstorage_py/tests/test_submission_checker_structure.py`

- `TestIssue612WorkloadCategoriesAcceptsAllFour` (5):
  - `test_vector_database_category_accepted` — `vector_database` no longer flagged
  - `test_kv_cache_category_accepted` — `kv_cache` no longer flagged
  - `test_short_form_vectordb_still_flagged` — defense in depth: the short form `vectordb` (not the disk-canonical name) is still flagged as unexpected; submissions with that name on disk indicate a writer-side regression
  - `test_short_form_kvcache_still_flagged` — same for `kvcache`
  - `test_error_message_enumerates_all_four_categories` — violation text contains all four allowed names, not just the pre-fix `'training' and 'checkpointing'`
- `TestIssue612ModeToCheckersKeys` (3):
  - `test_keys_are_disk_canonical` — `vector_database` / `kv_cache` present
  - `test_short_form_keys_are_absent` — `vectordb` / `kvcache` absent (so misnamed submissions still hit the unrecognized-mode branch)
  - `test_keys_align_with_benchmark_types_enum` — round-trip check: every `BENCHMARK_TYPES.name` must be a `MODE_TO_CHECKERS` key. Pins the writer↔consumer contract so future enum renames trip a clear test, not a runtime mismatch.

### `mlpstorage_py/tests/test_loader_missing_optional_dirs.py` (5)

- `test_issue_612_kvcache_layout_walks_command_then_timestamp` — builds `kv_cache/llama3.1-8b/{datagen,run}/<datetime>/` with metadata + summary; asserts `datagen_files` and `run_files` each get exactly 1 entry with the right timestamp string
- `test_issue_612_vector_database_yields_one_logs_per_engine_index` — builds `vector_database/milvus/{DISKANN,HNSW}/{datagen,run}/<datetime>/`; asserts two `SubmissionLogs` yielded, one per index, with `folder` ending in `milvus/<INDEX>`
- `test_issue_612_vector_database_missing_index_dir_does_not_crash` — empty `<engine>/` (no indexes) is handled gracefully; mirrors the existing BUG-T1 defensive pattern
- `test_issue_612_kvcache_missing_command_dirs_does_not_crash` — empty `<model>/` under kv_cache returns empty file lists, doesn't raise
- `test_issue_612_checkpointing_branch_preserved` — regression guard: the existing `<model>/<datetime>/` shape (no command segment) still loads into `checkpoint_files`, not `run_files` / `datagen_files`

## Test plan

- [x] `tests/` — 2446 passed, 13 deselected
- [x] `mlpstorage_py/tests/` — 793 passed, 1 xfailed (pre-existing, unrelated)
- [x] `kv_cache_benchmark/tests/` — 238 passed, 2 deselected
- [x] `vdb_benchmark/tests/tests/` — 144 passed
- [x] **Total: 3621 passed**
- [ ] Reviewer to verify with a real vdb/kvcache submission: a smoke-test submission that previously hit `[2.1.10 workloadCategories] unrecognized mode directory 'kv_cache'` now flows through to the per-rule checks (or to legitimate per-rule violations, but no longer skipped at the mode-dispatch layer).