### PR TITLE
fix(#629): allow storage.storage_options.prefetch_window on OPEN

### DIFF
--- a/mlpstorage_py/rules/run_checkers/training.py
+++ b/mlpstorage_py/rules/run_checkers/training.py
@@ -36,6 +36,11 @@ class TrainingRunRulesChecker(RunRulesChecker):
         'dataset.format',
         'dataset.num_samples_per_file',
         'reader.data_loader',
+        # Issue #629: s3dlio client-side prefetch depth for object-storage
+        # runs. Documented as a tunable in docs/RetinaNet_NP_Scaling_Results.md
+        # (default 256). Tunes I/O concurrency, not the workload spec —
+        # OPEN-only so closed submissions stay comparable.
+        'storage.storage_options.prefetch_window',
     ]
 
     # Parameters that the mlpstorage tool injects into the DLIO config without

--- a/tests/unit/test_rules_checkers.py
+++ b/tests/unit/test_rules_checkers.py
@@ -955,3 +955,72 @@ class TestTrainingParquetFormat:
             assert len(issues) == 1
             assert issues[0].validation == PARAM_VALIDATION.OPEN, \
                 f"dataset.format={format_value} should be OPEN category"
+
+
+class TestOpenStorageOptionsPrefetchWindowIssue629:
+    """Issue #629: `storage.storage_options.prefetch_window` is an s3dlio
+    client-side prefetch-depth knob (docs/RetinaNet_NP_Scaling_Results.md
+    documents it as a tunable, default 256). Tuning it changes I/O
+    concurrency, not the workload spec — so it belongs in OPEN's
+    allow-list. Before this fix it was absent from every allow-list and
+    was rejected as INVALID, aborting the reporter's OPEN run.
+    """
+
+    @pytest.fixture
+    def mock_logger(self):
+        return MagicMock()
+
+    def test_prefetch_window_override_is_open_category_issue_629(self, mock_logger):
+        """OPEN override of storage.storage_options.prefetch_window must
+        classify as OPEN, not INVALID.
+
+        Repro from issue #629:
+          mlpstorage open training unet3d run object \\
+            --params storage.storage_options.prefetch_window=8 ...
+          -> ERROR: INVALID: Disallowed parameter override:
+             storage.storage_options.prefetch_window = 8
+        """
+        data = BenchmarkRunData(
+            benchmark_type=BENCHMARK_TYPES.training,
+            model="unet3d",
+            command="run",
+            run_datetime="20260701_195014",
+            num_processes=1,
+            parameters={
+                "dataset": {"num_files_train": 28271},
+                "reader": {"read_threads": 1},
+            },
+            override_parameters={
+                "storage.storage_options.prefetch_window": 8,
+            },
+        )
+        run = BenchmarkRun.from_data(data, mock_logger)
+        checker = TrainingRunRulesChecker(run, logger=mock_logger)
+        issues = checker.check_allowed_params()
+
+        assert len(issues) == 1
+        assert issues[0].validation == PARAM_VALIDATION.OPEN, (
+            f"Issue #629: storage.storage_options.prefetch_window must be "
+            f"OPEN-allowed, got {issues[0].validation!r}. Message: "
+            f"{issues[0].message!r}"
+        )
+
+    def test_prefetch_window_in_open_allowed_params_issue_629(self):
+        """Set-membership assertion: locks the allow-list entry."""
+        assert (
+            'storage.storage_options.prefetch_window'
+            in TrainingRunRulesChecker.OPEN_ALLOWED_PARAMS
+        )
+
+    def test_prefetch_window_not_in_closed_allowed_params_issue_629(self):
+        """Scope guard: prefetch_window must NOT be CLOSED-allowed.
+
+        On CLOSED, all client tuning knobs affecting AU stay at their
+        defaults so submissions are comparable. Adding this to
+        CLOSED_ALLOWED_PARAMS would let closed submitters game AU by
+        cranking prefetch depth. This is an OPEN-only knob.
+        """
+        assert (
+            'storage.storage_options.prefetch_window'
+            not in TrainingRunRulesChecker.CLOSED_ALLOWED_PARAMS
+        )


### PR DESCRIPTION
## Summary

Fixes #629. Adds \`storage.storage_options.prefetch_window\` to \`TrainingRunRulesChecker.OPEN_ALLOWED_PARAMS\` so operators can tune s3dlio prefetch depth on \`mlpstorage open training ...\` object-storage runs without hitting \`INVALID\`.

## The bug

The classifier at \`mlpstorage_py/rules/run_checkers/training.py:144\` buckets every override into CLOSED / OPEN / INVALID from three fixed sets. \`storage.storage_options.prefetch_window\` was absent from all three, so it landed in the \`else\` at line 187 with:

\`\`\`
[INVALID] Disallowed parameter override:
  storage.storage_options.prefetch_window = 8
\`\`\`

\`INVALID\` short-circuits *before* the open/closed branch in \`Benchmark.verify_benchmark_parameters\` (\`base.py:928-937\`), so the \`open\` first positional does not unlock the parameter today — the run aborts unless \`--allow-invalid-params\` is set (which taints the run as INVALID in metadata).

## Why OPEN, not CLOSED

\`prefetch_window\` is an s3dlio client-side prefetch depth (docs/RetinaNet_NP_Scaling_Results.md documents it as a tunable, default 256). It tunes I/O concurrency, not the workload spec — analogous to \`reader.read_threads\` for filesystem runs, which is CLOSED-allowed because it is client-side.

CLOSED submissions must keep it at default so AU numbers stay comparable across submitters. Cranking prefetch depth would let a closed submitter game accelerator utilization. So \`CLOSED_ALLOWED_PARAMS\` is untouched.

## Test plan

- [x] TDD RED: three new tests in \`TestOpenStorageOptionsPrefetchWindowIssue629\` — one asserting the override classifies as OPEN, one set-membership lock, one scope guard preventing accidental CLOSED-allow. Two failed before the fix; the CLOSED scope guard was already green (locking that stays true through the fix).
- [x] GREEN: all three pass; no regression in the surrounding \`check_allowed_params\` suite.
- [x] Full 4-suite sweep (\`uv run pytest\`):
  - \`tests/\` — 2539 passed
  - \`mlpstorage_py/tests/\` — 811 passed
  - \`vdb_benchmark/tests/\` — 155 passed
  - \`kv_cache_benchmark/tests/\` — 238 passed (2 pre-existing \`@pytest.mark.slow\` deselections, unrelated)
- [ ] Live UAT deferred: needs an \`mlpstorage open training unet3d run object --params storage.storage_options.prefetch_window=8 ...\` run against a real s3dlio-backed endpoint — repro from #629 is the natural fit.

## Follow-up

Reporter's issue also hints at a broader question: should the entire \`storage.storage_options.*\` namespace be OPEN-allowed (endpoint config, buffer sizes, concurrency knobs)? Not addressed here — this PR is scoped to unblock the specific reported parameter. Worth a follow-up survey of what s3dlio exposes and where the CLOSED/OPEN line should sit for each knob.