### PR TITLE
fix(#637): lowercase DriveInterface enum values (sata, sas)

### DIFF
--- a/mlpstorage_py/system_description/schema.yaml
+++ b/mlpstorage_py/system_description/schema.yaml
@@ -98,7 +98,7 @@ drive_instance:
     unit_count:                 int( min=1 )        # Number of drives that look like this
     vendor_name:                str( min=1 )        # The name of the vendor who supplies this drive
     model_name:                 str( min=1 )        # The vendor's model name for this drive
-    interface:                  enum( 'nvme', 'SAS', 'SATA', 'other' )
+    interface:                  enum( 'nvme', 'sas', 'sata', 'other' )
     media_type:                 enum( 'HDD', 'TLC', 'QLC', 'other' )    # Spinning disk or NAND cell type
     capacity_in_GB:             int( min=1 )        # in base 10 GB, not in GiB
     performance:                include( 'drive_performance', required=False )

--- a/mlpstorage_py/system_description/schema_validator.py
+++ b/mlpstorage_py/system_description/schema_validator.py
@@ -80,8 +80,8 @@ class TrafficType(str, Enum):
 
 class DriveInterface(str, Enum):
     nvme  = 'nvme'
-    SAS   = 'SAS'
-    SATA  = 'SATA'
+    sas   = 'sas'
+    sata  = 'sata'
     other = 'other'
 
 

--- a/tests/unit/test_cluster_collector.py
+++ b/tests/unit/test_cluster_collector.py
@@ -3260,6 +3260,36 @@ class TestDrivesCollector:
         out = cc.collect_drives()
         assert out == []
 
+    @pytest.mark.parametrize("tran", ["nvme", "sata", "sas"])
+    def test_collector_interface_passes_drive_instance_schema(
+        self, monkeypatch, tran
+    ):
+        """Issue #637 regression: every TRAN the collector accepts must round-trip
+        through the DriveInstance pydantic schema without a case-mismatch error.
+
+        Prior behavior: DriveInterface enum required 'SAS'/'SATA' uppercase while
+        the collector emitted lowercase 'sas'/'sata', so every SAS/SATA client
+        drive failed [2.1.7 systemsDirectoryFiles] validation.
+        """
+        from mlpstorage_py import cluster_collector as cc
+        from mlpstorage_py.system_description.schema_validator import DriveInstance
+
+        payload = {
+            "blockdevices": [
+                {"name": "sda", "model": "X", "vendor": "Y",
+                 "size": "500000000000", "rota": "1", "tran": tran,
+                 "rm": "0"},
+            ]
+        }
+        monkeypatch.setattr(cc.subprocess, "run",
+                            lambda *a, **k: _lsblk_cp(payload))
+        out = cc.collect_drives()
+        assert len(out) == 1
+        # `media_type` is an SER-02 submitter-fills blank; supply a valid
+        # value so the schema check exercises `interface` in isolation.
+        drive = {**out[0], "unit_count": 1, "media_type": "TLC"}
+        DriveInstance.model_validate(drive)
+
     def test_size_decimal_gb_floor(self, monkeypatch):
         """RESEARCH Q1 — capacity_in_GB = int(size) // 10**9 (decimal GB,
         nameplate convention). A 1 TB drive (1_000_204_886_016 bytes) emits


### PR DESCRIPTION
Fixes #637.

## Summary
`lsblk -o TRAN` emits lowercase transport names (`nvme`, `sata`, `sas`); the collector at `cluster_collector.py:1307,1384` forwards them unchanged. `DriveInterface` required uppercase `SAS`/`SATA`, so every non-NVMe client drive failed `[2.1.7 systemsDirectoryFiles]` validation. A recent 51-client kvcache submission hit 51 identical failures on this one line.

## Change
Normalize the schema (`schema_validator.py` enum + `schema.yaml` yamale enum) to the raw Linux lowercase (`nvme`, `sata`, `sas`, `other`). This matches what the collector already produces, so no collector edit is needed. Bundled `example_*.yaml` files all use `nvme` (lowercase) and are unaffected.

## Regression test
Added a parametrized test in `test_cluster_collector.py` that runs `collect_drives()` for each of the three accepted trans (nvme/sata/sas) and validates the emitted dict through `DriveInstance.model_validate(...)`. This ties the collector output to the pydantic schema so future case-drift cannot recur silently.

## Test plan
- [x] `uv run pytest tests/` — 2555 passed
- [x] `uv run pytest mlpstorage_py/tests/` — 811 passed
- [x] `uv run pytest vdb_benchmark/tests/` — 155 passed
- [x] `uv run pytest kv_cache_benchmark/tests/` — 238 passed