### PR TITLE
fix(#628): CAP-02 verifies content, not st_ino; honor --skip-validation

### DIFF
--- a/mlpstorage_py/benchmarks/base.py
+++ b/mlpstorage_py/benchmarks/base.py
@@ -1030,16 +1030,30 @@ class Benchmark(BenchmarkInterface, abc.ABC):
         # once in __init__ and passed through to mpirun argv verbatim
         # (W-5 launcher pass-through contract). The destination reused
         # here is the same path CAP-01 just statvfs'd.
-        hosts = getattr(self.args, 'hosts', None) or []
-        run_shared_fs_probe(
-            destination=destination,
-            hosts=hosts,
-            run_uuid=self._run_uuid,
-            logger=self.logger,
-            mpi_bin=getattr(self.args, 'mpi_bin', None),
-            allow_run_as_root=getattr(self.args, 'allow_run_as_root', False),
-            ssh_username=getattr(self.args, 'ssh_username', None),
-        )
+        #
+        # Issue #628 escape hatch: --skip-validation bypasses CAP-02 so a
+        # submitter on a filesystem the probe cannot verify (e.g., a
+        # per-mount-inode FUSE mount that briefly lags on file-visibility)
+        # can proceed. CAP-01 stays armed regardless. Log a WARNING (not
+        # info) so the bypass shows up prominently in the run log.
+        if getattr(self.args, 'skip_validation', False):
+            self.logger.warning(
+                "CAP-02 shared-FS probe SKIPPED via --skip-validation. "
+                "The dataset destination has NOT been verified as accessible "
+                "from every participating host; multi-host runs may silently "
+                "produce invalid results if the path is not genuinely shared."
+            )
+        else:
+            hosts = getattr(self.args, 'hosts', None) or []
+            run_shared_fs_probe(
+                destination=destination,
+                hosts=hosts,
+                run_uuid=self._run_uuid,
+                logger=self.logger,
+                mpi_bin=getattr(self.args, 'mpi_bin', None),
+                allow_run_as_root=getattr(self.args, 'allow_run_as_root', False),
+                ssh_username=getattr(self.args, 'ssh_username', None),
+            )
         # ------------------------------------------------------------------
         # Slice 5 / CAP-03: FS-separation probe (issue #601).
         # ------------------------------------------------------------------

--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -2515,16 +2515,30 @@ if __name__ == '__main__':
 # Pattern B): different lifecycle stage (pre-execution gate vs. start-of-run
 # cluster snapshot) so the two scripts are NOT merged. The probe runs once
 # per benchmark instance from `_pre_execution_gate`, after the CAP-01
-# capacity check; rank 0 creates a per-run-uuid-suffixed sentinel file in the
-# dataset destination, every rank `os.stat`s it, the MPI gather collects
-# (st_dev, st_ino) tuples to rank 0, rank 0 enforces st_ino cardinality
-# exactly 1 (or fails fast with each hostname's reported tuple — st_dev is
-# still reported in the diagnostic since it can help operators triage
-# mismatched mounts, but it is NOT used in the equality check because
-# FUSE / distributed FS mount device ids legitimately differ per node),
-# unlinks in a finally
-# block, sleeps 5.0s for storage quiesce (D-49), and all ranks reach a final
-# MPI_Barrier so the measured workload starts simultaneously.
+# capacity check. Content-verify protocol (issue #628):
+#
+#   1. Rank 0 creates a per-run-uuid-suffixed sentinel in the dataset
+#      destination, writes 64 bytes (run_uuid prefix + urandom padding),
+#      fsyncs, and closes.
+#   2. Rank 0 sleeps 5.0s (visibility quiesce) so per-mount FUSE / overlay
+#      filesystems have time to propagate the new file to sibling mounts.
+#   3. A Barrier releases every rank to read the sentinel.
+#   4. Each rank reads the sentinel, computes sha256(bytes), and gathers
+#      {content_sha256, content_length} to rank 0.
+#   5. Rank 0's verdict: every rank must report content_sha256 equal to
+#      rank 0's expected hash AND content_length == 64. Any mismatch or
+#      short read fails the probe.
+#   6. Rank 0 unlinks the sentinel (D-44 cosmetic; warns, not raises),
+#      sleeps 5.0s (D-49 quiesce), and all ranks reach a final Barrier so
+#      the measured workload starts simultaneously.
+#
+# Previous protocols compared st_dev then st_ino across ranks (issues #566,
+# #628). Both are per-mount kernel implementation details that legitimately
+# differ across sibling mounts of the same shared namespace on FUSE / overlay
+# filesystems (s3fs, goofys, JuiceFS, DAOS DFuse, ...). Content-verify is
+# a strict superset of "shared filesystem": if every rank reads back rank
+# 0's exact bytes, the destination is genuinely shared regardless of how
+# each mount numbers inodes.
 #
 # References:
 #   - D-36 Pattern B: script-side helpers are inlined in untyped form (no
@@ -2537,10 +2551,13 @@ if __name__ == '__main__':
 #   - D-44: unlink failure in the finally block is a logger.warning, NOT a
 #     raise — leftover sentinels are cosmetic.
 #   - D-45: any per-rank failure (EACCES / ENOSPC / ENOENT / NFS-stale) or
-#     cardinality > 1 raises FileSystemError BEFORE the workload begins.
+#     content mismatch / short read raises FileSystemError BEFORE the
+#     workload begins.
 #   - D-49: rank 0 sleeps 5.0s INSIDE the finally block, BEFORE the final
 #     comm.Barrier(); the sleep is rank-0-only so non-rank-0 ranks don't
-#     block the whole fleet for 5s.
+#     block the whole fleet for 5s. Issue #628 adds a second rank-0
+#     5.0s sleep BEFORE the readback Barrier for FS visibility quiesce;
+#     both sleeps are rank-0-only.
 #   - Pitfall 4 / A5 (LOAD-BEARING): rank 0 broadcasts status='fail' via
 #     comm.bcast(status, root=0) BEFORE the final barrier when it is about
 #     to raise; non-rank-0 ranks read the broadcast and raise FileSystemError
@@ -2574,7 +2591,7 @@ if __name__ == '__main__':
 #   {
 #     "status": "ok" | "fail",
 #     "failure_summary": None | {
-#       "kind": "cardinality" | "per_rank",
+#       "kind": "content_mismatch" | "content_empty_or_short" | "per_rank",
 #       "message": str   # human-readable, used by the launcher verbatim;
 #                        # built from per-rank payloads in Step E so the
 #                        # detail survives without shipping the array.
@@ -2601,10 +2618,10 @@ generics, no `from typing import`). Runs once per benchmark instance from
 for the full argv / JSON / D-43 / D-44 / D-45 / D-49 / Pitfall 4 contract.
 """
 
+import hashlib
 import json
 import os
 import socket
-import stat as stat_mod
 import sys
 import time
 
@@ -2612,24 +2629,30 @@ import time
 _PER_HOST_LINE_CAP = 16  # Issue #573: sample-plus-summary cap so the
                          # wire JSON stays under PIPE_BUF at any scale.
 
+# Sentinel payload size: 32 bytes of run_uuid (hex) + 32 random bytes.
+# Rank 0 writes exactly this many bytes; every rank must read exactly this
+# many bytes for the shared-FS check to pass.
+_PAYLOAD_LEN = 64
 
-def _build_cardinality_message(payloads):
-    """Build the verbatim multi-line error body for a cardinality > 1 fault.
+
+def _build_content_mismatch_message(payloads, expected_sha, expected_len):
+    """Build the verbatim multi-line error body for a content-mismatch fault.
+
+    Issue #628: the probe now verifies that every rank reads back the same
+    bytes rank 0 wrote to the sentinel. A cross-host content mismatch means
+    the ranks are looking at different files (or the FS is not shared).
 
     Format (D-45 + REQUIREMENTS.md CAP-02):
 
       CAP-02: shared-FS probe detected the data-dir is NOT the same filesystem
       on every participating host.
-        host=<h1> rank=<r1> st_dev=<d1> st_ino=<i1>
-        host=<h2> rank=<r2> st_dev=<d2> st_ino=<i2>
+        host=<h1> rank=<r1> content_sha256=<s1> length=<n1> (expected|MISMATCH|MISSING)
+        host=<h2> rank=<r2> content_sha256=<s2> length=<n2> (...)
         ...
       This typically means one or more hosts have a local-disk path where a
       shared mount was expected.
 
-    Issue #573: per-host lines are capped at _PER_HOST_LINE_CAP. Above
-    the cap, a "... and N more ranks omitted" tail line tells the
-    operator the true scale of the failure without pushing the wire
-    JSON over PIPE_BUF.
+    Issue #573: per-host lines are capped at _PER_HOST_LINE_CAP.
     """
     lines = []
     lines.append(
@@ -2638,12 +2661,23 @@ def _build_cardinality_message(payloads):
     )
     shown = payloads[:_PER_HOST_LINE_CAP]
     for p in shown:
+        got_sha = p.get("content_sha256")
+        got_len = p.get("content_length")
+        if got_sha == expected_sha and got_len == expected_len:
+            tag = "expected"
+        elif got_sha is None or (got_len or 0) < expected_len:
+            tag = "MISSING"
+        else:
+            tag = "MISMATCH"
+        # Short-prefix the hash so the wire line stays compact.
+        short = (got_sha[:12] + "...") if got_sha else "None"
         lines.append(
-            "  host={h} rank={r} st_dev={d} st_ino={i}".format(
+            "  host={h} rank={r} content_sha256={s} length={n} ({t})".format(
                 h=p.get("hostname", "?"),
                 r=p.get("rank", "?"),
-                d=p.get("st_dev"),
-                i=p.get("st_ino"),
+                s=short,
+                n=got_len,
+                t=tag,
             )
         )
     omitted = len(payloads) - len(shown)
@@ -2748,22 +2782,42 @@ def main():
 
     # Per-rank failure tracker. None = healthy; dict = failure to report.
     failure = None
-    st_dev = None
-    st_ino = None
+    content_sha256 = None
+    content_length = None
     unlink_warning = None
     status = None  # rank 0 sets to 'ok' or 'fail'; non-rank-0 reads via bcast.
     rank0_failure_summary = None
+    expected_sha = None  # rank 0 only: sha256 of the bytes it wrote.
 
     try:
-        # ---- Step A: rank 0 atomically creates the sentinel (O_CREAT|O_EXCL).
+        # ---- Step A: rank 0 atomically creates the sentinel, writes a
+        # unique payload, and fsyncs before close. Content verification
+        # (issue #628) — the previous st_ino-based check falsely rejected
+        # per-mount-inode FUSE filesystems (s3fs, goofys, JuiceFS, ...) that
+        # number inodes per mount even when every rank stats the same
+        # shared file. The bytes rank 0 writes here are what every rank
+        # must read back in Step C for the check to pass.
         if rank == 0:
+            # run_uuid prefix + urandom padding, sliced to _PAYLOAD_LEN.
+            # The run_uuid already guarantees uniqueness per benchmark
+            # instance (Pitfall 7); the random bytes are defense in depth
+            # against a pathological filesystem returning zeros for
+            # O_EXCL-created files without an actual read. Pad with a full
+            # _PAYLOAD_LEN of urandom so the concatenation is always
+            # long enough to slice regardless of run_uuid length.
+            payload_bytes = (run_uuid.encode("ascii") + os.urandom(_PAYLOAD_LEN))[:_PAYLOAD_LEN]
+            expected_sha = hashlib.sha256(payload_bytes).hexdigest()
             try:
                 fd = os.open(
                     sentinel,
                     os.O_CREAT | os.O_EXCL | os.O_WRONLY,
                     0o644,
                 )
-                os.close(fd)
+                try:
+                    os.write(fd, payload_bytes)
+                    os.fsync(fd)
+                finally:
+                    os.close(fd)
             except OSError as e:
                 failure = {
                     "mode": "sentinel_create",
@@ -2772,18 +2826,30 @@ def main():
                     "message": str(e),
                 }
 
-        # ---- Step B: synchronize so non-rank-0 ranks don't stat too early.
+        # ---- Step A': rank-0 visibility quiesce (issue #628). Per-mount
+        # FUSE / overlay filesystems can lag briefly before a new file is
+        # visible to sibling mounts. Sleep BEFORE the readback barrier so
+        # non-rank-0 ranks aren't released until the write has had time to
+        # propagate. rank-0-only so non-rank-0 ranks don't idle for 5s.
+        if rank == 0:
+            time.sleep(5.0)
+
+        # ---- Step B: synchronize so non-rank-0 ranks don't read too early.
         comm.Barrier()
 
-        # ---- Step C: every rank stats the sentinel; report per-rank failure.
+        # ---- Step C: every rank reads the sentinel and hashes its content.
+        # A short read (< _PAYLOAD_LEN) or ENOENT means the FS didn't
+        # propagate rank 0's write; a mismatched hash means the rank is
+        # reading a different file.
         if failure is None:
             try:
-                st = os.stat(sentinel)
-                st_dev = st.st_dev
-                st_ino = st.st_ino
+                with open(sentinel, "rb") as _fh:
+                    data = _fh.read(_PAYLOAD_LEN + 1)
+                content_length = len(data)
+                content_sha256 = hashlib.sha256(data).hexdigest() if data else None
             except OSError as e:
                 failure = {
-                    "mode": "sentinel_stat",
+                    "mode": "sentinel_read",
                     "host": socket.gethostname(),
                     "errno": e.errno,
                     "message": str(e),
@@ -2794,12 +2860,17 @@ def main():
             "hostname": socket.gethostname(),
             "rank": rank,
             "failure": failure,
-            "st_dev": st_dev,
-            "st_ino": st_ino,
+            "content_sha256": content_sha256,
+            "content_length": content_length,
         }
         all_payloads = comm.gather(local_payload, root=0)
 
-        # ---- Step E: rank 0 analyzes the gather.
+        # ---- Step E: rank 0 analyzes the gather. Content-based verdict
+        # (issue #628): every rank's sha256 must equal rank 0's expected
+        # sha256, and every rank's read length must equal _PAYLOAD_LEN.
+        # Distinguish "content_empty_or_short" (readback failed / FS
+        # visibility didn't propagate) from "content_mismatch" (rank is
+        # reading a different file).
         if rank == 0:
             any_failure = any(p.get("failure") is not None for p in all_payloads)
             if any_failure:
@@ -2809,22 +2880,26 @@ def main():
                     "message": _build_per_rank_message(all_payloads),
                 }
             else:
-                # NOTE: st_dev is intentionally excluded. It is the kernel's
-                # per-mount device id, assigned per-node, and legitimately
-                # differs across hosts on FUSE / distributed filesystems
-                # (DAOS DFuse, NFS, Lustre, GPFS, BeeGFS, ...) even when
-                # every rank stats the same shared sentinel. st_ino is the
-                # cross-host identity signal: if all ranks see the same
-                # inode for rank 0's unique sentinel, the data-dir is
-                # genuinely shared. See issue #566.
-                ids = set()
-                for p in all_payloads:
-                    ids.add(p.get("st_ino"))
-                if len(ids) != 1:
+                bad = [
+                    p for p in all_payloads
+                    if p.get("content_sha256") != expected_sha
+                    or p.get("content_length") != _PAYLOAD_LEN
+                ]
+                if bad:
+                    # If every bad rank is short/empty, it's a visibility
+                    # failure. Otherwise at least one rank read a different
+                    # file — call it a mismatch.
+                    all_short = all(
+                        (p.get("content_length") or 0) < _PAYLOAD_LEN
+                        for p in bad
+                    )
+                    kind = "content_empty_or_short" if all_short else "content_mismatch"
                     status = "fail"
                     rank0_failure_summary = {
-                        "kind": "cardinality",
-                        "message": _build_cardinality_message(all_payloads),
+                        "kind": kind,
+                        "message": _build_content_mismatch_message(
+                            all_payloads, expected_sha, _PAYLOAD_LEN,
+                        ),
                     }
                 else:
                     status = "ok"

--- a/tests/unit/test_cluster_collector.py
+++ b/tests/unit/test_cluster_collector.py
@@ -3665,27 +3665,30 @@ class TestStageScriptPreservesBasename:
         )
 
 
-class TestSharedFsProbeIgnoresStDevAcrossHosts:
-    """Regression for issue #566: the CAP-02 probe must NOT include st_dev
-    in the cross-host identity check.
+class TestSharedFsProbeSucceedsOnMatchingContent:
+    """Regression for issues #566 and #628: the CAP-02 probe must NOT reject
+    a run because st_dev or st_ino differ across nodes.
 
-    st_dev is the kernel's per-mount device id. On FUSE / distributed
-    filesystems (DAOS DFuse, NFS, Lustre, GPFS, BeeGFS, ...) the same
-    shared mount gets a different st_dev on every node because each node
-    runs its own mount instance. st_ino IS identical cluster-wide because
-    it is derived from the underlying object/inode identity.
+    History:
+      #566 — the old probe compared (st_dev, st_ino) tuples; on FUSE /
+        distributed filesystems (DAOS DFuse, NFS, Lustre, GPFS, BeeGFS)
+        st_dev legitimately differs per node. The #566 fix dropped st_dev
+        from the check and compared st_ino only.
+      #628 — st_ino equality is still not a valid universal shared-FS test.
+        Per-mount-inode FUSE filesystems (s3fs, goofys, JuiceFS, many
+        object-storage gateways) assign inodes per-mount even when the
+        underlying namespace is shared. The current probe verifies content
+        instead: rank 0 writes a 64-byte payload, every rank reads it back
+        and reports content_sha256. Only the bytes matter — st_dev and
+        st_ino are no longer collected or checked.
 
-    Pre-fix behavior (the bug): rank 0 gathered (st_dev, st_ino) tuples
-    from every rank and rejected the run unless all tuples were identical,
-    which made CAP-02 unsatisfiable on FUSE — blocking every multi-host
-    DAOS / NFS / Lustre run.
-
-    Post-fix behavior (locked by this test): rank 0 must succeed (status
-    "ok", no failure_summary) when every rank reports the same st_ino,
-    even with mismatched st_dev values.
+    Post-fix behavior (locked by this test): with a fake mpi4py that
+    gathers rank 0's own payload into every slot (i.e., every rank read
+    the same bytes), the probe emits status='ok' regardless of any
+    st_dev/st_ino values that might appear in a real deployment.
     """
 
-    def test_same_st_ino_different_st_dev_succeeds(self, tmp_path, monkeypatch):
+    def test_matching_content_across_ranks_succeeds(self, tmp_path, monkeypatch):
         import contextlib
         import io
         import json
@@ -3693,18 +3696,16 @@ class TestSharedFsProbeIgnoresStDevAcrossHosts:
         import sys
         from unittest.mock import MagicMock
 
-        # Build the exact bad-tuple-good-inode shape from the issue:
-        #   host=R2-06 rank=0 st_dev=46 st_ino=281482956119445
-        #   host=R2-05 rank=1 st_dev=47 st_ino=281482956119445  (different st_dev)
+        # Gather returns [rank_0_payload, rank_0_payload] — simulating a
+        # genuinely shared FS where every rank reads back the same bytes
+        # rank 0 wrote. Under a per-mount-inode FUSE mount the underlying
+        # st_ino values would differ, but the probe no longer looks at
+        # them (issue #628). Only content_sha256/content_length are
+        # consulted, and they match by construction.
         fake_comm = MagicMock()
         fake_comm.Get_rank.return_value = 0
         fake_comm.Get_size.return_value = 2
-        fake_comm.gather.return_value = [
-            {"hostname": "R2-06", "rank": 0, "failure": None,
-             "st_dev": 46, "st_ino": 281482956119445},
-            {"hostname": "R2-05", "rank": 1, "failure": None,
-             "st_dev": 47, "st_ino": 281482956119445},
-        ]
+        fake_comm.gather.side_effect = lambda payload, root=0: [payload, payload]
         fake_comm.bcast.side_effect = lambda v, root=0: v
         fake_comm.Barrier.return_value = None
 
@@ -3717,7 +3718,7 @@ class TestSharedFsProbeIgnoresStDevAcrossHosts:
 
         monkeypatch.setattr(
             sys, "argv",
-            ["probe", str(tmp_path), "fuse-st-dev-mismatch-uuid"],
+            ["probe", str(tmp_path), "content-verify-shared-fs-uuid"],
         )
 
         import time as _time
@@ -3746,8 +3747,8 @@ class TestSharedFsProbeIgnoresStDevAcrossHosts:
         payload = json.loads(m.group(1).strip())
 
         assert payload["status"] == "ok", (
-            "Issue #566: same st_ino with different st_dev must be treated as "
-            "shared FS (FUSE / DAOS / NFS / Lustre all assign st_dev per-node). "
+            "Every rank read back rank 0's bytes → shared FS. Any status "
+            "other than 'ok' means the content-verify check regressed. "
             f"Got payload: {payload!r}"
         )
         assert payload["failure_summary"] is None, (

--- a/tests/unit/test_shared_fs_probe.py
+++ b/tests/unit/test_shared_fs_probe.py
@@ -855,3 +855,557 @@ class TestLauncherFlags:
         assert "--map-by node" in cmd
         assert "--tag-output" in cmd
         assert "--ppn" not in cmd
+
+
+# =============================================================================
+# TestContentVerify — Issue #628 regression tests
+#
+# Contract change: the probe used to compare st_ino across ranks. That is
+# not a valid universal "shared FS" test — per-mount-inode FUSE filesystems
+# (s3fs, goofys, JuiceFS, many object-storage gateways) legitimately number
+# inodes per mount even when every rank is looking at the same shared file.
+# The new probe writes a 64-byte payload (run_uuid + urandom) on rank 0,
+# fsyncs, sleeps 5s for FS-visibility, then every rank reads back and reports
+# a SHA-256 of what it saw. If every rank's hash matches rank 0's expected
+# hash, the destination is genuinely shared.
+# =============================================================================
+
+
+class TestContentVerify:
+    """Issue #628: probe verifies content bytes, not st_ino."""
+
+    def test_probe_writes_payload_to_sentinel(self):
+        """Rank 0 must os.write() the payload — a zero-byte sentinel cannot
+        prove content accessibility across ranks."""
+        src = SHARED_FS_PROBE_SCRIPT
+        assert "os.write(fd" in src, (
+            "probe must write a payload to the sentinel; zero-byte sentinel "
+            "cannot verify content accessibility (issue #628)"
+        )
+
+    def test_probe_fsyncs_before_close(self):
+        """fsync before close so the payload is durable before FS-visibility
+        quiesce and the readback barrier."""
+        src = SHARED_FS_PROBE_SCRIPT
+        assert "os.fsync(fd)" in src, (
+            "probe must fsync the sentinel before close to survive the "
+            "visibility quiesce and reach every reader"
+        )
+
+    def test_probe_hashes_content_with_sha256(self):
+        """Fingerprint the readback with sha256 — full bytes over the wire
+        would push the gather past PIPE_BUF at high rank counts (#573)."""
+        src = SHARED_FS_PROBE_SCRIPT
+        assert "hashlib.sha256" in src
+
+    def test_gather_payload_has_content_fields_not_st_ino(self):
+        """Wire payload advertises content_sha256 + content_length; st_ino
+        (the old, per-mount-inode-broken signal) is no longer used in the
+        equality check."""
+        src = SHARED_FS_PROBE_SCRIPT
+        assert '"content_sha256"' in src
+        assert '"content_length"' in src
+
+    def test_rank0_visibility_sleep_between_close_and_readback(self):
+        """A visibility sleep is needed BETWEEN rank 0's sentinel close and
+        the readback Barrier, in addition to the pre-existing D-49 sleep
+        before the final Barrier. Detect the two-sleep contract via count."""
+        src = SHARED_FS_PROBE_SCRIPT
+        occurrences = src.count("time.sleep(5.0)")
+        assert occurrences >= 2, (
+            "expected at least TWO time.sleep(5.0) calls in the probe: one "
+            "for per-mount FS-visibility quiesce between rank-0 write-close "
+            "and the readback Barrier (issue #628), plus the pre-existing "
+            "D-49 quiesce before the final Barrier. Found {0}.".format(occurrences)
+        )
+
+    # ---- In-process execution of the heredoc against a fake mpi4py ---------
+    #
+    # These tests exercise the actual probe body under three scenarios:
+    #   1. every rank reads the same content → status='ok'
+    #   2. one rank reads mismatched content → status='fail' kind='content_mismatch'
+    #   3. one rank reads short/empty content → status='fail' kind='content_empty_or_short'
+
+    def _exec_probe(self, tmp_path, gather_return, *, capture_stdout=True):
+        """Exec the probe heredoc against a mocked mpi4py.
+
+        Rank 0 is the process running this test. The fake COMM_WORLD gathers
+        `gather_return` (already-crafted per-rank payload dicts) to rank 0
+        and passes bcast through verbatim. Returns the rank-0 JSON payload
+        parsed from the marker-framed stdout.
+        """
+        import io
+        from contextlib import redirect_stdout
+
+        class _FakeComm:
+            def Get_rank(self_inner):
+                return 0
+
+            def Get_size(self_inner):
+                return len(gather_return)
+
+            def Barrier(self_inner):
+                return None
+
+            def gather(self_inner, payload, root=0):
+                # Splice rank 0's real payload into the gather so the probe
+                # verifies its own hash against itself.
+                merged = list(gather_return)
+                merged[0] = payload
+                return merged
+
+            def bcast(self_inner, status, root=0):
+                return status
+
+        class _FakeMPI:
+            COMM_WORLD = _FakeComm()
+
+        fake_mpi4py = MagicMock()
+        fake_mpi4py.MPI = _FakeMPI()
+
+        saved_argv = sys.argv
+        saved_mpi4py = sys.modules.get("mpi4py")
+        saved_mpi = sys.modules.get("mpi4py.MPI")
+        import time as _time
+        saved_sleep = _time.sleep
+        try:
+            sys.modules["mpi4py"] = fake_mpi4py
+            sys.modules["mpi4py.MPI"] = _FakeMPI()
+            _time.sleep = lambda *_a, **_kw: None
+            sys.argv = ["<probe>", str(tmp_path), "test-uuid-content-verify"]
+            namespace = {"__name__": "__main__"}
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                with pytest.raises(SystemExit):
+                    exec(SHARED_FS_PROBE_SCRIPT, namespace)
+            out = buf.getvalue()
+        finally:
+            _time.sleep = saved_sleep
+            sys.argv = saved_argv
+            if saved_mpi4py is not None:
+                sys.modules["mpi4py"] = saved_mpi4py
+            else:
+                sys.modules.pop("mpi4py", None)
+            if saved_mpi is not None:
+                sys.modules["mpi4py.MPI"] = saved_mpi
+            else:
+                sys.modules.pop("mpi4py.MPI", None)
+
+        # Parse the rank-0 JSON between markers.
+        import re as _re
+        m = _re.search(
+            r"__CAP02_RESULT_BEGIN__\s*\n(?P<p>.*?)\n__CAP02_RESULT_END__",
+            out, _re.DOTALL,
+        )
+        assert m is not None, (
+            "probe did not emit marker-framed JSON on stdout; got:\n" + out
+        )
+        return json.loads(m.group("p"))
+
+    def _matching_payload_for_rank(self, hostname, rank, expected_sha):
+        return {
+            "hostname": hostname,
+            "rank": rank,
+            "failure": None,
+            "content_sha256": expected_sha,
+            "content_length": 64,
+        }
+
+    def _mismatched_payload_for_rank(self, hostname, rank):
+        return {
+            "hostname": hostname,
+            "rank": rank,
+            "failure": None,
+            # Different bytes than rank 0's payload → different hash.
+            "content_sha256": "deadbeef" * 8,
+            "content_length": 64,
+        }
+
+    def _short_payload_for_rank(self, hostname, rank):
+        return {
+            "hostname": hostname,
+            "rank": rank,
+            "failure": None,
+            "content_sha256": None,
+            "content_length": 0,
+        }
+
+    def test_matching_content_across_ranks_yields_ok(self, tmp_path):
+        """Every rank read the same 64-byte payload → status='ok'."""
+        # Rank 0 payload is spliced in by _exec_probe.gather; here we craft
+        # the OTHER ranks with rank 0's expected sha (which the probe
+        # computed from run_uuid + urandom).
+        # The probe writes run_uuid.encode() + os.urandom(32); test-uuid is
+        # short so we know rank 0's payload deterministically only up to its
+        # own read. Just use "same hash as whatever rank 0 read" — which is
+        # done by splicing rank 0's real gather.
+        # For non-rank-0 payloads we don't know the hash a priori; simulate
+        # by first executing with a placeholder and letting the probe verify
+        # against itself. Simpler: run once with two ranks, both slots filled
+        # with the rank-0 sentinel — the splice puts rank 0's real read into
+        # slot 0, and slot 1 we set to match rank 0's real read as well.
+        # Trick: pre-read rank 0's sentinel after exec by looking at what
+        # the payload gathered. Instead, use a two-pass gather where slot 1
+        # is a placeholder and the fake comm.gather replaces BOTH with rank 0.
+        class _AllRankZeroGather:
+            """Every gathered slot is the rank-0 payload itself."""
+            def __call__(self, payload, root=0):
+                return [payload, payload]
+
+        # Build a FakeComm that gathers rank 0's real payload into every slot.
+        import io
+        from contextlib import redirect_stdout
+
+        class _FakeComm:
+            def Get_rank(self_inner):
+                return 0
+
+            def Get_size(self_inner):
+                return 2
+
+            def Barrier(self_inner):
+                return None
+
+            def gather(self_inner, payload, root=0):
+                return [payload, payload]
+
+            def bcast(self_inner, status, root=0):
+                return status
+
+        class _FakeMPI:
+            COMM_WORLD = _FakeComm()
+
+        fake_mpi4py = MagicMock()
+        fake_mpi4py.MPI = _FakeMPI()
+
+        saved_argv = sys.argv
+        saved_mpi4py = sys.modules.get("mpi4py")
+        saved_mpi = sys.modules.get("mpi4py.MPI")
+        import time as _time
+        saved_sleep = _time.sleep
+        try:
+            sys.modules["mpi4py"] = fake_mpi4py
+            sys.modules["mpi4py.MPI"] = _FakeMPI()
+            _time.sleep = lambda *_a, **_kw: None
+            sys.argv = ["<probe>", str(tmp_path), "test-uuid-content-verify-ok"]
+            namespace = {"__name__": "__main__"}
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                with pytest.raises(SystemExit):
+                    exec(SHARED_FS_PROBE_SCRIPT, namespace)
+            out = buf.getvalue()
+        finally:
+            _time.sleep = saved_sleep
+            sys.argv = saved_argv
+            if saved_mpi4py is not None:
+                sys.modules["mpi4py"] = saved_mpi4py
+            else:
+                sys.modules.pop("mpi4py", None)
+            if saved_mpi is not None:
+                sys.modules["mpi4py.MPI"] = saved_mpi
+            else:
+                sys.modules.pop("mpi4py.MPI", None)
+
+        import re as _re
+        m = _re.search(
+            r"__CAP02_RESULT_BEGIN__\s*\n(?P<p>.*?)\n__CAP02_RESULT_END__",
+            out, _re.DOTALL,
+        )
+        assert m is not None, "no marker-framed JSON in stdout"
+        result = json.loads(m.group("p"))
+        assert result.get("status") == "ok", (
+            "matching content across all ranks must yield status='ok'; got: "
+            + repr(result)
+        )
+
+    def test_mismatched_content_yields_content_mismatch_fail(self, tmp_path):
+        """One rank reports a different content hash → kind='content_mismatch'."""
+        import io
+        from contextlib import redirect_stdout
+
+        class _FakeComm:
+            def Get_rank(self_inner):
+                return 0
+
+            def Get_size(self_inner):
+                return 2
+
+            def Barrier(self_inner):
+                return None
+
+            def gather(self_inner, payload, root=0):
+                # Slot 0: rank 0's real read (matches the file it just wrote).
+                # Slot 1: a fake reader that saw different bytes.
+                return [
+                    payload,
+                    {
+                        "hostname": "h2",
+                        "rank": 1,
+                        "failure": None,
+                        "content_sha256": "deadbeef" * 8,
+                        "content_length": 64,
+                    },
+                ]
+
+            def bcast(self_inner, status, root=0):
+                return status
+
+        class _FakeMPI:
+            COMM_WORLD = _FakeComm()
+
+        fake_mpi4py = MagicMock()
+        fake_mpi4py.MPI = _FakeMPI()
+
+        saved_argv = sys.argv
+        saved_mpi4py = sys.modules.get("mpi4py")
+        saved_mpi = sys.modules.get("mpi4py.MPI")
+        import time as _time
+        saved_sleep = _time.sleep
+        try:
+            sys.modules["mpi4py"] = fake_mpi4py
+            sys.modules["mpi4py.MPI"] = _FakeMPI()
+            _time.sleep = lambda *_a, **_kw: None
+            sys.argv = ["<probe>", str(tmp_path), "test-uuid-content-verify-mm"]
+            namespace = {"__name__": "__main__"}
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                with pytest.raises(SystemExit):
+                    exec(SHARED_FS_PROBE_SCRIPT, namespace)
+            out = buf.getvalue()
+        finally:
+            _time.sleep = saved_sleep
+            sys.argv = saved_argv
+            if saved_mpi4py is not None:
+                sys.modules["mpi4py"] = saved_mpi4py
+            else:
+                sys.modules.pop("mpi4py", None)
+            if saved_mpi is not None:
+                sys.modules["mpi4py.MPI"] = saved_mpi
+            else:
+                sys.modules.pop("mpi4py.MPI", None)
+
+        import re as _re
+        m = _re.search(
+            r"__CAP02_RESULT_BEGIN__\s*\n(?P<p>.*?)\n__CAP02_RESULT_END__",
+            out, _re.DOTALL,
+        )
+        assert m is not None, "no marker-framed JSON in stdout"
+        result = json.loads(m.group("p"))
+        assert result.get("status") == "fail"
+        assert result["failure_summary"]["kind"] == "content_mismatch", (
+            "mismatched content-sha across ranks must yield "
+            "kind='content_mismatch'; got: " + repr(result["failure_summary"])
+        )
+
+    def test_short_content_yields_content_empty_or_short_fail(self, tmp_path):
+        """One rank reports content_length < payload → kind='content_empty_or_short'."""
+        import io
+        from contextlib import redirect_stdout
+
+        class _FakeComm:
+            def Get_rank(self_inner):
+                return 0
+
+            def Get_size(self_inner):
+                return 2
+
+            def Barrier(self_inner):
+                return None
+
+            def gather(self_inner, payload, root=0):
+                return [
+                    payload,
+                    {
+                        "hostname": "h2",
+                        "rank": 1,
+                        "failure": None,
+                        "content_sha256": None,
+                        "content_length": 0,
+                    },
+                ]
+
+            def bcast(self_inner, status, root=0):
+                return status
+
+        class _FakeMPI:
+            COMM_WORLD = _FakeComm()
+
+        fake_mpi4py = MagicMock()
+        fake_mpi4py.MPI = _FakeMPI()
+
+        saved_argv = sys.argv
+        saved_mpi4py = sys.modules.get("mpi4py")
+        saved_mpi = sys.modules.get("mpi4py.MPI")
+        import time as _time
+        saved_sleep = _time.sleep
+        try:
+            sys.modules["mpi4py"] = fake_mpi4py
+            sys.modules["mpi4py.MPI"] = _FakeMPI()
+            _time.sleep = lambda *_a, **_kw: None
+            sys.argv = ["<probe>", str(tmp_path), "test-uuid-content-verify-empty"]
+            namespace = {"__name__": "__main__"}
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                with pytest.raises(SystemExit):
+                    exec(SHARED_FS_PROBE_SCRIPT, namespace)
+            out = buf.getvalue()
+        finally:
+            _time.sleep = saved_sleep
+            sys.argv = saved_argv
+            if saved_mpi4py is not None:
+                sys.modules["mpi4py"] = saved_mpi4py
+            else:
+                sys.modules.pop("mpi4py", None)
+            if saved_mpi is not None:
+                sys.modules["mpi4py.MPI"] = saved_mpi
+            else:
+                sys.modules.pop("mpi4py.MPI", None)
+
+        import re as _re
+        m = _re.search(
+            r"__CAP02_RESULT_BEGIN__\s*\n(?P<p>.*?)\n__CAP02_RESULT_END__",
+            out, _re.DOTALL,
+        )
+        assert m is not None, "no marker-framed JSON in stdout"
+        result = json.loads(m.group("p"))
+        assert result.get("status") == "fail"
+        assert result["failure_summary"]["kind"] == "content_empty_or_short", (
+            "empty/short readback must yield kind='content_empty_or_short'; "
+            "got: " + repr(result["failure_summary"])
+        )
+
+    def test_launcher_raises_on_content_mismatch_summary(self, tmp_path):
+        """Wire-level: kind='content_mismatch' → FileSystemError with content
+        fingerprints in the message."""
+        logger = MagicMock()
+        payload = {
+            "status": "fail",
+            "failure_summary": {
+                "kind": "content_mismatch",
+                "message": (
+                    "CAP-02: shared-FS probe detected the data-dir is NOT "
+                    "the same filesystem on every participating host.\n"
+                    "  host=h1 rank=0 content_sha256=abcd1234... length=64 (expected)\n"
+                    "  host=h2 rank=1 content_sha256=deadbeef... length=64 (MISMATCH)\n"
+                    "this typically means one or more hosts have a "
+                    "local-disk path where a shared mount was expected."
+                ),
+            },
+            "unlink_warning": None,
+        }
+        with patch(
+            "mlpstorage_py.cluster_collector.subprocess.run",
+            side_effect=_mock_subprocess_writes(payload, returncode=1),
+        ), patch(
+            "mlpstorage_py.cluster_collector.MPIClusterCollector"
+        ) as mock_coll_cls:
+            mock_coll_cls.return_value._stage_script_on_remote_hosts.return_value = {
+                "h1": None, "h2": None
+            }
+            with pytest.raises(FileSystemError) as exc_info:
+                run_shared_fs_probe(
+                    destination=str(tmp_path),
+                    hosts=["h1", "h2"],
+                    run_uuid="test-uuid",
+                    logger=logger,
+                )
+        msg = str(exc_info.value)
+        assert "content_sha256=" in msg
+        assert "MISMATCH" in msg
+        assert exc_info.value.code == ErrorCode.FS_INVALID_STRUCTURE
+
+
+# =============================================================================
+# TestSkipValidationBypassesCap02 — issue #628 escape hatch
+#
+# Submitters on per-mount-inode FUSE filesystems can bypass the CAP-02 probe
+# with --skip-validation. The bypass is deliberately awkward (a CLI flag) so
+# the choice is visible in the operator's command line and the run log.
+# CAP-01 (capacity gate) remains armed either way — skip-validation only
+# affects CAP-02.
+# =============================================================================
+
+
+class TestSkipValidationBypassesCap02:
+    """--skip-validation must skip run_shared_fs_probe but keep CAP-01."""
+
+    def _make_bench(self, tmp_path, *, skip_validation):
+        """Minimal Benchmark shim exposing just _pre_execution_gate.
+
+        The gate reads self.args, self.logger, self._capacity_gate_destination,
+        self.required_bytes_for_capacity_gate, and self._run_uuid — build
+        that surface directly rather than instantiating a concrete subclass
+        (which would pull in DLIO/psutil and a full CLI parse).
+        """
+        from mlpstorage_py.benchmarks.base import Benchmark
+
+        # Concrete _run stub to satisfy the ABC check without triggering
+        # subclass __init__ chains.
+        class _StubBench(Benchmark):
+            def _run(self):
+                return 0
+
+        bench = _StubBench.__new__(_StubBench)
+        bench.logger = MagicMock()
+        bench.args = SimpleNamespace(
+            hosts=["h1", "h2"],
+            skip_validation=skip_validation,
+            mpi_bin=None,
+            allow_run_as_root=False,
+            ssh_username=None,
+        )
+        bench._capacity_gate_destination = lambda: str(tmp_path)
+        bench.required_bytes_for_capacity_gate = lambda: 1
+        bench._run_uuid = "test-uuid"
+        return bench
+
+    def test_skip_validation_true_skips_cap02(self, tmp_path):
+        """--skip-validation set → run_shared_fs_probe NOT called."""
+        bench = self._make_bench(tmp_path, skip_validation=True)
+        with patch(
+            "mlpstorage_py.benchmarks.base.check_capacity_4field"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
+        ) as mock_probe:
+            bench._pre_execution_gate()
+        mock_probe.assert_not_called()
+
+    def test_skip_validation_true_still_runs_cap01(self, tmp_path):
+        """--skip-validation must NOT skip CAP-01 — capacity gate stays armed."""
+        bench = self._make_bench(tmp_path, skip_validation=True)
+        with patch(
+            "mlpstorage_py.benchmarks.base.check_capacity_4field"
+        ) as mock_cap01, patch(
+            "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
+        ):
+            bench._pre_execution_gate()
+        mock_cap01.assert_called_once()
+
+    def test_skip_validation_false_calls_cap02(self, tmp_path):
+        """Default: --skip-validation absent → probe fires normally."""
+        bench = self._make_bench(tmp_path, skip_validation=False)
+        with patch(
+            "mlpstorage_py.benchmarks.base.check_capacity_4field"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
+        ) as mock_probe:
+            bench._pre_execution_gate()
+        mock_probe.assert_called_once()
+
+    def test_skip_validation_logs_warning(self, tmp_path):
+        """Bypass must be visible: emit a WARNING (not info) with 'CAP-02'
+        and 'skip-validation' in the message so it stands out in the log."""
+        bench = self._make_bench(tmp_path, skip_validation=True)
+        with patch(
+            "mlpstorage_py.benchmarks.base.check_capacity_4field"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
+        ):
+            bench._pre_execution_gate()
+        assert bench.logger.warning.called, (
+            "bypassing CAP-02 must log a warning so the operator sees they "
+            "used the escape hatch"
+        )
+        msg = str(bench.logger.warning.call_args)
+        assert "CAP-02" in msg
+        assert "skip" in msg.lower()

--- a/tests/unit/test_shared_fs_probe.py
+++ b/tests/unit/test_shared_fs_probe.py
@@ -1357,6 +1357,10 @@ class TestSkipValidationBypassesCap02:
         bench._capacity_gate_destination = lambda: str(tmp_path)
         bench.required_bytes_for_capacity_gate = lambda: 1
         bench._run_uuid = "test-uuid"
+        # CAP-03 (issue #601) also fires from _pre_execution_gate. These
+        # tests target CAP-02 only; return None from _fs_separation_paths
+        # to take the A8 skip branch (no local FS to probe).
+        bench._fs_separation_paths = lambda: None
         return bench
 
     def test_skip_validation_true_skips_cap02(self, tmp_path):


### PR DESCRIPTION
Fixes #628.

## Summary
- CAP-02 shared-FS probe now writes 64 bytes on rank 0 and verifies every rank reads back the exact bytes, instead of comparing `st_ino` (which per-mount-inode FUSE filesystems — s3fs, goofys, JuiceFS, many object-storage gateways — legitimately assign per mount).
- Rank 0 sleeps 5s between sentinel close and the readback Barrier so FUSE/overlay caches have time to propagate the new file to sibling mounts.
- `--skip-validation` now bypasses CAP-02 (deliberately awkward escape hatch for filesystems the probe cannot verify). CAP-01 capacity gate stays armed regardless. The bypass emits a WARNING so it's visible in both the CLI and the run log.

## Why content-verify, not another `st_*` field
Per-mount FUSE / overlay filesystems legitimately number both `st_dev` (fix in #566) AND `st_ino` (this issue) per-mount even when the underlying namespace is fully shared. `st_ino` equality is not a valid universal test — the reporter observed `st_ino=8` on one client and `st_ino=5` on others for the same pre-existing file. Rules.md §3.3.5 asks for **content accessibility**, not inode identity. Content-verify is a strict superset: if every rank reads back rank 0's exact bytes, the destination is genuinely shared regardless of how each mount numbers inodes.

## Protocol
1. Rank 0 writes `run_uuid.encode() + os.urandom(...)` (64 bytes total) with `fsync`.
2. Rank 0 sleeps 5.0s (visibility quiesce).
3. Barrier releases every rank; each reads and reports `{content_sha256, content_length}` via `comm.gather`.
4. Rank 0 verdict:
   - all match, length == 64 → `status='ok'`
   - any hash mismatch → `kind='content_mismatch'`
   - any short/empty read → `kind='content_empty_or_short'`
5. Fingerprints (not raw bytes) travel on the wire, so the PIPE_BUF cap from #573 continues to hold at high rank counts.

## `--skip-validation` escape hatch
Wrapped only the CAP-02 block in `_pre_execution_gate`. CAP-01 (capacity) and CAP-03 (fs-separation, #601) are unaffected. The bypass logs at WARNING (not INFO) with `CAP-02` + `skip-validation` in the message so the operator's choice is obvious in the run log.

## Test plan
- [x] `uv run pytest tests` — 2543 passed
- [x] `uv run pytest mlpstorage_py/tests` — 811 passed
- [x] `uv run pytest vdb_benchmark/tests` — 144 passed
- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed
- [x] All 4 CI suites (3736 total) pass in parallel
- [x] RED-first: 9 tests in `TestContentVerify` + `TestSkipValidationBypassesCap02` fail on the pre-fix codebase, pass after
- [ ] Manual run on a per-mount-inode FUSE mount (e.g., a JuiceFS or s3fs deployment) to confirm the probe now accepts what it previously rejected

## Follow-up notes
- The launcher (`run_shared_fs_probe`) is agnostic to `failure_summary.kind` — it just uses `failure_summary.message` verbatim. Pre-existing wire-level tests that mock `kind='cardinality'` still pass; those labels are stale but inert.
- Test class `TestSharedFsProbeIgnoresStDevAcrossHosts` (from #566) is renamed to `TestSharedFsProbeSucceedsOnMatchingContent` and rewritten to splice rank 0's real payload into the gather. Same intent (shared FS succeeds regardless of per-mount kernel identifiers), new mechanism.