### PR TITLE
fix(#647): expand sysctl allowlist + inject at fan-out, restore client dedup

### DIFF
--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -20,7 +20,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
-from typing import Any, Dict, Final, List, Optional, Pattern, Tuple
+from typing import Any, Dict, Final, List, Optional, Pattern, Sequence, Tuple
 
 from mlpstorage_py.config import MPIRUN, MPIEXEC, MPI_RUN_BIN, MPI_EXEC_BIN
 from mlpstorage_py.errors import ErrorCode, FileSystemError
@@ -1065,17 +1065,48 @@ _SYSCTL_ALLOWLIST_PATH: str = str(
 )
 
 
+def _load_sysctl_allowlist_lines(
+    path: str = _SYSCTL_ALLOWLIST_PATH,
+) -> Tuple[str, ...]:
+    """Return the raw glob strings from the allowlist file.
+
+    Sister to :func:`_load_sysctl_allowlist` (which compiles the same
+    globs into regex objects for the head-node walk). This form returns
+    the strings themselves so they can be embedded into the MPI collector
+    script's ``_SYSCTL_ALLOWLIST_LINES`` placeholder at fan-out time —
+    single source of truth for both head-node and rank-node walks.
+
+    Blank lines and lines whose ``lstrip()`` starts with ``#`` are skipped;
+    each glob is ``.strip()``-ed. On any read failure (FileNotFoundError,
+    OSError, PermissionError) returns ``()`` per the universal D-2
+    collection-failure rule — ranks then emit ``[]`` for sysctl.
+    """
+    try:
+        with open(path, 'r') as f:
+            lines = f.readlines()
+    except OSError:
+        return tuple()
+    globs: List[str] = []
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        if line.lstrip().startswith('#'):
+            continue
+        globs.append(line)
+    return tuple(globs)
+
+
 def _load_sysctl_allowlist(
     path: str = _SYSCTL_ALLOWLIST_PATH,
 ) -> Tuple[Pattern, ...]:
     """Load the on-disk allowlist and return a tuple of compiled regex objects.
 
-    One regex per glob line, via ``re.compile(fnmatch.translate(glob))``.
-    Blank lines and lines whose ``lstrip()`` starts with ``#`` are skipped;
-    each glob is ``.strip()``-ed before translation. On any read failure
-    (FileNotFoundError, OSError, PermissionError) returns ``tuple()`` per
-    the universal D-2 collection-failure rule — ``collect_sysctl`` then
-    matches nothing and emits ``[]``.
+    Reads the raw globs via :func:`_load_sysctl_allowlist_lines` and
+    compiles each via ``re.compile(fnmatch.translate(glob))``. On any
+    read failure returns ``tuple()`` per the universal D-2
+    collection-failure rule — ``collect_sysctl`` then matches nothing
+    and emits ``[]``.
 
     RESEARCH Q3 "deep-match" gotcha: ``fnmatch`` is NOT path-separator aware.
     A glob ``net.core.*`` matches ``net.core.rmem_max`` AND
@@ -1087,20 +1118,47 @@ def _load_sysctl_allowlist(
     RESEARCH Q2). If shallow-only matching is ever desired, use
     ``re.compile(r'^net\\.ipv4\\.[^.]+$')`` directly instead of fnmatch.
     """
-    try:
-        with open(path, 'r') as f:
-            lines = f.readlines()
-    except OSError:
-        return tuple()
-    patterns: List[Pattern] = []
-    for raw in lines:
-        line = raw.strip()
-        if not line:
-            continue
-        if line.lstrip().startswith('#'):
-            continue
-        patterns.append(re.compile(fnmatch.translate(line)))
-    return tuple(patterns)
+    return tuple(
+        re.compile(fnmatch.translate(g))
+        for g in _load_sysctl_allowlist_lines(path)
+    )
+
+
+# Sentinel line inside MPI_COLLECTOR_SCRIPT that gets rewritten by
+# `_render_mpi_collector_script` at fan-out time. The raw string keeps an
+# empty tuple so the script remains valid Python for the parity tests
+# that exec MPI_COLLECTOR_SCRIPT directly; the rendered form (written to
+# each rank's staged copy) carries the head-node's on-disk globs.
+_MPI_SYSCTL_PLACEHOLDER: Final[str] = "_SYSCTL_ALLOWLIST_LINES = ()"
+
+
+def _render_mpi_collector_script(
+    script: str,
+    allowlist_lines: Sequence[str],
+) -> str:
+    """Substitute the sysctl allowlist tuple into ``MPI_COLLECTOR_SCRIPT``.
+
+    The raw ``MPI_COLLECTOR_SCRIPT`` contains one empty-tuple placeholder
+    (``_MPI_SYSCTL_PLACEHOLDER``); this function replaces it with a
+    tuple literal built from ``allowlist_lines`` so every rank walks
+    /proc/sys with the same globs the head node uses. Single source of
+    truth is ``system_description/sysctl_allowlist.txt``; the two
+    duplicate code paths (module walker + MPI-script walker) both read
+    it via :func:`_load_sysctl_allowlist_lines`, so a submitter editing
+    the file need not touch code.
+
+    Uses ``str.replace(..., 1)`` to guard against the (near-impossible)
+    case of two placeholder-shaped lines drifting into the script; a
+    second match would be silently left in place with the old value
+    rather than doubly rewritten.
+
+    Idempotency: rendering an already-rendered script is a no-op —
+    the placeholder is gone after the first pass, so ``replace`` finds
+    nothing to change.
+    """
+    tuple_body = "".join(f"{g!r}, " for g in allowlist_lines)
+    rendered_line = f"_SYSCTL_ALLOWLIST_LINES = ({tuple_body})"
+    return script.replace(_MPI_SYSCTL_PLACEHOLDER, rendered_line, 1)
 
 
 def collect_sysctl(
@@ -2111,21 +2169,17 @@ def collect_networking(net_root=_SYSFS_NET_ROOT, ib_root=_SYSFS_INFINIBAND_ROOT)
 #
 # Pattern B forbids file I/O for package-data lookups inside the script (the
 # script ships as a string and is exec'd over SSH; there's no installed
-# package on every host). The allowlist is therefore baked in as a tuple
-# literal here. SOURCE OF TRUTH for the four globs is
-# mlpstorage_py/system_description/sysctl_allowlist.txt; keep this tuple in
-# sync with that file — the parity test asserts behavioral equivalence, not
-# allowlist-content equivalence, so a manual sync between the two copies is
-# the load-bearing discipline. (Future editor: if you add a glob to the
-# shipped file, also add it here.)
+# package on every host). SOURCE OF TRUTH for the allowlist is
+# mlpstorage_py/system_description/sysctl_allowlist.txt on the head node;
+# `_write_collector_script` calls `_render_mpi_collector_script` at
+# fan-out time to substitute the file's globs into this empty-tuple
+# placeholder so every rank walks /proc/sys with the same list the head
+# node uses — no manual code-vs-file sync required. The raw string kept
+# in `MPI_COLLECTOR_SCRIPT` retains `()` so it stays valid Python for the
+# parity tests that exec it directly.
 _PROC_SYS_ROOT = '/proc/sys'
 
-_SYSCTL_ALLOWLIST_LINES = (
-    'vm.dirty_*',
-    'net.core.*',
-    'net.ipv4.tcp_*',
-    'kernel.numa_balancing',
-)
+_SYSCTL_ALLOWLIST_LINES = ()
 
 
 def _load_sysctl_allowlist():
@@ -3146,9 +3200,21 @@ class MPIClusterCollector:
         return cmd
 
     def _write_collector_script(self, script_path: str) -> None:
-        """Write the collector script to the specified path."""
+        """Write the collector script to the specified path.
+
+        Renders the sysctl allowlist into ``MPI_COLLECTOR_SCRIPT``'s
+        ``_SYSCTL_ALLOWLIST_LINES`` placeholder from the head node's
+        on-disk ``sysctl_allowlist.txt`` so every SCP'd rank copy carries
+        the same globs the head-node walker uses. On file-read failure
+        the placeholder stays ``()`` and ranks emit ``[]`` for sysctl
+        (D-2 envelope) — the benchmark continues rather than aborting.
+        """
+        allowlist_lines = _load_sysctl_allowlist_lines()
+        rendered = _render_mpi_collector_script(
+            MPI_COLLECTOR_SCRIPT, allowlist_lines,
+        )
         with open(script_path, 'w') as f:
-            f.write(MPI_COLLECTOR_SCRIPT)
+            f.write(rendered)
         os.chmod(script_path, 0o755)
 
     def _ssh_target(self, host: str) -> str:

--- a/mlpstorage_py/system_description/sysctl_allowlist.txt
+++ b/mlpstorage_py/system_description/sysctl_allowlist.txt
@@ -1,8 +1,97 @@
-# Phase 4 (COLL-05): sysctl key allowlist. One shell-style glob per line.
+# sysctl key allowlist. One shell-style glob per line.
 # Lines starting with '#' are comments; blank lines are ignored.
 # Edit this file to add patterns; no code change required.
+#
+# NOTE on cross-host dedup (auto_generator._sysctl_signature):
+# Every leaf listed here participates in the client-stanza fingerprint.
+# Keys whose value varies per-boot or per-host (e.g. net.core.netdev_rss_key,
+# net.core.rps_default_mask, net.core.flow_limit_cpu_bitmap) MUST NOT be
+# allowlisted or identically-configured clients will fail to collapse into
+# one node_description with quantity: N.
+#
+# NOTE on fnmatch depth (RESEARCH Q3 in cluster_collector.py):
+# `fnmatch` is not path-separator aware. `net.core.*` matches
+# `net.core.rmem_max` AND `net.core.netdev_rss_key` AND any future deeper
+# leaf. Prefer explicit literal keys over broad globs so a new noisy leaf
+# added in a future kernel doesn't silently break dedup.
 
-vm.dirty_*
-net.core.*
-net.ipv4.tcp_*
+# ---------------------------------------------------------------------
+# Page cache / writeback (buffered-I/O behavior; primary storage impact)
+# ---------------------------------------------------------------------
+vm.dirty_background_bytes
+vm.dirty_background_ratio
+vm.dirty_bytes
+vm.dirty_ratio
+vm.dirty_expire_centisecs
+vm.dirty_writeback_centisecs
+
+# ---------------------------------------------------------------------
+# Virtual memory tuning (reclaim / NUMA / mmap)
+# ---------------------------------------------------------------------
+vm.swappiness
+vm.min_free_kbytes
+vm.vfs_cache_pressure
+vm.zone_reclaim_mode
+vm.overcommit_memory
+vm.overcommit_ratio
+vm.max_map_count
+vm.nr_hugepages
+vm.nr_overcommit_hugepages
+vm.watermark_scale_factor
+vm.page-cluster
+
+# ---------------------------------------------------------------------
+# Socket buffers (critical for NFS / S3 / any network storage)
+# ---------------------------------------------------------------------
+net.core.rmem_default
+net.core.rmem_max
+net.core.wmem_default
+net.core.wmem_max
+net.core.optmem_max
+
+# ---------------------------------------------------------------------
+# Network stack throughput & latency knobs commonly tuned for storage
+# ---------------------------------------------------------------------
+net.core.netdev_max_backlog
+net.core.netdev_budget
+net.core.netdev_budget_usecs
+net.core.somaxconn
+net.core.busy_poll
+net.core.busy_read
+net.core.default_qdisc
+
+# ---------------------------------------------------------------------
+# TCP tuning (per-socket buffers, congestion control, mid-flow behavior)
+# ---------------------------------------------------------------------
+net.ipv4.tcp_rmem
+net.ipv4.tcp_wmem
+net.ipv4.tcp_congestion_control
+net.ipv4.tcp_slow_start_after_idle
+net.ipv4.tcp_mtu_probing
+net.ipv4.tcp_notsent_lowat
+net.ipv4.tcp_sack
+net.ipv4.tcp_window_scaling
+net.ipv4.tcp_timestamps
+net.ipv4.tcp_low_latency
+net.ipv4.tcp_no_metrics_save
+net.ipv4.ip_local_port_range
+
+# ---------------------------------------------------------------------
+# Filesystem limits (FD ceilings, libaio slots, inotify)
+# ---------------------------------------------------------------------
+fs.file-max
+fs.nr_open
+fs.aio-max-nr
+fs.inotify.max_user_watches
+
+# ---------------------------------------------------------------------
+# Kernel / scheduler / IPC
+# ---------------------------------------------------------------------
 kernel.numa_balancing
+kernel.io_uring_disabled
+kernel.sched_migration_cost_ns
+kernel.sched_autogroup_enabled
+kernel.pid_max
+kernel.threads-max
+kernel.shmmax
+kernel.shmall

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.28"
+version = "3.0.29"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -79,7 +79,10 @@ vectordb-elasticsearch = [
 packages = {find = {include = ["mlpstorage_py*", "vdbbench*"]}}
 
 [tool.setuptools.package-data]
-"mlpstorage_py" = ["../configs/dlio/workload/*.yaml"]
+"mlpstorage_py" = [
+    "../configs/dlio/workload/*.yaml",
+    "system_description/sysctl_allowlist.txt",
+]
 
 [project.scripts]
 mlpstorage = 'mlpstorage_py.main:main'

--- a/tests/unit/test_cluster_collector.py
+++ b/tests/unit/test_cluster_collector.py
@@ -2346,44 +2346,233 @@ class TestSysctlAllowlistFile:
     """The shipped allowlist file at
     mlpstorage_py/system_description/sysctl_allowlist.txt is the load-bearing
     artifact for COLL-05: editing it adds keys to the next run's output with
-    no code change. These tests pin its existence, structure, and the four
-    initial patterns locked by D-27."""
+    no code change. These tests pin its existence and the canonical keys
+    reviewers expect to see in every submission's sysctl block."""
 
     def test_allowlist_file_exists(self):
-        """D-27: the package ships sysctl_allowlist.txt as a data file."""
+        """The package ships sysctl_allowlist.txt as a data file."""
         from pathlib import Path
         import mlpstorage_py.system_description as sd_pkg
         sd_dir = Path(sd_pkg.__file__).parent
         path = sd_dir / "sysctl_allowlist.txt"
         assert path.exists(), (
-            f"D-27: package must ship sysctl_allowlist.txt at {path}"
+            f"package must ship sysctl_allowlist.txt at {path}"
         )
 
-    def test_allowlist_file_parses_to_four_patterns(self):
-        """D-27: the shipped file contains exactly four glob lines
-        (vm.dirty_*, net.core.*, net.ipv4.tcp_*, kernel.numa_balancing)."""
+    def test_allowlist_file_is_nonempty(self):
+        """The shipped file parses to at least one glob (the file being
+        stripped to nothing would silently disable sysctl collection on
+        every rank; catch that at test time)."""
         from mlpstorage_py.cluster_collector import _load_sysctl_allowlist
         patterns = _load_sysctl_allowlist()
-        assert len(patterns) == 4, (
-            f"D-27: expected 4 initial globs, got {len(patterns)}: {patterns!r}"
+        assert len(patterns) > 0, (
+            "shipped sysctl_allowlist.txt must contain at least one glob; "
+            "an empty file silently disables sysctl collection cluster-wide."
         )
 
     def test_shipped_globs_match_canonical_keys(self):
-        """D-27: the four globs round-trip to regex objects matching
-        vm.dirty_ratio, net.core.rmem_max, net.ipv4.tcp_rmem, kernel.numa_balancing."""
+        """The shipped allowlist must cover the storage-relevant keys
+        reviewers look at first: page-cache dirty tuning, socket buffers,
+        TCP tuning, and NUMA balancing."""
         from mlpstorage_py.cluster_collector import _load_sysctl_allowlist
         patterns = _load_sysctl_allowlist()
-        # For each canonical key, at least one pattern must match it.
         canonical_keys = [
             "vm.dirty_ratio",
+            "vm.dirty_background_ratio",
+            "vm.swappiness",
             "net.core.rmem_max",
+            "net.core.wmem_max",
+            "net.core.somaxconn",
             "net.ipv4.tcp_rmem",
+            "net.ipv4.tcp_congestion_control",
             "kernel.numa_balancing",
+            "fs.file-max",
         ]
         for key in canonical_keys:
             assert any(p.match(key) for p in patterns), (
-                f"D-27: no shipped glob matches canonical key {key!r}"
+                f"shipped allowlist must cover canonical key {key!r}"
             )
+
+    def test_shipped_globs_exclude_per_boot_random_keys(self):
+        """Regression guard: keys whose value is regenerated per boot (or
+        varies with CPU topology across identical hardware) must NOT be
+        allowlisted, or dedup via auto_generator._sysctl_signature breaks
+        and every client emits as its own node_description stanza."""
+        from mlpstorage_py.cluster_collector import _load_sysctl_allowlist
+        patterns = _load_sysctl_allowlist()
+        dedup_hostile_keys = [
+            "net.core.netdev_rss_key",       # 52-byte random per boot
+            "net.core.rps_default_mask",     # CPU-topology-dependent bitmap
+            "net.core.flow_limit_cpu_bitmap",
+        ]
+        for key in dedup_hostile_keys:
+            assert not any(p.match(key) for p in patterns), (
+                f"key {key!r} varies per host/boot and must NOT be "
+                "allowlisted; it breaks client-stanza dedup."
+            )
+
+
+class TestLoadSysctlAllowlistLines:
+    """`_load_sysctl_allowlist_lines` returns raw glob strings from the same
+    file `_load_sysctl_allowlist` compiles into regexes. It's the injection
+    source for the MPI script rendering path — every rank walks /proc/sys
+    with the same globs the head node uses."""
+
+    def test_returns_tuple_of_strings(self, tmp_path):
+        from mlpstorage_py.cluster_collector import (
+            _load_sysctl_allowlist_lines,
+        )
+        p = tmp_path / "allowlist.txt"
+        p.write_text("vm.dirty_ratio\nnet.core.rmem_max\n")
+        lines = _load_sysctl_allowlist_lines(str(p))
+        assert lines == ("vm.dirty_ratio", "net.core.rmem_max")
+
+    def test_skips_blanks_and_comments(self, tmp_path):
+        from mlpstorage_py.cluster_collector import (
+            _load_sysctl_allowlist_lines,
+        )
+        p = tmp_path / "allowlist.txt"
+        p.write_text(
+            "# header\n"
+            "\n"
+            "vm.dirty_ratio\n"
+            "   # indented comment\n"
+            "net.core.rmem_max\n"
+        )
+        lines = _load_sysctl_allowlist_lines(str(p))
+        assert lines == ("vm.dirty_ratio", "net.core.rmem_max")
+
+    def test_missing_file_returns_empty_tuple(self, tmp_path):
+        """D-2 rule: read failure yields ``()`` so the render step falls
+        back to the empty-tuple placeholder and ranks emit ``[]``."""
+        from mlpstorage_py.cluster_collector import (
+            _load_sysctl_allowlist_lines,
+        )
+        assert _load_sysctl_allowlist_lines(
+            str(tmp_path / "no_such_file.txt")
+        ) == ()
+
+    def test_shipped_file_lines_and_patterns_are_paired(self):
+        """The two loaders must operate on the same file and produce the
+        same number of entries — one regex per glob line. If these ever
+        diverge the head-node walk and the MPI-script rendering would
+        silently see different key sets."""
+        from mlpstorage_py.cluster_collector import (
+            _load_sysctl_allowlist,
+            _load_sysctl_allowlist_lines,
+        )
+        assert len(_load_sysctl_allowlist_lines()) == len(
+            _load_sysctl_allowlist()
+        )
+
+
+class TestRenderMPICollectorScript:
+    """`_render_mpi_collector_script` substitutes the head-node allowlist
+    into `MPI_COLLECTOR_SCRIPT`'s empty-tuple placeholder so every rank
+    walks /proc/sys with the same globs the head node uses. Single source
+    of truth: `sysctl_allowlist.txt`."""
+
+    def test_raw_script_contains_empty_tuple_placeholder(self):
+        """Invariant that keeps existing parity tests working: the raw
+        `MPI_COLLECTOR_SCRIPT` string must still be valid Python that
+        exec's cleanly, which means the placeholder is an empty tuple
+        assignment, not an undefined-name sentinel."""
+        from mlpstorage_py.cluster_collector import MPI_COLLECTOR_SCRIPT
+        assert "_SYSCTL_ALLOWLIST_LINES = ()" in MPI_COLLECTOR_SCRIPT
+
+    def test_render_substitutes_globs(self):
+        from mlpstorage_py.cluster_collector import (
+            MPI_COLLECTOR_SCRIPT, _render_mpi_collector_script,
+        )
+        rendered = _render_mpi_collector_script(
+            MPI_COLLECTOR_SCRIPT,
+            ("vm.dirty_ratio", "net.core.rmem_max"),
+        )
+        assert "_SYSCTL_ALLOWLIST_LINES = ()" not in rendered
+        assert "_SYSCTL_ALLOWLIST_LINES = ('vm.dirty_ratio', 'net.core.rmem_max', )" in rendered
+
+    def test_rendered_script_execs_with_correct_tuple(self):
+        """End-to-end: exec the rendered script and confirm the module-level
+        tuple matches the input. This is the "would-catch-drift" test that
+        the manual-sync discipline in the old comment couldn't offer."""
+        from mlpstorage_py.cluster_collector import (
+            MPI_COLLECTOR_SCRIPT, _render_mpi_collector_script,
+        )
+        rendered = _render_mpi_collector_script(
+            MPI_COLLECTOR_SCRIPT,
+            ("vm.dirty_ratio", "kernel.numa_balancing"),
+        )
+        ns = {}
+        try:
+            exec(rendered, ns)
+        except BaseException:
+            pass  # SystemExit from top-level MPI init; defs land first
+        assert ns.get("_SYSCTL_ALLOWLIST_LINES") == (
+            "vm.dirty_ratio", "kernel.numa_balancing",
+        )
+
+    def test_render_is_idempotent(self):
+        """Double-render is a no-op: after the first pass the placeholder
+        is gone, so a second call finds nothing to replace."""
+        from mlpstorage_py.cluster_collector import (
+            MPI_COLLECTOR_SCRIPT, _render_mpi_collector_script,
+        )
+        once = _render_mpi_collector_script(
+            MPI_COLLECTOR_SCRIPT, ("vm.dirty_ratio",),
+        )
+        twice = _render_mpi_collector_script(once, ("net.core.rmem_max",))
+        assert once == twice
+
+    def test_render_with_empty_allowlist_leaves_empty_tuple(self):
+        """D-2 fallback path: an empty allowlist (e.g. head-node file
+        read failed) substitutes to an empty tuple — same shape as the
+        raw placeholder — so the rendered script still exec's cleanly
+        and ranks emit ``[]``."""
+        from mlpstorage_py.cluster_collector import (
+            MPI_COLLECTOR_SCRIPT, _render_mpi_collector_script,
+        )
+        rendered = _render_mpi_collector_script(MPI_COLLECTOR_SCRIPT, ())
+        assert "_SYSCTL_ALLOWLIST_LINES = ()" in rendered
+
+
+class TestWriteCollectorScriptRenders:
+    """`MPIClusterCollector._write_collector_script` must render the head
+    node's sysctl_allowlist.txt into each rank's SCP'd script copy — the
+    replacement for the old "keep this tuple in sync" discipline."""
+
+    def test_written_script_carries_head_node_globs(self, tmp_path, monkeypatch):
+        """The file on disk (what SCP fans out) must have the head node's
+        globs baked into `_SYSCTL_ALLOWLIST_LINES`."""
+        from mlpstorage_py import cluster_collector as cc
+        # Stub the loader to return a fixed tuple so this test doesn't
+        # depend on the shipped file's evolving contents.
+        fixture = ("vm.dirty_ratio", "net.core.rmem_max", "kernel.numa_balancing")
+        monkeypatch.setattr(
+            cc, "_load_sysctl_allowlist_lines", lambda: fixture,
+        )
+        # Instantiate a bare MPIClusterCollector; `_write_collector_script`
+        # only uses `self` as a namespace hop.
+        collector = cc.MPIClusterCollector.__new__(cc.MPIClusterCollector)
+        script_path = tmp_path / "mlps_collector.py"
+        collector._write_collector_script(str(script_path))
+
+        contents = script_path.read_text()
+        assert "_SYSCTL_ALLOWLIST_LINES = ()" not in contents
+        for glob in fixture:
+            assert repr(glob) in contents, (
+                f"rendered rank script missing head-node glob {glob!r}"
+            )
+
+    def test_written_script_still_valid_python(self, tmp_path):
+        """The rendered file must exec cleanly (definitions land before
+        the top-level MPI init raises); the rank interpreter would
+        otherwise fail with a SyntaxError long before /proc/sys is read."""
+        from mlpstorage_py import cluster_collector as cc
+        collector = cc.MPIClusterCollector.__new__(cc.MPIClusterCollector)
+        script_path = tmp_path / "mlps_collector.py"
+        collector._write_collector_script(str(script_path))
+        # Compile-only; running would trigger the MPI top-level.
+        compile(script_path.read_text(), str(script_path), "exec")
 
 
 class TestLoadSysctlAllowlist:

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.28"
+version = "3.0.29"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
Fixes #647.

## Summary

- Replaces the four-glob sysctl allowlist (`vm.dirty_*`, `net.core.*`, `net.ipv4.tcp_*`, `kernel.numa_balancing`) with ~45 explicit literal keys covering the knobs storage reviewers actually look at, grouped by concern.
- Retires the "keep this hardcoded tuple in sync with the shipped file" discipline: `MPIClusterCollector._write_collector_script` now renders the head-node's on-disk allowlist into each rank's SCP'd script at fan-out time (new `_render_mpi_collector_script` helper). `sysctl_allowlist.txt` becomes the sole source of truth for both walkers.
- Fixes a latent packaging bug — `sysctl_allowlist.txt` was never in `[tool.setuptools.package-data]`, so wheel installs silently emitted `[]` sysctl on every rank.
- Bumps to `3.0.29`.

See #647 for the incident narrative (real customer run where `net.core.netdev_rss_key` in the fingerprint blocked all client-stanza dedup).

## Test plan

- [x] `pytest tests/unit/test_cluster_collector.py tests/unit/test_auto_generator.py tests/unit/test_auto_generator_write.py mlpstorage_py/tests/ -q` → 1273 passed locally
- [x] Existing `TestSysctlMPIScriptParity` still passes (raw `MPI_COLLECTOR_SCRIPT` remains valid Python)
- [x] New `TestRenderMPICollectorScript` covers: raw-script placeholder invariant, substitution correctness, exec-and-check parity, idempotency, and the empty-allowlist fallback path
- [x] New `TestWriteCollectorScriptRenders` verifies the file on disk carries the head-node globs and stays valid Python
- [x] New regression guard blocks re-introduction of `net.core.netdev_rss_key`, `net.core.rps_default_mask`, `net.core.flow_limit_cpu_bitmap`
- [ ] CI green