### PR TITLE
fix(#627): skip CAP-01 free-space check on training run

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -799,7 +799,19 @@ class TrainingBenchmark(DLIOBenchmark):
         nothing user-visible (the size calc's own .result/.warning calls
         are deliberately suppressed at the gate site; the user-facing
         path in ``datasize`` still gets the real logger).
+
+        Issue #627: on ``args.command == 'run'`` the dataset is a read
+        source, not a write destination — a prior ``datagen`` populated
+        it. Requiring an additional full-dataset worth of free space on
+        top of the already-occupied capacity is a false positive that
+        blocks valid runs on filesystems provisioned to just fit the
+        dataset. Return 0 in that case so ``check_capacity_4field``
+        trivially passes. CAP-02 shared-FS verification still fires
+        from ``_pre_execution_gate`` — the skip is scoped to the byte
+        budget, not the entire gate.
         """
+        if getattr(self.args, 'command', None) == 'run':
+            return 0
         import logging as _logging
         _silent = _logging.getLogger("mlpstorage_py.capacity_gate.silent")
         if not _silent.handlers:

--- a/tests/unit/test_capacity_gate.py
+++ b/tests/unit/test_capacity_gate.py
@@ -548,6 +548,105 @@ class TestTrainingBenchmarkRequiredBytes:
             f"suggestion (the flag IS accepted by `run`). Got: {logged!r}"
         )
 
+    # ------------------------------------------------------------------
+    # Issue #627: CAP-01 must skip the free-space check on `training run`.
+    # ------------------------------------------------------------------
+    # `training run` reads a pre-generated dataset — it does NOT write a
+    # fresh copy to data-dir. The current gate compares f_bavail against
+    # the full dataset size, which effectively requires two copies worth
+    # of free space (one already-populated + one for the phantom write).
+    # See issue #627 for the 80T/75T-used PFS repro. Fix: return 0 on
+    # `run` so check_capacity_4field trivially passes. datagen / datasize
+    # still compute and enforce the real byte budget.
+
+    def test_returns_zero_when_command_is_run_issue_627(self):
+        """Issue #627: `training run` must skip the free-space check.
+
+        Rationale: the dataset already exists on disk (produced by a prior
+        `datagen`). Requiring an additional full-dataset worth of
+        f_bavail on top of the already-consumed capacity blocks valid
+        runs on filesystems provisioned to just fit the dataset.
+
+        Contract: when args.command == 'run', the gate returns 0 WITHOUT
+        invoking calculate_training_data_size or accumulate_host_info.
+        The 0 return causes check_capacity_4field to trivially pass in
+        _pre_execution_gate (available_bytes >= 0 is always true).
+        CAP-02 shared-FS probe still runs — the fix is scoped to the
+        byte budget, not the whole pre-execution gate.
+        """
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        bm = MagicMock(spec=TrainingBenchmark)
+        bm.args = SimpleNamespace(data_dir="/mnt/pfs", command="run")
+        # Pre-populate cluster_information so we can prove the early-return
+        # doesn't need it (and thereby prove it didn't fall through to the
+        # calculate_training_data_size code path).
+        bm.cluster_information = MagicMock()
+        bm.combined_params = {"dataset": {}, "reader": {}}
+        bm.logger = MagicMock()
+        bm.accumulate_host_info = MagicMock()
+
+        with patch(
+            "mlpstorage_py.benchmarks.dlio.calculate_training_data_size",
+            return_value=(364_000, 100, 50_797_117_602_000),
+        ) as mock_calc:
+            result = TrainingBenchmark.required_bytes_for_capacity_gate(bm)
+
+        assert result == 0, (
+            f"Issue #627: training run must return 0 required_bytes so "
+            f"CAP-01 skips the free-space check. Got {result!r}."
+        )
+        mock_calc.assert_not_called()
+        bm.accumulate_host_info.assert_not_called()
+
+    def test_still_computes_full_size_when_command_is_datagen_issue_627(self):
+        """Issue #627 scope guard: datagen path must be unchanged.
+
+        The fix targets `run` only. `datagen` still needs to verify the
+        filesystem has room for a fresh full-size dataset before it
+        starts writing. Regression guard for accidental over-scoping.
+        """
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        bm = MagicMock(spec=TrainingBenchmark)
+        bm.args = SimpleNamespace(data_dir="/mnt/pfs", command="datagen")
+        bm.cluster_information = MagicMock()
+        bm.combined_params = {"dataset": {}, "reader": {}}
+        bm.logger = MagicMock()
+
+        with patch(
+            "mlpstorage_py.benchmarks.dlio.calculate_training_data_size",
+            return_value=(364_000, 100, 50_797_117_602_000),
+        ) as mock_calc:
+            result = TrainingBenchmark.required_bytes_for_capacity_gate(bm)
+
+        assert result == 50_797_117_602_000
+        mock_calc.assert_called_once()
+
+    def test_still_computes_full_size_when_command_is_datasize_issue_627(self):
+        """Issue #627 scope guard: datasize path must be unchanged.
+
+        `datasize` is a planning command — its whole purpose is to tell
+        the operator how much space a datagen would need. Skipping the
+        gate here would defeat that purpose.
+        """
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        bm = MagicMock(spec=TrainingBenchmark)
+        bm.args = SimpleNamespace(data_dir="/mnt/pfs", command="datasize")
+        bm.cluster_information = MagicMock()
+        bm.combined_params = {"dataset": {}, "reader": {}}
+        bm.logger = MagicMock()
+
+        with patch(
+            "mlpstorage_py.benchmarks.dlio.calculate_training_data_size",
+            return_value=(364_000, 100, 50_797_117_602_000),
+        ) as mock_calc:
+            result = TrainingBenchmark.required_bytes_for_capacity_gate(bm)
+
+        assert result == 50_797_117_602_000
+        mock_calc.assert_called_once()
+
 
 class TestCheckpointingBenchmarkRequiredBytes:
     """A7 destination join + sum(rank_gb) * GiB * num_checkpoints_write."""

--- a/tests/unit/test_capacity_gate.py
+++ b/tests/unit/test_capacity_gate.py
@@ -523,12 +523,19 @@ class TestTrainingBenchmarkRequiredBytes:
 
     def test_deferral_message_keeps_rerun_suggestion_for_non_datagen_commands(self):
         """Guardrail for #575: the rewrite must not silently drop the
-        actionable suggestion for the run / datasize commands where
-        --client-host-memory-in-gb IS accepted."""
+        actionable suggestion for the datasize / configview commands
+        where --client-host-memory-in-gb IS accepted.
+
+        Uses ``command="datasize"`` (not ``"run"``) after issue #627:
+        the run path now short-circuits with ``return 0`` before
+        reaching the lazy-collect branch, so it can no longer exercise
+        the deferral-message code path. ``datasize`` still hits it and
+        the #575 regression risk is identical there.
+        """
         from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
 
         bm = MagicMock(spec=TrainingBenchmark)
-        bm.args = SimpleNamespace(data_dir="/data", command="run")
+        bm.args = SimpleNamespace(data_dir="/data", command="datasize")
         try:
             del bm.cluster_information
         except AttributeError:
@@ -544,8 +551,8 @@ class TestTrainingBenchmarkRequiredBytes:
         assert result == 0
         logged = " ".join(str(c.args[0]) for c in bm.logger.info.call_args_list)
         assert "Re-run with --client-host-memory-in-gb" in logged, (
-            "run-path deferral message must retain the actionable re-run "
-            f"suggestion (the flag IS accepted by `run`). Got: {logged!r}"
+            "datasize-path deferral message must retain the actionable re-run "
+            f"suggestion (the flag IS accepted by `datasize`). Got: {logged!r}"
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #627. Makes CAP-01's byte budget zero for \`training run\` — a pre-generated dataset is a read source, not a write destination, so the current free-space check is a false positive that blocks valid runs on filesystems provisioned to just fit the dataset.

## The bug

\`Benchmark.run()\` unconditionally calls \`_pre_execution_gate\`, which asks \`TrainingBenchmark.required_bytes_for_capacity_gate()\` for the byte budget and hands that to \`check_capacity_4field\`. The training override always returned the full \`calculate_training_data_size\` result — the same value \`datasize\` reports for provisioning a fresh dataset. On \`run\` this effectively required \"used-dataset + another full dataset\" of free space.

Repro from #627: 80 T total / 75 T used (dataset lives there) / 5.3 T free ⇒

\`\`\`
[E403] CAP-01: insufficient disk space at /mnt/pfs/
  available_bytes: 135912652800
  required_bytes:  50797117602000
  deficit:         50661204949200
\`\`\`

## The fix

Early-return \`0\` from \`TrainingBenchmark.required_bytes_for_capacity_gate\` when \`args.command == 'run'\`. \`check_capacity_4field\` then trivially passes (\`available_bytes >= 0\`).

Scope discipline:
- **Byte budget only** — CAP-02 shared-FS verification still fires from \`_pre_execution_gate\` on multi-host runs.
- **\`datagen\` and \`datasize\` unchanged** — they still compute and enforce the real byte budget (they *are* the write / planning paths).
- **Checkpointing unchanged** — its required-bytes math (\`num_checkpoints_write × per-rank state\` at \`dlio.py:982-1007\`) already models run-time writes, so the free-space check remains correct there.

## Guardrail-test tweak

The existing #575 regression guard \`test_deferral_message_keeps_rerun_suggestion_for_non_datagen_commands\` used \`command=\"run\"\` to exercise the lazy-collect deferral message. After this fix, \`run\` short-circuits before that branch, so the guardrail is redirected to \`command=\"datasize\"\` — same lazy-collect path, same #575 regression risk covered.

## Test plan

- [x] TDD RED: three new tests in \`TestTrainingBenchmarkRequiredBytes\` — one asserting \`run\` returns 0 without calling \`calculate_training_data_size\`, two scope guards locking \`datagen\` / \`datasize\` unchanged. RED test failed with \`50797117602000 != 0\` before the fix.
- [x] GREEN: all 48 tests in \`test_capacity_gate.py\` pass.
- [x] Full 4-suite sweep (via \`uv run pytest\`):
  - \`tests/\` — 2536 passed
  - \`mlpstorage_py/tests/\` — 811 passed
  - \`vdb_benchmark/tests/\` — 155 passed
  - \`kv_cache_benchmark/tests/\` — 238 passed (2 pre-existing \`@pytest.mark.slow\` deselections, unrelated)
- [ ] Live UAT deferred: needs a multi-host closed \`training run\` on a real pre-populated data-dir where \`f_bavail < calculate_training_data_size()\`. Repro from #627 (80T/75T-used PFS) is the natural fit.