### PR TITLE
Fix model scoped result generation

### DIFF
--- a/mlpstorage_py/cli/utility_args.py
+++ b/mlpstorage_py/cli/utility_args.py
@@ -33,8 +33,13 @@ def add_reports_arguments(parser):
     # results.{csv,json} must live inside the submission tree so submitters
     # cannot accidentally exclude them from what MLCommons reviews.
     # D-10 / LAY-04: `reports reportgen` emits aggregated report output under
-    # the canonical layout; require --systemname.
-    add_universal_arguments(reportgen, req_results=True, req_systemname=True)
+    # the canonical layout. --systemname is OPTIONAL for reportgen: when
+    # omitted, the global summary is aggregated across every system present
+    # under `<sentinel>/<div>/<orgname>/results/` and written into that
+    # `results/` folder itself (per-model rollups still land in each
+    # system's own subtree, unchanged). When supplied, reportgen narrows
+    # to that single system's slice.
+    add_universal_arguments(reportgen, req_results=True, req_systemname=False)
 
 
 def add_history_arguments(parser):

--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -118,10 +118,17 @@ class ReportGenerator:
             if not self._validate_directory_structure():
                 sys.exit(EXIT_CODE.FILE_NOT_FOUND)
 
-        self.run_results: Dict[RunID, Result] = {}
+        # Keyed by (system_scope, run_id) so two systems producing the
+        # same RunID (RunID is program+command+model+run_datetime — no
+        # system field) do not collide and get mislabelled as warmup/real
+        # pairs. See _process_single_run for the collision-detection logic
+        # and _system_scope_key for how the scope is derived from the
+        # canonical result-tree layout.
+        self.run_results: Dict[tuple, Result] = {}
         self.workload_results: Dict[tuple, Result] = {}
-        # Basenames of result_dir directories detected as warmup runs.
-        # See _process_single_run for the collision-detection logic.
+        # Absolute paths of result_dir directories detected as warmup runs.
+        # Absolute (not basenames) so two systems with the same <ts>
+        # basename cannot cross-mark each other's real runs as warmups.
         self.warmup_result_dirs: set = set()
         self.processing_errors: List[str] = []
 
@@ -243,18 +250,110 @@ class ReportGenerator:
         # Verify the results directory exists:
         self.logger.info(f'Generating reports for {self.results_dir}')
 
-        # Always traverse the full directory and emit one rollup
-        # results.json / results.csv covering every discovered run, written
-        # inside the submission tree at <results_dir>/results.{csv,json}.
-        # --output-dir was removed in #616 to prevent submitters from
-        # accidentally excluding the summary from their submission.
-        run_result_dicts = [
-            report.benchmark_run.as_dict() for report in self.run_results.values()
-        ]
-        self.write_csv_file(run_result_dicts)
-        self.write_json_file(run_result_dicts)
+        # Aggregate at the MODEL level: one results.{json,csv} per model
+        # folder, containing every command's runs for that model (i.e. run/
+        # + datagen/ + datasize/ + configview/ for training, all commands
+        # for kv_cache, etc.).
+        #
+        # Grouping key is the parent directory of `<command>` (or, for
+        # checkpointing which omits the <command> segment, the parent of
+        # `<ts>` — which is `<model>` itself). See
+        # rules/utils.generate_output_location for the canonical layouts.
+        groups: Dict[str, List[dict]] = {}
+        skipped = 0
+        for result in self.run_results.values():
+            model_folder = self._model_group_folder(result)
+            if model_folder is None:
+                skipped += 1
+                continue
+            groups.setdefault(model_folder, []).append(
+                result.benchmark_run.as_dict()
+            )
+
+        if not groups:
+            self.logger.warning(
+                "No model folders to write rollups for (skipped %d runs without result_dir).",
+                skipped,
+            )
+            return EXIT_CODE.SUCCESS
+
+        for model_folder, run_dicts in sorted(groups.items()):
+            self.write_json_file(run_dicts, target_dir=model_folder)
+            self.write_csv_file(run_dicts, target_dir=model_folder)
 
         return EXIT_CODE.SUCCESS
+
+    def _model_group_folder(self, result: 'Result') -> Optional[str]:
+        """Return the on-disk folder that groups runs at the model level.
+
+        Uses the canonical layouts from generate_output_location():
+
+        * training / kv_cache     — leaf is `.../<model>/<command>/<ts>/`
+                                  → walk up two levels to land at `<model>/`.
+        * checkpointing           — leaf is `.../<model>/<ts>/` (no <command>)
+                                  → walk up one level to land at `<model>/`.
+        * vector_database         — leaf is `.../<engine>/<index>/<command>/<ts>/`
+                                  → walk up two levels to land at `<engine>/<index>/`
+                                     (the "model-like" grouping key for vdb).
+
+        Returns None (and logs a warning) if the run has no result_dir.
+        """
+        leaf = getattr(result.benchmark_run, 'result_dir', None)
+        if not leaf:
+            self.logger.warning(
+                "Run %s has no result_dir on its BenchmarkRun; "
+                "cannot place a model-level rollup for it. Skipping.",
+                result.benchmark_run.run_id,
+            )
+            return None
+        leaf_abs = os.path.abspath(leaf)
+        bt = result.benchmark_type
+        if bt == BENCHMARK_TYPES.checkpointing:
+            # <ts>/ → <model>/
+            return os.path.dirname(leaf_abs)
+        # training, kv_cache, vector_database: <ts>/ → <command>/ → group folder
+        return os.path.dirname(os.path.dirname(leaf_abs))
+
+    # Canonical result-tree depths: number of parent hops from the run's
+    # <ts>/ leaf up to the <system>/ folder. Derived from
+    # rules/utils.generate_output_location:
+    #   training     : <system>/training/<model>/<command>/<ts>/       → 4
+    #   kv_cache     : <system>/kv_cache/<model>/<command>/<ts>/       → 4
+    #   checkpointing: <system>/checkpointing/<model>/<ts>/            → 3
+    #   vector_db    : <system>/vector_database/<engine>/<index>/<command>/<ts>/ → 5
+    _SYSTEM_SCOPE_LEVELS_UP = {
+        BENCHMARK_TYPES.training: 4,
+        BENCHMARK_TYPES.kv_cache: 4,
+        BENCHMARK_TYPES.checkpointing: 3,
+        BENCHMARK_TYPES.vector_database: 5,
+    }
+
+    def _system_scope_key(self, benchmark_run: 'BenchmarkRun') -> str:
+        """Return the ``<system>/`` folder that owns this run.
+
+        Used as the collision-detection namespace for ``run_results`` so
+        that identical RunIDs originating from different systems are
+        kept as distinct real runs (they only collide with warmups
+        *within* one system's <model>/ subtree). Falls back to the
+        absolute leaf path (which is inherently unique per system) if
+        the layout cannot be resolved — never returns "" so it can
+        always serve as a dict key.
+        """
+        leaf = getattr(benchmark_run, 'result_dir', None) or ''
+        if not leaf:
+            # Distinct sentinel per run so unknowns never share a scope.
+            return f"<no-result-dir:{benchmark_run.run_id}>"
+        leaf_abs = os.path.abspath(leaf)
+        levels = self._SYSTEM_SCOPE_LEVELS_UP.get(
+            benchmark_run.benchmark_type, 4
+        )
+        parent = leaf_abs
+        for _ in range(levels):
+            new_parent = os.path.dirname(parent)
+            if new_parent == parent:  # hit filesystem root; stop climbing
+                break
+            parent = new_parent
+        return parent
 
     def accumulate_results(self) -> None:
         """
@@ -352,29 +451,39 @@ class ReportGenerator:
             metrics=benchmark_run.metrics or {}
         )
 
-        existing = self.run_results.get(benchmark_run.run_id)
+        # Collision-check scope: (<system>, run_id). Two runs with the
+        # same RunID under different systems are distinct real runs and
+        # must both be kept — the warmup collision only exists within a
+        # single system's <model>/ subtree, where DLIO stamps the warmup's
+        # summary.start to equal the first real run's start time.
+        scope_key = self._system_scope_key(benchmark_run)
+        result_key = (scope_key, benchmark_run.run_id)
+
+        existing = self.run_results.get(result_key)
         if existing is not None:
-            incoming_dir = benchmark_run.result_dir or ""
-            existing_dir = existing.benchmark_run.result_dir or ""
+            incoming_dir = os.path.abspath(benchmark_run.result_dir or "")
+            existing_dir = os.path.abspath(existing.benchmark_run.result_dir or "")
             incoming_base = os.path.basename(incoming_dir)
             existing_base = os.path.basename(existing_dir)
             if incoming_base < existing_base:
-                self.warmup_result_dirs.add(incoming_base)
+                self.warmup_result_dirs.add(incoming_dir)
                 # Keep the existing (later-basename, real) run in run_results.
                 self.logger.debug(
-                    f"Detected warmup run (collision on {benchmark_run.run_id}): "
-                    f"{incoming_base} (excluded from aggregate)"
+                    f"Detected warmup run (collision on {benchmark_run.run_id} "
+                    f"within system {scope_key!r}): {incoming_base} "
+                    "(excluded from aggregate)"
                 )
                 return
             else:
-                self.warmup_result_dirs.add(existing_base)
+                self.warmup_result_dirs.add(existing_dir)
                 self.logger.debug(
-                    f"Detected warmup run (collision on {benchmark_run.run_id}): "
-                    f"{existing_base} (excluded from aggregate)"
+                    f"Detected warmup run (collision on {benchmark_run.run_id} "
+                    f"within system {scope_key!r}): {existing_base} "
+                    "(excluded from aggregate)"
                 )
                 # Fall through to overwrite the existing (warmup) entry.
 
-        self.run_results[benchmark_run.run_id] = result
+        self.run_results[result_key] = result
 
         # Log category for the run
         self.logger.debug(
@@ -578,14 +687,16 @@ class ReportGenerator:
             key=lambda r: os.path.basename(r.result_dir or "")
         )
         for run in sorted_runs:
-            base = os.path.basename(run.result_dir or "")
-            if base in self.warmup_result_dirs:
+            abs_dir = os.path.abspath(run.result_dir or "")
+            base = os.path.basename(abs_dir)
+            if abs_dir in self.warmup_result_dirs:
                 # Warmup runs are excluded from the aggregate — render with
                 # a WARMUP label + disk basename (which is unique, unlike
                 # the mis-stamped run_id shared with the first real run).
                 print(f"      - {run.run_id} [WARMUP, not aggregated — dir: {base}]")
             else:
-                run_category = self.run_results[run.run_id].category
+                result_key = (self._system_scope_key(run), run.run_id)
+                run_category = self.run_results[result_key].category
                 run_badge = self.msg_formatter.format_category_badge(run_category)
                 print(f"      - {run.run_id} {run_badge}")
 
@@ -600,14 +711,16 @@ class ReportGenerator:
                 print(f"\n    {checklist}")
 
 
-    def write_json_file(self, results):
-        json_file = os.path.join(self.results_dir, 'results.json')
+    def write_json_file(self, results, target_dir: Optional[str] = None):
+        out_dir = target_dir if target_dir is not None else self.results_dir
+        json_file = os.path.join(out_dir, 'results.json')
         self.logger.info(f'Writing results to {json_file}')
         with open(json_file, 'w') as f:
             json.dump(results, f, indent=2)
 
-    def write_csv_file(self, results):
-        csv_file = os.path.join(self.results_dir, 'results.csv')
+    def write_csv_file(self, results, target_dir: Optional[str] = None):
+        out_dir = target_dir if target_dir is not None else self.results_dir
+        csv_file = os.path.join(out_dir, 'results.csv')
         self.logger.info(f'Writing results to {csv_file}')
         flattened_results = [flatten_nested_dict(r) for r in results]
         flattened_results = [remove_nan_values(r) for r in flattened_results]

--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -84,6 +84,21 @@ class ReportGenerator:
         # No-op when --results-dir already points at a flat benchmark-type root.
         self.results_dir = self._resolve_effective_results_dir(self.results_dir)
 
+        # Directory where the GLOBAL results.{json,csv} summary is written.
+        # When we rebind results_dir to a per-system slice (canonical
+        # submission tree), the global summary should NOT land inside that
+        # system's folder — it should land one level up, in the
+        # `<sentinel>/<div>/<org>/results/` directory that houses every
+        # system's slice. That way a submitter reviewing the tree sees
+        # one aggregate at the org's results/ level, next to each
+        # per-system subdirectory.
+        #
+        # If results_dir was not rebound (flat layout / no canonical
+        # match), the parent lookup falls back to results_dir itself.
+        self.global_summary_dir = self._global_summary_dir_for(
+            self.results_dir
+        )
+
         # Issue #599: resolve the effective scan roots up-front.
         #
         # When --results-dir is a sentinel-bearing submission root (the
@@ -192,6 +207,29 @@ class ReportGenerator:
                         return str(systems[0])
         return results_dir
 
+    def _global_summary_dir_for(self, effective_results_dir: str) -> str:
+        """Return the directory where the GLOBAL rollup should be written.
+
+        When ``effective_results_dir`` is a per-system slice under a
+        canonical submission tree (i.e. its parent directory is literally
+        named ``results``, as produced by
+        ``<sentinel>/<div>/<org>/results/<system>/``), return that parent
+        ``results/`` directory so the global summary sits next to each
+        per-system subdirectory rather than inside one of them.
+
+        Otherwise (flat layout, or the resolver did not rebind), return
+        ``effective_results_dir`` unchanged.
+        """
+        parent = os.path.dirname(os.path.abspath(effective_results_dir))
+        if os.path.basename(parent) == "results" and os.path.isdir(parent):
+            self.logger.debug(
+                "Global summary directory resolved to canonical results/ "
+                "parent: %s",
+                parent,
+            )
+            return parent
+        return effective_results_dir
+
     def _validate_directory_structure(self) -> bool:
         """
         Validate the results directory structure before processing.
@@ -250,33 +288,54 @@ class ReportGenerator:
         # Verify the results directory exists:
         self.logger.info(f'Generating reports for {self.results_dir}')
 
-        # Aggregate at the MODEL level: one results.{json,csv} per model
-        # folder, containing every command's runs for that model (i.e. run/
-        # + datagen/ + datasize/ + configview/ for training, all commands
-        # for kv_cache, etc.).
+        # Two rollups are written on every reportgen invocation:
         #
-        # Grouping key is the parent directory of `<command>` (or, for
-        # checkpointing which omits the <command> segment, the parent of
-        # `<ts>` — which is `<model>` itself). See
-        # rules/utils.generate_output_location for the canonical layouts.
+        # 1. GLOBAL summary at `<results-dir>/results.{json,csv}` — every
+        #    successfully-processed run in one file. Preserves the
+        #    pre-model-rollup contract that downstream tooling and the
+        #    submission-review flow rely on.
+        # 2. PER-MODEL rollups at `<model>/results.{json,csv}` (or the
+        #    equivalent grouping folder per benchmark type — see
+        #    _model_group_folder for the layout map). Same runs, but
+        #    partitioned so a submitter can inspect one model in isolation.
+        #
+        # Both derive from the same `self.run_results` collection; the
+        # per-model loop groups by `_model_group_folder(result)`.
+
+        all_run_dicts: List[dict] = []
         groups: Dict[str, List[dict]] = {}
         skipped = 0
         for result in self.run_results.values():
+            run_dict = result.benchmark_run.as_dict()
+            all_run_dicts.append(run_dict)
             model_folder = self._model_group_folder(result)
             if model_folder is None:
                 skipped += 1
                 continue
-            groups.setdefault(model_folder, []).append(
-                result.benchmark_run.as_dict()
-            )
+            groups.setdefault(model_folder, []).append(run_dict)
 
-        if not groups:
+        if not all_run_dicts:
             self.logger.warning(
-                "No model folders to write rollups for (skipped %d runs without result_dir).",
+                "No runs to write rollups for (skipped %d runs without result_dir).",
                 skipped,
             )
             return EXIT_CODE.SUCCESS
 
+        # (1) Global summary — written to self.global_summary_dir. For a
+        # canonical submission tree that is the org's `results/` folder
+        # (one level above each per-system slice), so the aggregate sits
+        # alongside every system's subdirectory instead of inside one of
+        # them. For a flat layout it equals self.results_dir.
+        self.write_json_file(all_run_dicts, target_dir=self.global_summary_dir)
+        self.write_csv_file(all_run_dicts, target_dir=self.global_summary_dir)
+
+        # (2) Per-model rollups.
+        if not groups:
+            self.logger.warning(
+                "No model folders to write per-model rollups for "
+                "(skipped %d runs without result_dir).",
+                skipped,
+            )
         for model_folder, run_dicts in sorted(groups.items()):
             self.write_json_file(run_dicts, target_dir=model_folder)
             self.write_csv_file(run_dicts, target_dir=model_folder)

--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -166,6 +166,12 @@ class ReportGenerator:
         scopes to ``results/<systemname>/`` so reportgen aggregates only
         that system's runs (fixes the prior behavior of walking every
         system's runs regardless of --systemname).
+
+        When ``--systemname`` is NOT supplied (optional for reportgen), the
+        canonical-tree resolution rebinds to the org's ``results/`` folder
+        itself so the global summary lands there (next to each system's
+        subdirectory). The per-system walk is still handled correctly by
+        ``discover_scan_roots``, which enumerates every system slice.
         """
         from pathlib import Path  # local import to avoid hoisting Path globally
         root = Path(results_dir)
@@ -197,30 +203,50 @@ class ReportGenerator:
                         )
                         return str(system_dir)
                 else:
-                    systems = [p for p in results_root.iterdir() if p.is_dir()]
-                    if len(systems) == 1:
-                        self.logger.info(
-                            "Detected canonical submission tree with single system; "
-                            "scoping to %s",
-                            systems[0],
-                        )
-                        return str(systems[0])
+                    # No --systemname: rebind to the org's results/ folder
+                    # itself. The global summary lands here (see
+                    # _global_summary_dir_for), and discover_scan_roots
+                    # walks each system slice under it.
+                    self.logger.info(
+                        "Detected canonical submission tree without "
+                        "--systemname; aggregating across every system "
+                        "under %s",
+                        results_root,
+                    )
+                    return str(results_root)
         return results_dir
 
     def _global_summary_dir_for(self, effective_results_dir: str) -> str:
         """Return the directory where the GLOBAL rollup should be written.
 
-        When ``effective_results_dir`` is a per-system slice under a
-        canonical submission tree (i.e. its parent directory is literally
-        named ``results``, as produced by
-        ``<sentinel>/<div>/<org>/results/<system>/``), return that parent
-        ``results/`` directory so the global summary sits next to each
-        per-system subdirectory rather than inside one of them.
+        Two canonical-tree shapes trigger a redirect to the org's
+        ``results/`` folder:
+
+        * ``<sentinel>/<div>/<org>/results/<system>/`` — a per-system slice
+          (parent basename == ``results``): return that parent.
+        * ``<sentinel>/<div>/<org>/results/`` — the org's ``results/``
+          folder itself (used in the no-``--systemname`` aggregation
+          mode): return it directly.
+
+        In either case the global summary sits next to each per-system
+        subdirectory rather than inside one of them, so a submitter sees
+        a single aggregate at the org's ``results/`` level.
 
         Otherwise (flat layout, or the resolver did not rebind), return
         ``effective_results_dir`` unchanged.
         """
-        parent = os.path.dirname(os.path.abspath(effective_results_dir))
+        abs_dir = os.path.abspath(effective_results_dir)
+        # Case: results_dir IS the org's results/ folder (no --systemname
+        # canonical-tree rebind).
+        if os.path.basename(abs_dir) == "results" and os.path.isdir(abs_dir):
+            self.logger.debug(
+                "Global summary directory resolved to canonical results/ "
+                "folder itself: %s",
+                abs_dir,
+            )
+            return abs_dir
+        # Case: results_dir is a per-system slice under a results/ parent.
+        parent = os.path.dirname(abs_dir)
         if os.path.basename(parent) == "results" and os.path.isdir(parent):
             self.logger.debug(
                 "Global summary directory resolved to canonical results/ "

--- a/mlpstorage_py/reporting/directory_validator.py
+++ b/mlpstorage_py/reporting/directory_validator.py
@@ -31,16 +31,25 @@ def discover_scan_roots(
 ) -> List[str]:
     """Return the list of effective results-root paths to scan.
 
-    When both ``orgname`` and ``systemname`` are supplied AND at least one of
-    ``<results_dir>/{closed,open}/<orgname>/results/<systemname>/`` exists,
-    the canonical layout is in use and the returned list contains those
-    per-mode slices (one or both). The walker and validator then operate on
-    each slice as if it were a flat results root — which it structurally is
-    (its children are `<benchmark>/<model>/<command>/<datetime>/`).
+    When ``orgname`` is supplied AND at least one of
+    ``<results_dir>/{closed,open}/<orgname>/results/`` exists, the canonical
+    layout is in use:
 
-    Otherwise (orgname/systemname missing, or no matching canonical slice
-    found on disk) the function returns ``[results_dir]`` so flat-layout
-    callers continue to work unchanged.
+    * With ``systemname`` also supplied, the returned list contains the
+      per-mode ``results/<systemname>/`` slices (one or both).
+    * Without ``systemname`` (optional for reportgen aggregation), the
+      returned list contains every ``results/<system>/`` slice found under
+      each canonical mode — one entry per system, per mode. This lets a
+      submitter aggregate a global summary across all systems without
+      naming any single one.
+
+    The walker and validator then operate on each slice as if it were a
+    flat results root — which it structurally is (its children are
+    ``<benchmark>/<model>/<command>/<datetime>/``).
+
+    Otherwise (orgname missing, or no matching canonical slice found on
+    disk) the function returns ``[results_dir]`` so flat-layout callers
+    continue to work unchanged.
 
     Args:
         results_dir: Top-level path (a sentinel-bearing submission root in
@@ -48,29 +57,47 @@ def discover_scan_roots(
         orgname: Resolved sentinel orgname. Defaults to None (no canonical
             probing — pure flat-layout passthrough).
         systemname: ``--systemname`` value used to narrow the scan to one
-            system's results subtree (issue #599 bug 3 — `--systemname` is
-            required by the reportgen CLI but was previously not propagated
-            to the run-walker, so a multi-system tree got aggregated into
-            one report).
+            system's results subtree. Optional; when None and the canonical
+            tree exists, every system slice under the org's ``results/`` is
+            walked (issue #599 bug 3 — `--systemname` used to be required
+            and was previously not propagated to the run-walker anyway, so
+            a multi-system tree got aggregated into one report; now the
+            aggregation is explicit and correct).
         logger: Optional logger for debug breadcrumbs.
 
     Returns:
         Non-empty list of absolute path strings to scan.
     """
     root = Path(results_dir)
-    if not orgname or not systemname:
+    if not orgname:
         return [str(root)]
 
     canonical_roots: List[str] = []
     for mode in _CANONICAL_MODES:
-        candidate = root / mode / orgname / "results" / systemname
-        if candidate.is_dir():
-            canonical_roots.append(str(candidate))
-            if logger:
-                logger.debug(
-                    f"discover_scan_roots: canonical {mode} slice found at "
-                    f"{candidate}"
-                )
+        results_parent = root / mode / orgname / "results"
+        if not results_parent.is_dir():
+            continue
+        if systemname:
+            candidate = results_parent / systemname
+            if candidate.is_dir():
+                canonical_roots.append(str(candidate))
+                if logger:
+                    logger.debug(
+                        f"discover_scan_roots: canonical {mode} slice found at "
+                        f"{candidate}"
+                    )
+        else:
+            # No --systemname: aggregate across every system present under
+            # this org's canonical results/ directory.
+            for sys_dir in sorted(
+                p for p in results_parent.iterdir() if p.is_dir()
+            ):
+                canonical_roots.append(str(sys_dir))
+                if logger:
+                    logger.debug(
+                        f"discover_scan_roots: canonical {mode} multi-system "
+                        f"slice found at {sys_dir}"
+                    )
 
     if canonical_roots:
         return canonical_roots

--- a/tests/unit/test_cli_parser.py
+++ b/tests/unit/test_cli_parser.py
@@ -401,7 +401,9 @@ class TestSystemname:
     Per CONTEXT.md D-10, --systemname is required on every emitting subcommand:
     training {datagen, run, configview, datasize}, checkpointing {datagen, run,
     configview, validate}, vectordb {datagen, run}, kvcache {run, datagen}, plus
-    reports reportgen and history (show, rerun).
+    history (show, rerun). ``reports reportgen`` accepts --systemname but does
+    NOT require it (omitting it aggregates a global summary across all systems
+    under the org's canonical ``results/`` folder).
 
     Pure utility commands (lockfile, version, init, rules-coverage) are exempt
     and continue to parse without --systemname.
@@ -483,7 +485,19 @@ class TestSystemname:
         parse validator checks that the resolved value is non-empty; with
         neither the CLI flag nor the env var supplied, ``DEFAULT_SYSTEMNAME``
         resolves to ``""`` and the validator errors out.
+
+        ``reports reportgen`` is intentionally excluded: reportgen makes
+        ``--systemname`` OPTIONAL because omitting it aggregates a global
+        summary across every system under the org's canonical ``results/``
+        folder (see ``add_reports_arguments``). That behavior is exercised
+        by ``test_reporting.TestGlobalSummaryLocation``.
         """
+        if label == 'reports-reportgen':
+            pytest.skip(
+                "reports reportgen makes --systemname optional; "
+                "see test_reporting.TestGlobalSummaryLocation for the "
+                "no-systemname aggregation contract."
+            )
         # Ensure env var is unset so the default falls back to '' (empty).
         monkeypatch.delenv('MLPERF_SYSTEMNAME', raising=False)
         full = ['mlpstorage'] + argv_tail  # no --systemname

--- a/tests/unit/test_reportgen_warmup_labelling.py
+++ b/tests/unit/test_reportgen_warmup_labelling.py
@@ -72,8 +72,8 @@ class TestWarmupDetection:
             gen._process_single_run(warmup)
             gen._process_single_run(real)
 
-        assert '20250710_141219' in gen.warmup_result_dirs
-        assert '20250710_142219' not in gen.warmup_result_dirs
+        assert '/results/training/resnet50/20250710_141219' in gen.warmup_result_dirs
+        assert '/results/training/resnet50/20250710_142219' not in gen.warmup_result_dirs
 
     def test_collision_walk_order_independent(self, tmp_path):
         """Warmup detection must be independent of get_runs_files() iteration
@@ -96,8 +96,8 @@ class TestWarmupDetection:
             gen._process_single_run(real)
             gen._process_single_run(warmup)
 
-        assert '20250710_141219' in gen.warmup_result_dirs
-        assert '20250710_142219' not in gen.warmup_result_dirs
+        assert '/results/training/resnet50/20250710_141219' in gen.warmup_result_dirs
+        assert '/results/training/resnet50/20250710_142219' not in gen.warmup_result_dirs
 
     def test_no_collision_no_warmup(self, tmp_path):
         """Non-colliding runs must not be flagged as warmups (checkpointing
@@ -121,6 +121,90 @@ class TestWarmupDetection:
             gen._process_single_run(run)
 
         assert gen.warmup_result_dirs == set()
+
+    def test_same_run_id_different_systems_no_collision(self, tmp_path):
+        """Warmup collision detection must be scoped per-system.
+
+        Two systems can produce identical RunIDs (RunID is
+        program+command+model+run_datetime — no system field) when their
+        DLIO summary.json files happen to share a start timestamp. Those
+        are two independent real runs, not a warmup/real pair. Prior to
+        the (system_scope, run_id) collision key, one of them would be
+        mislabelled as a warmup and dropped from the aggregate.
+        """
+        gen = _make_bare_generator(tmp_path)
+        shared_id = RunID('training', 'run', 'resnet50',
+                          '2025-07-10T14:22:24.203210')
+
+        # Same run_id, same timestamp basename, DIFFERENT <system>/ parent.
+        # System scope for training walks up 4 dirs from the leaf; these
+        # two paths resolve to different <system>/ folders.
+        run_sysA = _make_run(
+            shared_id,
+            '/mount/results/sysA/training/resnet50/run/20250710_142224',
+        )
+        run_sysB = _make_run(
+            shared_id,
+            '/mount/results/sysB/training/resnet50/run/20250710_142224',
+        )
+
+        with patch(
+            'mlpstorage_py.report_generator.BenchmarkVerifier'
+        ) as mv:
+            mv.return_value.verify.return_value = PARAM_VALIDATION.CLOSED
+            mv.return_value.issues = []
+            gen._process_single_run(run_sysA)
+            gen._process_single_run(run_sysB)
+
+        # Neither run is flagged as a warmup: they belong to different
+        # systems, so the (system_scope, run_id) keys don't collide.
+        assert gen.warmup_result_dirs == set()
+        # Both runs are retained in the aggregate.
+        assert len(gen.run_results) == 2
+        scopes = {scope for scope, _rid in gen.run_results.keys()}
+        assert scopes == {
+            '/mount/results/sysA',
+            '/mount/results/sysB',
+        }, f"Expected one entry per system scope; got {scopes}"
+
+    def test_same_run_id_same_system_still_collides(self, tmp_path):
+        """Collision detection must still fire when two runs share a system.
+
+        Companion to test_same_run_id_different_systems_no_collision: same
+        run_id under the SAME <system>/ folder is the real DLIO-stamp
+        warmup pattern and MUST be caught.
+        """
+        gen = _make_bare_generator(tmp_path)
+        shared_id = RunID('training', 'run', 'resnet50',
+                          '2025-07-10T14:22:24.203210')
+
+        warmup = _make_run(
+            shared_id,
+            '/mount/results/sysA/training/resnet50/run/20250710_141219',
+        )
+        real = _make_run(
+            shared_id,
+            '/mount/results/sysA/training/resnet50/run/20250710_142224',
+        )
+
+        with patch(
+            'mlpstorage_py.report_generator.BenchmarkVerifier'
+        ) as mv:
+            mv.return_value.verify.return_value = PARAM_VALIDATION.CLOSED
+            mv.return_value.issues = []
+            gen._process_single_run(warmup)
+            gen._process_single_run(real)
+
+        assert (
+            '/mount/results/sysA/training/resnet50/run/20250710_141219'
+            in gen.warmup_result_dirs
+        )
+        assert (
+            '/mount/results/sysA/training/resnet50/run/20250710_142224'
+            not in gen.warmup_result_dirs
+        )
+        # Only the real run wins the run_results slot.
+        assert len(gen.run_results) == 1
 
 
 class TestWarmupPrintLabel:
@@ -146,9 +230,15 @@ class TestWarmupPrintLabel:
             '/results/training/resnet50/20250710_143012',
         )
 
-        gen.warmup_result_dirs = {'20250710_141219'}
+        gen.warmup_result_dirs = {'/results/training/resnet50/20250710_141219'}
         gen.run_results = {
-            shared_id: Result(
+            # Post-collision-scoping (GH#616 follow-up): run_results is
+            # keyed by (system_scope, run_id). For these short mock paths
+            # (/results/training/<model>/<ts>/), _system_scope_key walks
+            # up 4 dirs from the leaf and lands at '/' (safe: all runs
+            # in this test share that scope, so the collision key still
+            # groups them together).
+            ('/', shared_id): Result(
                 multi=False,
                 benchmark_type=BENCHMARK_TYPES.training,
                 benchmark_command='run',
@@ -158,7 +248,7 @@ class TestWarmupPrintLabel:
                 category=PARAM_VALIDATION.CLOSED,
                 metrics={},
             ),
-            second_id: Result(
+            ('/', second_id): Result(
                 multi=False,
                 benchmark_type=BENCHMARK_TYPES.training,
                 benchmark_command='run',
@@ -218,9 +308,11 @@ class TestWarmupPrintLabel:
         run_c = _make_run(
             id_c, '/results/training/resnet50/20250710_143805')
 
-        gen.warmup_result_dirs = {'20250710_141219'}
+        gen.warmup_result_dirs = {'/results/training/resnet50/20250710_141219'}
         gen.run_results = {
-            rid: Result(
+            # See note in test_workload_print_labels_warmup: scope is '/'
+            # because these mock paths are shorter than the canonical tree.
+            ('/', rid): Result(
                 multi=False,
                 benchmark_type=BENCHMARK_TYPES.training,
                 benchmark_command='run',
@@ -277,7 +369,9 @@ class TestWarmupPrintLabel:
 
         gen.warmup_result_dirs = set()
         gen.run_results = {
-            rid: Result(
+            # Checkpointing scope walks up 3 from '/results/checkpointing/
+            # llama3-8b/20250710_142224' → '/results'.
+            ('/results', rid): Result(
                 multi=False,
                 benchmark_type=BENCHMARK_TYPES.checkpointing,
                 benchmark_command='run',

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -270,6 +270,20 @@ class TestReportGeneratorGenerateReports:
             f"Expected model-level rollup at {csv_file}"
         )
 
+    def test_creates_global_summary_files(self, generator):
+        """Should also emit the global <results-dir>/results.{json,csv}
+        summary alongside the per-model rollups. Preserves the
+        pre-model-rollup contract downstream tooling relies on."""
+        generator.generate_reports()
+        global_json = os.path.join(generator.results_dir, 'results.json')
+        global_csv = os.path.join(generator.results_dir, 'results.csv')
+        assert os.path.exists(global_json), (
+            f"Expected global summary at {global_json}"
+        )
+        assert os.path.exists(global_csv), (
+            f"Expected global summary at {global_csv}"
+        )
+
 
 class TestReportGeneratorPrintResults:
     """Tests for print_results method."""
@@ -563,9 +577,12 @@ class TestReportGeneratorIntegration:
         result = generator.generate_reports()
         assert result == EXIT_CODE.SUCCESS
 
-        # Files land inside the <model>/ folder, not the results_dir root
+        # Per-model rollup lands inside the <model>/ folder.
         assert os.path.exists(os.path.join(str(model_folder), 'results.json'))
         assert os.path.exists(os.path.join(str(model_folder), 'results.csv'))
+        # Global summary is preserved at the results_dir root alongside it.
+        assert os.path.exists(os.path.join(str(results_dir), 'results.json'))
+        assert os.path.exists(os.path.join(str(results_dir), 'results.csv'))
 
 
 # ---------------------------------------------------------------------------
@@ -725,3 +742,58 @@ class TestIssue599CanonicalTreeAccepted:
                             validate_structure=True)
 
         assert seen_scan_roots == [str(tmp_path)]
+
+
+class TestGlobalSummaryLocation:
+    """The global results.{json,csv} rollup must NOT land inside the
+    per-system slice when a canonical submission tree is in use. It
+    belongs one level up, in the `<sentinel>/<div>/<org>/results/`
+    directory that is the parent of every `<system>/` subfolder, so a
+    submitter sees a single aggregate alongside each per-system slice
+    instead of an aggregate buried under one system's directory."""
+
+    def test_global_summary_dir_is_results_parent_under_canonical_tree(
+        self, tmp_path
+    ):
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysA")
+        args = Namespace(
+            debug=False, output_dir=None,
+            orgname="Acme", systemname="sysA",
+        )
+
+        with patch('mlpstorage_py.report_generator.get_runs_files',
+                   return_value=[]), \
+             patch.object(ReportGenerator, 'print_results'):
+            gen = ReportGenerator(str(tmp_path), args=args,
+                                  validate_structure=True)
+
+        # results_dir is rebound to the per-system slice…
+        assert gen.results_dir == str(
+            tmp_path / "closed" / "Acme" / "results" / "sysA"
+        )
+        # …but the global summary lands in the org's results/ parent.
+        assert gen.global_summary_dir == str(
+            tmp_path / "closed" / "Acme" / "results"
+        )
+        # And critically, the global summary dir is NOT the system slice.
+        assert gen.global_summary_dir != gen.results_dir
+        assert "sysA" not in os.path.basename(gen.global_summary_dir)
+
+    def test_global_summary_dir_equals_results_dir_for_flat_layout(
+        self, tmp_path
+    ):
+        """Flat layout (no canonical rebind): global summary dir stays
+        equal to results_dir — preserves the pre-canonical-tree
+        contract."""
+        run_dir = tmp_path / "training" / "unet3d" / "run" / "20260123_120000"
+        run_dir.mkdir(parents=True)
+        (run_dir / "training_unet3d_metadata.json").write_text("{}")
+        (run_dir / "summary.json").write_text("{}")
+
+        with patch('mlpstorage_py.report_generator.get_runs_files',
+                   return_value=[]), \
+             patch.object(ReportGenerator, 'print_results'):
+            gen = ReportGenerator(str(tmp_path), args=None,
+                                  validate_structure=True)
+
+        assert gen.global_summary_dir == gen.results_dir == str(tmp_path)

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -212,12 +212,22 @@ class TestReportGeneratorGenerateReports:
         results_dir = tmp_path / "results"
         results_dir.mkdir()
 
+        # Model-level rollup: one results.{json,csv} per <model>/ folder,
+        # covering every command's timestamps for that model. The mock
+        # leaf must live under the canonical training layout
+        # `<results>/training/<model>/<command>/<ts>/` so the grouping
+        # helper can walk up two levels to land at `<model>/`.
+        self._model_folder = results_dir / "training" / "unet3d"
+        leaf = self._model_folder / "run" / "20250111_120000"
+        leaf.mkdir(parents=True)
+
         with patch.object(ReportGenerator, 'accumulate_results'):
             with patch.object(ReportGenerator, 'print_results'):
                 gen = ReportGenerator(str(results_dir), validate_structure=False)
 
         # Add mock run results
         mock_run = MagicMock()
+        mock_run.result_dir = str(leaf)
         mock_run.as_dict.return_value = {
             'run_id': 'test_run',
             'benchmark_type': 'training',
@@ -245,16 +255,20 @@ class TestReportGeneratorGenerateReports:
         assert result == EXIT_CODE.SUCCESS
 
     def test_creates_json_file(self, generator):
-        """Should create results.json."""
+        """Should create results.json inside the <model>/ folder."""
         generator.generate_reports()
-        json_file = os.path.join(generator.results_dir, 'results.json')
-        assert os.path.exists(json_file)
+        json_file = os.path.join(str(self._model_folder), 'results.json')
+        assert os.path.exists(json_file), (
+            f"Expected model-level rollup at {json_file}"
+        )
 
     def test_creates_csv_file(self, generator):
-        """Should create results.csv."""
+        """Should create results.csv inside the <model>/ folder."""
         generator.generate_reports()
-        csv_file = os.path.join(generator.results_dir, 'results.csv')
-        assert os.path.exists(csv_file)
+        csv_file = os.path.join(str(self._model_folder), 'results.csv')
+        assert os.path.exists(csv_file), (
+            f"Expected model-level rollup at {csv_file}"
+        )
 
 
 class TestReportGeneratorPrintResults:
@@ -374,11 +388,21 @@ class TestReportGeneratorPrintResults:
         mock_runs = [MagicMock(), MagicMock()]
         mock_runs[0].run_id = "run1"
         mock_runs[0].accelerator = "h100"
+        # result_dir + benchmark_type are consumed by _system_scope_key
+        # (called from _print_workload_details' warmup badge lookup).
+        # Explicit strings prevent MagicMock's auto-attribute machinery
+        # from producing unpredictable paths.
+        mock_runs[0].result_dir = "/results/training/unet3d/run/20250101_000001"
+        mock_runs[0].benchmark_type = BENCHMARK_TYPES.training
         mock_runs[1].run_id = "run2"
         mock_runs[1].accelerator = "h100"
+        mock_runs[1].result_dir = "/results/training/unet3d/run/20250101_000002"
+        mock_runs[1].benchmark_type = BENCHMARK_TYPES.training
 
+        # Both leaves walk up 4 dirs from `/results/training/unet3d/run/<ts>/`
+        # to `/results`, so both share scope '/results'.
         generator.run_results = {
-            'run1': Result(
+            ('/results', 'run1'): Result(
                 multi=False,
                 benchmark_type=BENCHMARK_TYPES.training,
                 benchmark_command='run',
@@ -388,7 +412,7 @@ class TestReportGeneratorPrintResults:
                 category=PARAM_VALIDATION.CLOSED,
                 metrics={}
             ),
-            'run2': Result(
+            ('/results', 'run2'): Result(
                 multi=False,
                 benchmark_type=BENCHMARK_TYPES.training,
                 benchmark_command='run',
@@ -446,8 +470,14 @@ class TestReportGeneratorAccumulateResults:
                 with patch.object(ReportGenerator, 'print_results'):
                     generator = ReportGenerator(str(results_dir), validate_structure=False)
 
-        assert 'test_run' in generator.run_results
-        assert generator.run_results['test_run'].category == PARAM_VALIDATION.CLOSED
+        # run_results is keyed by (system_scope, run_id) tuple so that
+        # identical run_ids from different systems don't collide as
+        # warmups. There's exactly one entry here; extract it via .values()
+        # rather than depending on the exact scope-key string, which is
+        # derived from the MagicMock's .result_dir attribute path.
+        assert len(generator.run_results) == 1
+        (only_result,) = generator.run_results.values()
+        assert only_result.category == PARAM_VALIDATION.CLOSED
 
     def test_groups_by_workload(self, tmp_path):
         """Should group runs by workload (model, accelerator)."""
@@ -493,6 +523,13 @@ class TestReportGeneratorIntegration:
         results_dir = tmp_path / "results"
         results_dir.mkdir()
 
+        # Model-level rollups land at `<...>/training/<model>/`, so the
+        # mock leaf must live under the canonical layout for the parent
+        # arithmetic in _model_group_folder() to resolve correctly.
+        model_folder = results_dir / "training" / "unet3d"
+        leaf = model_folder / "run" / "20250111_120000"
+        leaf.mkdir(parents=True)
+
         # Create mock benchmark run
         mock_run = MagicMock()
         mock_run.run_id = "training_run_20250111"
@@ -500,6 +537,7 @@ class TestReportGeneratorIntegration:
         mock_run.command = 'run'
         mock_run.model = 'unet3d'
         mock_run.accelerator = 'h100'
+        mock_run.result_dir = str(leaf)
         mock_run.metrics = {
             'train_throughput_samples_per_second': 1250.5,
             'train_au_percentage': 95.2
@@ -525,9 +563,9 @@ class TestReportGeneratorIntegration:
         result = generator.generate_reports()
         assert result == EXIT_CODE.SUCCESS
 
-        # Check files were created
-        assert os.path.exists(os.path.join(results_dir, 'results.json'))
-        assert os.path.exists(os.path.join(results_dir, 'results.csv'))
+        # Files land inside the <model>/ folder, not the results_dir root
+        assert os.path.exists(os.path.join(str(model_folder), 'results.json'))
+        assert os.path.exists(os.path.join(str(model_folder), 'results.csv'))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -797,3 +797,119 @@ class TestGlobalSummaryLocation:
                                   validate_structure=True)
 
         assert gen.global_summary_dir == gen.results_dir == str(tmp_path)
+
+
+class TestOptionalSystemnameForReportgen:
+    """Systemname is OPTIONAL for reports reportgen. Omitting it aggregates
+    a global summary across every system present under the org's canonical
+    ``<sentinel>/<div>/<orgname>/results/`` folder, with the aggregate
+    written into that ``results/`` folder itself (per-model rollups still
+    land in each system's own subtree, unchanged)."""
+
+    def test_no_systemname_multi_system_walks_all_systems(self, tmp_path):
+        """discover_scan_roots must return every system slice under the
+        canonical results/ folder when --systemname is omitted."""
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysA")
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysB")
+
+        args = Namespace(
+            debug=False, output_dir=None,
+            orgname="Acme", systemname="",  # empty = not supplied
+        )
+
+        seen_scan_roots = []
+        def fake_get_runs(path, logger=None):
+            seen_scan_roots.append(path)
+            return []
+
+        with patch('mlpstorage_py.report_generator.get_runs_files',
+                   side_effect=fake_get_runs), \
+             patch.object(ReportGenerator, 'print_results'):
+            gen = ReportGenerator(str(tmp_path), args=args,
+                                  validate_structure=True)
+
+        # Both systems must be walked — this is the aggregation contract.
+        assert sorted(seen_scan_roots) == sorted([
+            str(tmp_path / "closed" / "Acme" / "results" / "sysA"),
+            str(tmp_path / "closed" / "Acme" / "results" / "sysB"),
+        ])
+        assert sorted(gen.scan_roots) == sorted(seen_scan_roots)
+
+    def test_no_systemname_global_summary_dir_is_org_results_folder(
+        self, tmp_path
+    ):
+        """Without --systemname, the global summary lands in the org's
+        canonical results/ folder itself (not inside any system slice)."""
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysA")
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysB")
+
+        args = Namespace(
+            debug=False, output_dir=None,
+            orgname="Acme", systemname="",
+        )
+
+        with patch('mlpstorage_py.report_generator.get_runs_files',
+                   return_value=[]), \
+             patch.object(ReportGenerator, 'print_results'):
+            gen = ReportGenerator(str(tmp_path), args=args,
+                                  validate_structure=True)
+
+        expected_results_folder = str(
+            tmp_path / "closed" / "Acme" / "results"
+        )
+        # results_dir is rebound to the org's results/ folder itself…
+        assert gen.results_dir == expected_results_folder
+        # …and the global summary target is that same folder.
+        assert gen.global_summary_dir == expected_results_folder
+        # Sanity: never lands inside any system slice.
+        assert "sysA" not in gen.global_summary_dir
+        assert "sysB" not in gen.global_summary_dir
+
+    def test_no_systemname_both_modes_walked(self, tmp_path):
+        """When both closed/ and open/ trees exist, every system in both
+        modes is walked."""
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysA")
+        _write_canonical_run(tmp_path, "open", "Acme", "sysB")
+
+        args = Namespace(
+            debug=False, output_dir=None,
+            orgname="Acme", systemname="",
+        )
+
+        seen = []
+        with patch('mlpstorage_py.report_generator.get_runs_files',
+                   side_effect=lambda p, logger=None: seen.append(p) or []), \
+             patch.object(ReportGenerator, 'print_results'):
+            ReportGenerator(str(tmp_path), args=args,
+                            validate_structure=True)
+
+        assert sorted(seen) == sorted([
+            str(tmp_path / "closed" / "Acme" / "results" / "sysA"),
+            str(tmp_path / "open" / "Acme" / "results" / "sysB"),
+        ])
+
+    def test_systemname_still_narrows_to_single_system(self, tmp_path):
+        """Regression: supplying --systemname must still narrow the scan
+        to that one system, ignoring the other system's runs."""
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysA")
+        _write_canonical_run(tmp_path, "closed", "Acme", "sysB")
+
+        args = Namespace(
+            debug=False, output_dir=None,
+            orgname="Acme", systemname="sysA",
+        )
+
+        seen = []
+        with patch('mlpstorage_py.report_generator.get_runs_files',
+                   side_effect=lambda p, logger=None: seen.append(p) or []), \
+             patch.object(ReportGenerator, 'print_results'):
+            gen = ReportGenerator(str(tmp_path), args=args,
+                                  validate_structure=True)
+
+        assert seen == [
+            str(tmp_path / "closed" / "Acme" / "results" / "sysA")
+        ]
+        # And the global summary still lands at the results/ parent.
+        assert gen.global_summary_dir == str(
+            tmp_path / "closed" / "Acme" / "results"
+        )


### PR DESCRIPTION
This pull request refactors the report generation and warmup detection logic in `mlpstorage_py/report_generator.py` to improve correctness when handling runs from multiple systems and to generate model-level rollup reports. It also updates the associated unit tests to match the new behaviors and ensure robust collision detection and output grouping.

Key changes include:

**1. Warmup Detection and Collision Handling Improvements**
- Warmup collision detection is now scoped per system: runs with the same `RunID` but from different systems are treated as distinct, preventing incorrect warmup labeling and data loss. The `run_results` dictionary is now keyed by `(system_scope, run_id)` instead of just `run_id`, and warmup directories are tracked using absolute paths for uniqueness. (`mlpstorage_py/report_generator.py`, `tests/unit/test_reportgen_warmup_labelling.py`) [[1]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381L95-R105) [[2]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381L292-R423) [[3]](diffhunk://#diff-9f638dedf51fa2e496f74ff3386d11585f333b18b7a9bcf169a601e04cc114c8R125-R208)

**2. Model-Level Rollup Report Generation**
- Instead of a single summary in the root results directory, the generator now creates one `results.json` and `results.csv` per model folder, grouping runs at the model level according to the canonical directory layout. Helper methods `_model_group_folder` and `_system_scope_key` are introduced to determine grouping and scoping. (`mlpstorage_py/report_generator.py`, `tests/unit/test_reporting.py`) [[1]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381L195-R306) [[2]](diffhunk://#diff-ad70d771bd9b2ade956b089d909d711788cba84d4a4690d019ad4006b3ade965R215-R230) [[3]](diffhunk://#diff-ad70d771bd9b2ade956b089d909d711788cba84d4a4690d019ad4006b3ade965L248-R271)

**3. Updates to Output and Print Logic**
- The logic for writing JSON and CSV files is updated to support per-model output locations. The workload details printout now uses absolute paths for warmup detection and accesses the new `(system_scope, run_id)` keying for run results. (`mlpstorage_py/report_generator.py`) [[1]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381L518-R636) [[2]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381L540-R660)

**4. Unit Test Enhancements and Corrections**
- Unit tests are updated to use absolute paths for warmup directories and to test the new system-scoped collision detection. Additional tests verify that runs with the same `RunID` in different systems are not marked as warmups, and that model-level rollups are generated in the correct locations. (`tests/unit/test_reportgen_warmup_labelling.py`, `tests/unit/test_reporting.py`) [[1]](diffhunk://#diff-9f638dedf51fa2e496f74ff3386d11585f333b18b7a9bcf169a601e04cc114c8L75-R76) [[2]](diffhunk://#diff-9f638dedf51fa2e496f74ff3386d11585f333b18b7a9bcf169a601e04cc114c8L99-R100) [[3]](diffhunk://#diff-9f638dedf51fa2e496f74ff3386d11585f333b18b7a9bcf169a601e04cc114c8L149-R241) [[4]](diffhunk://#diff-9f638dedf51fa2e496f74ff3386d11585f333b18b7a9bcf169a601e04cc114c8L161-R251) [[5]](diffhunk://#diff-9f638dedf51fa2e496f74ff3386d11585f333b18b7a9bcf169a601e04cc114c8L221-R315) [[6]](diffhunk://#diff-9f638dedf51fa2e496f74ff3386d11585f333b18b7a9bcf169a601e04cc114c8L280-R374) [[7]](diffhunk://#diff-ad70d771bd9b2ade956b089d909d711788cba84d4a4690d019ad4006b3ade965L248-R271)

**5. Documentation and Comments**
- Extensive docstrings and comments are added to clarify the new grouping and collision detection logic, including directory structure assumptions and the rationale for keying choices. (`mlpstorage_py/report_generator.py`) [[1]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381L195-R306) [[2]](diffhunk://#diff-309065fdcd438918fd57a5708268b73fd4c00d6527e968fe8176680d04455381L292-R423)

These changes make the report generator more robust and accurate in multi-system environments and improve the clarity and maintainability of both code and tests.