### PR TITLE
fix(#643): denylist per-rank/per-invocation launcher env vars

### DIFF
--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -1205,6 +1205,7 @@ _ENV_PREFIXES: Final[Tuple[str, ...]] = (
 # LIFE-04). Phase 5.1 will broaden this to other launchers
 # (.planning/todos/pending/phase-5.1-env-sysctl-fingerprint-audit.md).
 _ENV_RUNTIME_DENYLIST: Final[frozenset] = frozenset({
+    # Phase 5 UAT (LIFE-04) — original 7 entries.
     "OMPI_ARGV",
     "OMPI_FILE_LOCATION",
     "OMPI_MCA_ess_base_jobid",
@@ -1212,6 +1213,22 @@ _ENV_RUNTIME_DENYLIST: Final[frozenset] = frozenset({
     "OMPI_MCA_orte_jobfam_session_dir",
     "OMPI_MCA_orte_local_daemon_uri",
     "OMPI_MCA_orte_precondition_transports",
+    # Issue #643 — per-rank / per-invocation vars surfaced during
+    # multi-phase checkpointing bring-up. Without these, the
+    # environment fingerprint differs across separate mpirun
+    # invocations (e.g. checkpointing write phase → read phase) and
+    # SystemDriftError fires on legitimate re-runs. They also leak into
+    # the auto_generator client-stanza fingerprint, defeating
+    # `quantity: N` dedup across identically-configured clients.
+    "NCCL_DEBUG_FILE",
+    "OMPI_COMM_WORLD_RANK",
+    "OMPI_COMM_WORLD_LOCAL_RANK",
+    "OMPI_COMM_WORLD_NODE_RANK",
+    "OMPI_MCA_ess_base_vpid",
+    "OMPI_MCA_initial_wdir",
+    "OMPI_MCA_orte_ess_node_rank",
+    "OMPI_MCA_orte_node_regex",
+    "OMPI_MCA_orte_top_session_dir",
 })
 
 
@@ -2182,6 +2199,7 @@ _ENV_PREFIXES = ("AWS_", "STORAGE_", "OMPI_", "UCX_", "NCCL_")
 # / LIFE-04). Must match the module-level _ENV_RUNTIME_DENYLIST byte-for-byte
 # or TestEnvironmentMPIScriptParity will trip.
 _ENV_RUNTIME_DENYLIST = (
+    # Phase 5 UAT (LIFE-04) — original 7 entries.
     "OMPI_ARGV",
     "OMPI_FILE_LOCATION",
     "OMPI_MCA_ess_base_jobid",
@@ -2189,6 +2207,16 @@ _ENV_RUNTIME_DENYLIST = (
     "OMPI_MCA_orte_jobfam_session_dir",
     "OMPI_MCA_orte_local_daemon_uri",
     "OMPI_MCA_orte_precondition_transports",
+    # Issue #643 — per-rank / per-invocation launcher metadata.
+    "NCCL_DEBUG_FILE",
+    "OMPI_COMM_WORLD_RANK",
+    "OMPI_COMM_WORLD_LOCAL_RANK",
+    "OMPI_COMM_WORLD_NODE_RANK",
+    "OMPI_MCA_ess_base_vpid",
+    "OMPI_MCA_initial_wdir",
+    "OMPI_MCA_orte_ess_node_rank",
+    "OMPI_MCA_orte_node_regex",
+    "OMPI_MCA_orte_top_session_dir",
 )
 
 

--- a/tests/unit/test_cluster_collector.py
+++ b/tests/unit/test_cluster_collector.py
@@ -2927,6 +2927,85 @@ class TestEnvironmentRuntimeDenylist:
         assert "OMPI_MCA_hwloc_base_binding_policy" in names
 
 
+class TestEnvironmentRuntimeDenylistExpanded643:
+    """Issue #643: extension of the runtime-volatile launcher denylist.
+
+    Between the checkpointing write and read phases (two separate
+    ``mpirun`` invocations) mpirun injects per-rank / per-invocation
+    metadata that leaks into the environment fingerprint and trips
+    ``SystemDriftError`` even on a legitimate identical re-run. The
+    original Phase-5 denylist (see ``TestEnvironmentRuntimeDenylist``)
+    caught 7 vars; these tests pin the 9 additional vars that customer
+    bring-up runs surfaced.
+
+    Notably one is NCCL, not OMPI: ``NCCL_DEBUG_FILE`` is commonly set
+    to a per-rank template like ``/logs/nccl_$RANK.log`` and defeats
+    fingerprint stability the same way per-rank OMPI vars do.
+
+    Kept in a separate class from ``TestEnvironmentRuntimeDenylist`` so
+    the #643 expansion is documented and grepable; the underlying
+    exclusion mechanism (``_env_allowlist_match`` subtracting
+    ``_ENV_RUNTIME_DENYLIST``) is identical.
+    """
+
+    _RUNTIME_VOLATILE_VARS_ADDED_IN_643 = [
+        "NCCL_DEBUG_FILE",
+        "OMPI_COMM_WORLD_RANK",
+        "OMPI_COMM_WORLD_LOCAL_RANK",
+        "OMPI_COMM_WORLD_NODE_RANK",
+        "OMPI_MCA_ess_base_vpid",
+        "OMPI_MCA_initial_wdir",
+        "OMPI_MCA_orte_ess_node_rank",
+        "OMPI_MCA_orte_node_regex",
+        "OMPI_MCA_orte_top_session_dir",
+    ]
+
+    @pytest.mark.parametrize("varname", _RUNTIME_VOLATILE_VARS_ADDED_IN_643)
+    def test_var_excluded_from_collect_environment(self, monkeypatch, varname):
+        """Each newly-denylisted var must NOT appear in collect_environment
+        output even when live in ``os.environ`` (which is the state every
+        rank sees under ``mpirun``)."""
+        from mlpstorage_py.cluster_collector import collect_environment
+
+        _clear_env_allowlist_vars(monkeypatch)
+        monkeypatch.setenv(varname, "some-per-rank-value-12345")
+        out = collect_environment()
+        names = {e["name"] for e in out}
+        assert varname not in names, (
+            f"{varname} is a per-rank / per-invocation launcher variable "
+            "and must be excluded from the fingerprint to prevent spurious "
+            "SystemDriftError on legitimate re-runs (#643)."
+        )
+
+    @pytest.mark.parametrize("varname", _RUNTIME_VOLATILE_VARS_ADDED_IN_643)
+    def test_var_denied_by_env_allowlist_match(self, monkeypatch, varname):
+        """Name-level assertion at the allowlist boundary — decoupled from
+        the collect_environment machinery so a refactor that reshapes the
+        outer collector still surfaces a regression here."""
+        from mlpstorage_py.cluster_collector import _env_allowlist_match
+        assert _env_allowlist_match(varname) is False, (
+            f"{varname} must be denied by _env_allowlist_match (#643)."
+        )
+
+    def test_stable_ompi_vars_still_pass(self, monkeypatch):
+        """Guardrail: the expansion must not swallow the STABLE OMPI vars
+        that legitimately describe MPI configuration (rank count, binding
+        policy). Companion to ``TestEnvironmentRuntimeDenylist``'s
+        equivalent test but re-asserted here so this class is a
+        self-contained contract for the #643 expansion."""
+        from mlpstorage_py.cluster_collector import _env_allowlist_match
+        for stable in (
+            "OMPI_COMM_WORLD_SIZE",
+            "OMPI_COMM_WORLD_LOCAL_SIZE",
+            "OMPI_MCA_mpi_oversubscribe",
+            "OMPI_MCA_hwloc_base_binding_policy",
+        ):
+            assert _env_allowlist_match(stable) is True, (
+                f"{stable} is stable configuration and must survive the "
+                "#643 denylist expansion."
+            )
+
+
 class TestEnvironmentMPIScriptParity:
     """Pattern B (D-36): collect_environment + _env_allowlist_match +
     _mask_credential_id + _redact_secret live inline in MPI_COLLECTOR_SCRIPT.

--- a/tests/unit/test_cluster_collector.py
+++ b/tests/unit/test_cluster_collector.py
@@ -2700,7 +2700,12 @@ class TestEnvAllowlistMatch:
             ("AWS_REGION", True),
             ("STORAGE_BACKEND", True),
             ("STORAGE_URI_SCHEME", True),
-            ("OMPI_COMM_WORLD_RANK", True),
+            # OMPI_COMM_WORLD_SIZE is the stable rank-count var (a legitimate
+            # part of the fingerprint). OMPI_COMM_WORLD_RANK — the pre-#643
+            # representative here — is now denylisted because it's per-rank
+            # volatile; the #643 denylist coverage lives in
+            # TestEnvironmentRuntimeDenylistExpanded643.
+            ("OMPI_COMM_WORLD_SIZE", True),
             ("UCX_NET_DEVICES", True),
             ("NCCL_DEBUG", True),
             ("PATH", False),
@@ -2801,12 +2806,14 @@ class TestEnvironmentCollector:
 
         _clear_env_allowlist_vars(monkeypatch)
         monkeypatch.setenv("STORAGE_BACKEND", "s3dlio")
-        monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "0")
+        # OMPI_COMM_WORLD_SIZE (stable rank count) is the post-#643
+        # representative; OMPI_COMM_WORLD_RANK is now denylisted.
+        monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "8")
         monkeypatch.setenv("UCX_NET_DEVICES", "mlx5_0:1")
         monkeypatch.setenv("NCCL_DEBUG", "INFO")
         out = collect_environment()
         assert {"name": "STORAGE_BACKEND", "value": "s3dlio"} in out
-        assert {"name": "OMPI_COMM_WORLD_RANK", "value": "0"} in out
+        assert {"name": "OMPI_COMM_WORLD_SIZE", "value": "8"} in out
         assert {"name": "UCX_NET_DEVICES", "value": "mlx5_0:1"} in out
         assert {"name": "NCCL_DEBUG", "value": "INFO"} in out
 
@@ -3050,7 +3057,10 @@ class TestEnvironmentMPIScriptParity:
         )
         monkeypatch.setenv("AWS_REGION", "us-east-1")
         monkeypatch.setenv("STORAGE_BACKEND", "s3dlio")
-        monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "0")
+        # Post-#643: OMPI_COMM_WORLD_RANK is denylisted. Use the stable
+        # OMPI_COMM_WORLD_SIZE as the OMPI-prefix representative so the
+        # parity test still exercises a non-denylisted OMPI dispatch.
+        monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "8")
         monkeypatch.setenv("UCX_NET_DEVICES", "mlx5_0:1")
         monkeypatch.setenv("NCCL_DEBUG", "INFO")
 


### PR DESCRIPTION
Fixes #643.

## Summary

Extends `_ENV_RUNTIME_DENYLIST` from 7 → 16 entries. Both copies (module-level `frozenset` at `cluster_collector.py:1207` + MPI-script inline `tuple` at `:2184`) are updated identically; `TestEnvironmentMPIScriptParity` enforces the sync.

Added vars:
```
NCCL_DEBUG_FILE
OMPI_COMM_WORLD_RANK
OMPI_COMM_WORLD_LOCAL_RANK
OMPI_COMM_WORLD_NODE_RANK
OMPI_MCA_ess_base_vpid
OMPI_MCA_initial_wdir
OMPI_MCA_orte_ess_node_rank
OMPI_MCA_orte_node_regex
OMPI_MCA_orte_top_session_dir
```

All are per-rank or per-invocation launcher metadata. They leaked through the `OMPI_` / `NCCL_` allowlist prefixes and:
- broke the environment fingerprint across separate `mpirun` invocations (checkpointing write → read tripped `SystemDriftError` even on unchanged systems)
- leaked into `auto_generator._environment_signature`, defeating `quantity: N` client-stanza dedup (sibling of the sysctl-driven dedup failure in #647)

## What NOT added

`OMPI_COMM_WORLD_SIZE` and `OMPI_COMM_WORLD_LOCAL_SIZE` stay in the fingerprint — rank count is legitimate configuration to detect drift on.

## Test plan

- [x] New `TestEnvironmentRuntimeDenylistExpanded643` class: 18 RED assertions (9 vars × 2 boundaries — `collect_environment` and `_env_allowlist_match`) turn GREEN with the fix
- [x] Two pre-existing tests updated to use `OMPI_COMM_WORLD_SIZE` as the OMPI-prefix representative (the pre-#643 tests used `OMPI_COMM_WORLD_RANK`, which is now correctly denylisted)
- [x] `TestEnvironmentMPIScriptParity` still passes (both copies of the denylist match byte-for-byte)
- [x] Full unit + submission-checker + integration suite: 3386 pass, 13 deselected (slow markers)
- [ ] CI green

## Notes on scope

- Version bump deferred: `main` is at 3.0.28; PR #648 already bumps to 3.0.29 and isn't merged yet. This makes four open PRs (#648, #649, #650, this) — last to merge reconciles.
- Follow-up: `.planning/todos/pending/phase-5.1-env-sysctl-fingerprint-audit.md` covers broader launcher support (PMI/SLURM/PALS/HYDRA/PBS/LSF). This fix stays scoped to OpenMPI + NCCL because that's what customer bring-up surfaced; the todo file is where the systematic audit lives.