### PR TITLE
fix(#638): kvcache emits summary.json, matching submission loader

### DIFF
--- a/ManPage.md
+++ b/ManPage.md
@@ -351,6 +351,7 @@ Checkpointing intentionally omits the `<command>` segment under `<systemname>/ch
 
 ```
 <results-dir>/<mode>/<orgname>/results/<systemname>/kv_cache/<model>/run/<YYYYMMDD_HHMMSS>/
+├── summary.json                          aggregated per-run summary read by the submission checker
 ├── results.json
 ├── option_1_results.json                 one per autoscaler option
 ├── option_2_results.json

--- a/kv_cache_benchmark/README.md
+++ b/kv_cache_benchmark/README.md
@@ -108,6 +108,6 @@ KV cache benchmark results are calculated for each workload:
 - "Write Bandwidth (GiB/s)" - Sum of "tier_storage_write_bandwidth_gbps" from all instances during a run
 - "P95 Read Latency (ms)" - Highest of "storage_read_p95_ms" from all instance during a run
 
-Each workload is run three times. The final submission results that will be displayed in the results table is the mean of the three runs for throughput and bandwidth, and the max of the three runs for latency. These results are reported in the generated `kvcache_run_summary` JSON file.
+Each workload is run three times. The final submission results that will be displayed in the results table is the mean of the three runs for throughput and bandwidth, and the max of the three runs for latency. These results are reported in the generated `summary.json` file at the root of the run's result directory.
 
 

--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -823,8 +823,13 @@ class KVCacheBenchmark(Benchmark):
                 r.get('partial_failure', False) for r in option_results.values()
             ),
         }
-        summary_filename = f"kvcache_run_summary_{self.run_datetime}.json"
-        summary_path = Path(self.run_result_output) / summary_filename
+        # `summary.json` matches the filename training/checkpointing DLIO
+        # writes and the name the submission checker's loader looks for
+        # (submission_checker/loader.py). `run_result_output` is already
+        # per-run-unique via _reserve_run_directory, so an unqualified
+        # `summary.json` inside it cannot collide with sibling runs. See
+        # storage #638.
+        summary_path = Path(self.run_result_output) / "summary.json"
         with open(summary_path, 'w+') as fd:
             json.dump(summary, fd, indent=2, cls=MLPSJsonEncoder)
         self.logger.status(f"Run summary written to: {summary_path}")

--- a/tests/integration/test_benchmark_flow.py
+++ b/tests/integration/test_benchmark_flow.py
@@ -683,10 +683,10 @@ class TestKVCacheRunIntegration:
              patch.object(bm, 'write_metadata'):
             bm._execute_run()
 
-        summary_files = list(Path(bm.run_result_output).glob('kvcache_run_summary_*.json'))
-        assert len(summary_files) == 1, f"Expected 1 summary file, found: {summary_files}"
+        summary_path = Path(bm.run_result_output) / 'summary.json'
+        assert summary_path.exists(), f"Expected summary at {summary_path}"
 
-        data = json.loads(summary_files[0].read_text())
+        data = json.loads(summary_path.read_text())
         assert data['schema_version'] == '1.0'
         assert 'options' in data
         options = data['options']
@@ -703,6 +703,8 @@ class TestKVCacheRunIntegration:
              patch.object(bm, 'write_metadata'):
             rc = bm._execute_run()
 
-        summary_files = list(Path(bm.run_result_output).glob('kvcache_run_summary_*.json'))
-        assert summary_files == [], f"Expected no summary in what-if mode, found: {summary_files}"
+        summary_path = Path(bm.run_result_output) / 'summary.json'
+        assert not summary_path.exists(), (
+            f"Expected no summary in what-if mode, found: {summary_path}"
+        )
         assert rc == 0

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -662,8 +662,35 @@ class TestWriteRunSummary:
         option_results = {1: self._option_result()}
         bm._write_run_summary(option_results, npernode=2, host_count=1, total_ranks=2, trials=3)
 
-        expected = Path(output_dir) / 'kvcache_run_summary_20260523_120000.json'
+        expected = Path(output_dir) / 'summary.json'
         assert expected.exists(), f"Expected summary at {expected}"
+
+    def test_summary_filename_matches_submission_loader(self, tmp_path):
+        """Issue #638 regression: the emitted filename must match the literal
+        string the submission checker's loader looks for. Prior behavior wrote
+        `kvcache_run_summary_<datetime>.json`; loader.py:102 hardcodes
+        `summary.json`, so kvcache summaries were never loaded and STRUCT-09
+        cross-checks silently degraded.
+        """
+        import inspect
+        from mlpstorage_py.submission_checker.loader import Loader
+        # Loader._collect_timestamped_logs joins timestamp_path with the literal
+        # basename. Assert that literal is present in the loader source so a
+        # future rename in either place fails this test.
+        loader_src = inspect.getsource(Loader._collect_timestamped_logs)
+        assert '"summary.json"' in loader_src, (
+            "loader._collect_timestamped_logs no longer joins 'summary.json'; "
+            "kvcache._write_run_summary must be updated in lockstep."
+        )
+        bm = _make_run_benchmark(tmp_path)
+        output_dir = str(tmp_path / 'summary_out')
+        os.makedirs(output_dir, exist_ok=True)
+        bm.run_result_output = output_dir
+        bm._write_run_summary(
+            {1: self._option_result()},
+            npernode=2, host_count=1, total_ranks=2, trials=3,
+        )
+        assert (Path(output_dir) / 'summary.json').exists()
 
     def test_schema_version_is_1_0(self, tmp_path):
         """Written JSON must have schema_version='1.0'."""
@@ -674,7 +701,7 @@ class TestWriteRunSummary:
 
         bm._write_run_summary({1: self._option_result()}, npernode=2, host_count=1, total_ranks=2, trials=3)
 
-        with open(Path(output_dir) / 'kvcache_run_summary_20260523_120000.json') as f:
+        with open(Path(output_dir) / 'summary.json') as f:
             data = json.load(f)
         assert data['schema_version'] == '1.0'
 
@@ -687,7 +714,7 @@ class TestWriteRunSummary:
 
         bm._write_run_summary({1: self._option_result()}, npernode=2, host_count=1, total_ranks=2, trials=3)
 
-        with open(Path(output_dir) / 'kvcache_run_summary_20260523_120000.json') as f:
+        with open(Path(output_dir) / 'summary.json') as f:
             data = json.load(f)
 
         required = {'schema_version', 'run_datetime', 'npernode', 'host_count',
@@ -708,7 +735,7 @@ class TestWriteRunSummary:
         }
         bm._write_run_summary(option_results, npernode=2, host_count=1, total_ranks=2, trials=3)
 
-        with open(Path(output_dir) / 'kvcache_run_summary_20260523_120000.json') as f:
+        with open(Path(output_dir) / 'summary.json') as f:
             data = json.load(f)
         assert data['partial_failure'] is True
 
@@ -722,7 +749,7 @@ class TestWriteRunSummary:
         option_results = {1: self._option_result(partial=False)}
         bm._write_run_summary(option_results, npernode=2, host_count=1, total_ranks=2, trials=3)
 
-        with open(Path(output_dir) / 'kvcache_run_summary_20260523_120000.json') as f:
+        with open(Path(output_dir) / 'summary.json') as f:
             data = json.load(f)
         assert data['partial_failure'] is False
 
@@ -736,7 +763,7 @@ class TestWriteRunSummary:
         option_results = {1: self._option_result(bw=5.0)}
         bm._write_run_summary(option_results, npernode=2, host_count=1, total_ranks=2, trials=3)
 
-        with open(Path(output_dir) / 'kvcache_run_summary_20260523_120000.json') as f:
+        with open(Path(output_dir) / 'summary.json') as f:
             data = json.load(f)
         # JSON keys are strings after serialization
         options = data['options']
@@ -763,7 +790,7 @@ class TestWriteRunSummary:
             'cpu_tier_ranks': [],
         }
         bm._write_run_summary({1: option_result}, npernode=2, host_count=1, total_ranks=2, trials=3)
-        summary_files = list(Path(output_dir).glob('kvcache_run_summary_*.json'))
+        summary_files = list(Path(output_dir).glob('summary.json'))
         assert len(summary_files) == 1
 
 


### PR DESCRIPTION
Fixes #638.

## Summary
Training and checkpointing benchmarks write their per-run summary as `summary.json` (via DLIO). The submission checker's `Loader._collect_timestamped_logs` hardcodes that same basename. Kvcache diverged, writing `kvcache_run_summary_<datetime>.json`, so the loader silently missed every kvcache summary — Lou's recent Everpure validation reported `[WARNING] Could not load Summary log from .../summary.json, path does not exists` which is exactly this. STRUCT-09 cross-checks and any KVCache rule that reads summary fields also degrade to `None`.

## Change
Emit `summary.json` at the root of `run_result_output`. The timestamp in the old filename was redundant: `run_result_output` is already per-run-unique via `_reserve_run_directory`, so an unqualified `summary.json` cannot collide with sibling runs. This is the same pattern training and checkpointing already use.

Also updated:
- `tests/unit/test_benchmarks_kvcache.py` — filename references
- `tests/integration/test_benchmark_flow.py` — filename references (positive + what-if negative)
- `kv_cache_benchmark/README.md` — user-facing doc

## Regression test
Added `test_summary_filename_matches_submission_loader` that asserts the literal string `"summary.json"` appears in `Loader._collect_timestamped_logs`'s source. That wires both ends together — a future rename in either the emitter or the loader breaks the test.

## Test plan
- [x] `uv run pytest tests/` — 2553 passed
- [x] `uv run pytest mlpstorage_py/tests/` — 811 passed
- [x] `uv run pytest vdb_benchmark/tests/` — 155 passed
- [x] `uv run pytest kv_cache_benchmark/tests/` — 238 passed

Related: #612 fixed the kv_cache mode-recognition layer walk in the same loader but did not touch the filename mismatch.