### PR TITLE
fix(#642): use forkserver for writer subprocess, never fork after Tokio

### DIFF
--- a/mlpstorage_py/checkpointing/streaming_checkpoint.py
+++ b/mlpstorage_py/checkpointing/streaming_checkpoint.py
@@ -7,6 +7,39 @@ by isolating data generation from storage operations using shared memory buffers
 import os
 import time
 import multiprocessing as mp
+
+
+def _writer_mp_context():
+    """Return the multiprocessing context for the streaming-checkpoint writer.
+
+    Prefers ``forkserver`` — children fork from a clean, early-started
+    interpreter with no live Tokio runtime — falling back to ``spawn``
+    only on platforms without ``forkserver`` (Windows/macOS). ``fork``
+    is intentionally never used.
+
+    Issue #642: before this fix, ``save()`` used ``mp.get_context('fork')``.
+    On the s3dlio object-storage path the parent has already started
+    s3dlio's Tokio runtime via ``ObjStoreLibStorage._preflight()`` →
+    ``s3dlio.list()`` by the time the writer subprocess is created;
+    ``fork()`` then copies the parent's mutex state without the threads
+    holding those mutexes and the writer futex-deadlocks the first time
+    it re-enters s3dlio. The old code comment claimed fork was safe
+    "because the writer child creates fresh StorageWriter instances after
+    fork so Tokio/Rayon are initialized cleanly in the child" — that
+    reasoning holds for what the child does, not for the mutex state the
+    child inherits.
+
+    ``spawn`` is a fallback rather than the primary choice because it
+    re-imports ``__main__`` and blocks MPI ranks re-joining the
+    OpenMPI communicator (the historical reason the pre-#642 code
+    picked ``fork`` over ``spawn`` in the first place). ``forkserver``
+    gets the "clean interpreter, no live Tokio" property of ``spawn``
+    without ``spawn``'s ``__main__`` re-import.
+    """
+    try:
+        return mp.get_context('forkserver')
+    except ValueError:
+        return mp.get_context('spawn')
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import shared_memory
 from typing import Optional, Dict, Any
@@ -170,11 +203,11 @@ class StreamingCheckpointing:
         if self.use_direct_io:
             print(f"[Main] ⚠ Disabling O_DIRECT (shared_memory buffers not page-aligned)")
         
-        # Start writer process with fork context (Linux only).
-        # Uses 'fork' to inherit environment variables (AWS credentials, etc.)
-        # and to avoid MPI re-initialization deadlocks that occur with 'spawn'
-        # (spawned children inherit OMPI_COMM_WORLD_* and block trying to
-        # re-join the MPI communicator).
+        # Writer subprocess context — see `_writer_mp_context` at module
+        # scope for the forkserver-over-fork rationale (#642: fork after
+        # live s3dlio Tokio deadlocks; forkserver avoids re-importing
+        # __main__, which is what makes spawn hang MPI ranks re-joining
+        # the OpenMPI communicator).
         #
         # CRITICAL: IPC objects (Queue, Event) MUST be created from the SAME
         # context as the child process — mixing contexts (e.g. fork-context
@@ -182,15 +215,7 @@ class StreamingCheckpointing:
         #   RuntimeError: A SemLock created in a fork context is being shared
         #                 with a process in a spawn context.
         # Always create IPC objects from ctx BEFORE ctx.Process().
-        #
-        # Fork safety: the writer child does NOT call dgen-py or s3dlio from the
-        # parent's Rust runtimes — it creates fresh StorageWriter instances after
-        # fork, so Tokio/Rayon are initialized cleanly in the child.
-        try:
-            ctx = mp.get_context('fork')
-        except ValueError:
-            # Fork not available (Windows/macOS) — fall back to spawn.
-            ctx = mp.get_context('spawn')
+        ctx = _writer_mp_context()
 
         # Setup IPC using the same context as the child process.
         buffer_queue = ctx.Queue(maxsize=self.num_buffers)

--- a/tests/unit/test_streaming_checkpoint_mp_context.py
+++ b/tests/unit/test_streaming_checkpoint_mp_context.py
@@ -1,0 +1,79 @@
+"""Tests for issue #642 — streaming checkpoint writer must not fork after
+the parent's s3dlio Tokio runtime is live.
+
+``StreamingCheckpointing.save()`` previously created its writer subprocess
+with ``mp.get_context('fork')``. On the s3dlio object-storage path the
+parent has already started s3dlio's Tokio runtime (via
+``ObjStoreLibStorage._preflight()`` → ``s3dlio.list()``) by the time
+``save()`` runs, so ``fork()`` copies the parent's mutex state without
+the threads holding those mutexes. The writer futex-deadlocks the moment
+it re-enters s3dlio, the producer blocks on a full queue, and all ranks
+sit at ~0% CPU right after ``[Writer] Attached to N buffers``.
+
+The fix uses ``forkserver`` — children fork from a clean, early-started
+interpreter with no live Tokio — falling back to ``spawn`` on platforms
+without ``forkserver`` (Windows/macOS). ``spawn`` is a fallback rather
+than the primary choice because it re-imports ``__main__``, which the
+in-code comment history records as the source of an MPI-rejoin hang.
+``fork`` is intentionally NEVER used.
+
+These tests lock the contract at the helper boundary
+(``_writer_mp_context``) so a future refactor cannot silently regress
+the choice.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from unittest.mock import patch
+
+
+class TestWriterMPContext:
+    """`_writer_mp_context` returns the multiprocessing context used to
+    spawn the writer subprocess. Prefers ``forkserver``; falls back to
+    ``spawn`` only when ``forkserver`` is unavailable; never returns
+    ``fork``."""
+
+    def test_returns_forkserver_on_linux(self):
+        """Linux (and any platform where forkserver is supported) must
+        get the forkserver context — the whole point of the fix."""
+        from mlpstorage_py.checkpointing.streaming_checkpoint import (
+            _writer_mp_context,
+        )
+        ctx = _writer_mp_context()
+        assert ctx.get_start_method() == 'forkserver', (
+            f"expected forkserver, got {ctx.get_start_method()!r}"
+        )
+
+    def test_falls_back_to_spawn_when_forkserver_unavailable(self):
+        """If ``forkserver`` raises ``ValueError`` (unsupported platform),
+        the helper must return the ``spawn`` context, not ``fork``."""
+        from mlpstorage_py.checkpointing import streaming_checkpoint as sc
+
+        real_get_context = mp.get_context
+
+        def fake_get_context(name):
+            if name == 'forkserver':
+                raise ValueError("forkserver not available on this platform")
+            return real_get_context(name)
+
+        with patch.object(sc.mp, 'get_context', side_effect=fake_get_context):
+            ctx = sc._writer_mp_context()
+
+        assert ctx.get_start_method() == 'spawn', (
+            f"expected spawn fallback, got {ctx.get_start_method()!r}"
+        )
+
+    def test_never_returns_fork(self):
+        """Regression guard: even in a hypothetical future where both
+        forkserver and spawn are unavailable, the helper must not silently
+        fall through to ``fork`` — the whole reason for this refactor is
+        that fork deadlocks on the s3dlio Tokio-live path."""
+        from mlpstorage_py.checkpointing.streaming_checkpoint import (
+            _writer_mp_context,
+        )
+        ctx = _writer_mp_context()
+        assert ctx.get_start_method() != 'fork', (
+            "the writer subprocess must not be forked from the parent "
+            "after s3dlio's Tokio runtime is live (#642)"
+        )


### PR DESCRIPTION
Fixes #642.

## Summary

`StreamingCheckpointing.save()` was forking its writer subprocess with `mp.get_context('fork')`. On the s3dlio object-storage path the parent has already started s3dlio's Tokio runtime via `ObjStoreLibStorage._preflight()` → `s3dlio.list()` by the time `save()` runs, so `fork()` copies parent mutex state without the threads holding those mutexes and the writer child futex-deadlocks on first s3dlio re-entry. All ranks stall at ~0% CPU right after `[Writer] Attached to N buffers`.

- Extract `_writer_mp_context()` at module scope, prefers `forkserver`, falls back to `spawn` only when forkserver is unavailable (Windows/macOS). `fork` is never used.
- `save()` now calls the helper instead of doing the choice inline.
- Rewrite the misleading pre-#642 comment that claimed fork was safe because the child creates fresh StorageWriter instances — true, but irrelevant: the child inherits the parent's mutex *state*, not just its code paths.

## Why `forkserver` over `spawn`

`spawn` re-imports `__main__` on the child, which the pre-#642 code comment records as the source of an OMPI MPI-rejoin hang (`OMPI_COMM_WORLD_*` inherited, rank tries to re-join the communicator). `forkserver` gets `spawn`'s "clean interpreter, no live Tokio" property without `spawn`'s `__main__` re-import.

## Test plan

- [x] Three new failing tests reproduce the missing helper on `main` (RED, commit `8d9cc8f`)
- [x] Fix turns them GREEN
- [x] Full unit + submission-checker suite: 3275 pass
- [x] Integration suite: 95 pass, 13 deselected (slow markers)
- [ ] CI green

## Notes on scope

- Version bump deferred: `main` is at 3.0.28, PR #648 already bumps to 3.0.29 and isn't merged yet. Whichever of my three open PRs (#648, #649, this) merges last should reconcile.
- Companion to #641 (read-path scheme reconstruction). Both were filed together after the same customer bring-up; both are write/read symmetry gaps but touch different files.