### PR TITLE
fix(#644): correct CAP-01 subset-mode math; extract shared helper

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -1020,37 +1020,68 @@ class CheckpointingBenchmark(DLIOBenchmark):
     # CAP-01 capacity-gate hooks (Phase 5 / Plan 05-03)
     # ------------------------------------------------------------------
 
-    def required_bytes_for_capacity_gate(self) -> int:
-        """Return total bytes needed for the checkpoint dataset (CAP-01).
+    def _checkpoint_gb_per_rank(self) -> list:
+        """Return per-rank checkpoint size in GiB for one checkpoint.
 
-        Mirrors the per-rank GiB math at ``CheckpointingBenchmark.datasize``
-        (dlio.py:593-625) WITHOUT the logger.debug/verbose calls so the
-        happy path stays silent per SC#6. The total is multiplied by
-        ``self.args.num_checkpoints_write`` because each checkpoint is
-        written in full to the destination.
+        Single source of truth for CAP-01's ``required_bytes_for_capacity_gate``
+        AND ``datasize``'s per-rank printout. Both callers previously
+        duplicated this math (the retired "A7 lock" discipline), and
+        both were subtly wrong for subset mode:
 
-        A7 lock: same math as datasize at dlio.py:593.
+        Issue #644 — the denominator must be the FULL-run rank count
+        (``ClosedGPUs`` for zero_level=3; ``ClosedGPUs`` for the
+        optimizer term and ``GPUpDP`` for the model term in
+        zero_level=1), not ``self.args.num_processes``. In subset mode
+        each rank owns the same slice it would own in the full run —
+        the total scales linearly with ``num_processes`` because fewer
+        representative ranks are writing, not because the per-rank
+        share shrinks. The old ``/ num_processes`` formula collapsed
+        for zero_level=3 to ``model + optimizer`` regardless of
+        ``num_processes``, blocking legitimate subset runs at CAP-01
+        with the full-mode required-bytes total.
+
+        Full CLOSED runs (``num_processes == ClosedGPUs``) are
+        unchanged because the two denominators are equal there.
         """
         min_procs, zero_level, GPUpDP, ClosedGPUs = LLM_ALLOWED_VALUES.get(self.args.model)
         model_gb, optimizer_gb = LLM_SIZE_BY_RANK.get(self.args.model)
         rank_gb = []
         for rank in range(self.args.num_processes):
-            rank_gb.append(0)
             if zero_level == 1:
-                rank_gb[rank] = optimizer_gb / self.args.num_processes
+                # Optimizer sharded across all ClosedGPUs ranks; each
+                # subset rank writes its own 1/ClosedGPUs share.
+                share = optimizer_gb / ClosedGPUs
+                # Model written only by the first DP instance (first
+                # GPUpDP ranks). In subset mode num_processes < GPUpDP
+                # so every subset rank is a first-DP rank.
                 if rank < GPUpDP:
-                    rank_gb[rank] += model_gb / GPUpDP
+                    share += model_gb / GPUpDP
+                rank_gb.append(share)
             elif zero_level == 3:
-                rank_gb[rank] = (model_gb + optimizer_gb) / self.args.num_processes
+                # Model + optimizer fully sharded across all ClosedGPUs
+                # ranks; each subset rank writes its own share.
+                rank_gb.append((model_gb + optimizer_gb) / ClosedGPUs)
             else:
-                raise ValueError("Invalid zero_level")
-        total_bytes = int(sum(rank_gb) * 1024**3 * self.args.num_checkpoints_write)
-        return total_bytes
+                raise ValueError(f"Invalid zero_level: {zero_level}")
+        return rank_gb
+
+    def required_bytes_for_capacity_gate(self) -> int:
+        """Return total bytes needed for the checkpoint dataset (CAP-01).
+
+        Sums ``_checkpoint_gb_per_rank`` and multiplies by
+        ``num_checkpoints_write`` because each checkpoint is written in
+        full to the destination. Silent on the happy path per SC#6 —
+        the shared helper does no logging.
+        """
+        rank_gb = self._checkpoint_gb_per_rank()
+        return int(sum(rank_gb) * 1024**3 * self.args.num_checkpoints_write)
 
     def _capacity_gate_destination(self):
         """Return the checkpoint destination as
-        ``os.path.join(args.checkpoint_folder, args.model)`` — mirrors the
-        join at dlio.py:562 in ``add_checkpoint_params`` (A7 lock).
+        ``os.path.join(args.checkpoint_folder, args.model)`` — mirrors
+        the join in ``add_checkpoint_params`` where DLIO is told to
+        write. Kept in step by convention; a future refactor could
+        share a helper if a third caller appears.
 
         If ``args.checkpoint_folder`` is None or empty, returns ``None`` so
         the ``_pre_execution_gate`` A8 escape hatch fires cleanly. The
@@ -1086,32 +1117,22 @@ class CheckpointingBenchmark(DLIOBenchmark):
         # CAP-01: fail fast BEFORE the rank-by-rank size table prints.
         self._pre_execution_gate()
         self.logger.verbose(f'Running datasize for {self.args.model}...')
-        # Calculate the total writes per rank which equates to memory required per rank
-        # If zero_level is 1, then rank 0 writes the entire model,
-        # If zero_level is 3, then the model is sharded across all ranks
-        min_procs, zero_level, GPUpDP, ClosedGPUs = LLM_ALLOWED_VALUES.get(self.args.model)
         model_gb, optimizer_gb = LLM_SIZE_BY_RANK.get(self.args.model)
-        rank_gb = []
+        self.logger.verbose(
+            f'Model & optimizer size: {model_gb:.2f}GiB, {optimizer_gb:.2f}GiB'
+        )
+        # Per-rank size math lives in _checkpoint_gb_per_rank (single
+        # source of truth shared with required_bytes_for_capacity_gate;
+        # subset-mode fix is in #644).
+        rank_gb = self._checkpoint_gb_per_rank()
 
-        self.logger.verbose(f'Model & optimizer size: {model_gb:.2f}GiB, {optimizer_gb:.2f}GiB')
-        for rank in range(self.args.num_processes):
-            rank_gb.append(0)
-            if zero_level == 1:
-                self.logger.debug("Optimizer is written by all ranks, but only the ranks on the first DP instance write the model")
-                rank_gb[rank] = optimizer_gb / self.args.num_processes
-                if rank < GPUpDP:
-                    rank_gb[rank] += model_gb / GPUpDP
-                    self.logger.debug(f'First DP: rank-{rank} write model: {rank_gb[rank]:.2f}GiB')
-            elif zero_level == 3:
-                rank_gb[rank] = (model_gb + optimizer_gb) / self.args.num_processes
-                self.logger.debug(f'Rank {rank} writes portion of model and optimizer: {rank_gb[rank]:.2f}GiB')
-            else:
-                self.logger.error(f'Invalid zero_level: {zero_level}')
-                raise ValueError("Invalid zero_level")
-
-        rank_string = "\n\t".join(f"Rank {rank}: {rank_gb[rank]:.2f}GiB" for rank in range(self.args.num_processes))
-
+        rank_string = "\n\t".join(
+            f"Rank {rank}: {rank_gb[rank]:.2f}GiB"
+            for rank in range(self.args.num_processes)
+        )
         self.logger.result(f'Total GiB required per rank:\n\t{rank_string}')
-        self.logger.result(f'Total GiB required for all ranks: {sum(rank_gb):.2f}GiB')
+        self.logger.result(
+            f'Total GiB required for all ranks: {sum(rank_gb):.2f}GiB'
+        )
 
 

--- a/tests/unit/test_capacity_gate.py
+++ b/tests/unit/test_capacity_gate.py
@@ -656,11 +656,17 @@ class TestTrainingBenchmarkRequiredBytes:
 
 
 class TestCheckpointingBenchmarkRequiredBytes:
-    """A7 destination join + sum(rank_gb) * GiB * num_checkpoints_write."""
+    """Destination join + sum(rank_gb) * GiB * num_checkpoints_write.
+
+    The per-rank size math itself is covered by
+    ``tests/unit/test_checkpoint_capacity_gate_subset.py`` (issue #644);
+    this test only exercises the aggregation step at the
+    ``required_bytes_for_capacity_gate`` seam.
+    """
 
     def test_returns_sum_rank_gb_times_gib_times_num_checkpoints_write(self):
         from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
-        from mlpstorage_py.config import LLM_ALLOWED_VALUES, LLM_SIZE_BY_RANK
+        from mlpstorage_py.config import LLM_SIZE_BY_RANK
 
         bm = MagicMock(spec=CheckpointingBenchmark)
         bm.args = SimpleNamespace(
@@ -670,10 +676,16 @@ class TestCheckpointingBenchmarkRequiredBytes:
             checkpoint_folder="/cp",
         )
         bm.logger = MagicMock()
+        # Delegate the per-rank helper to the real class method so the
+        # aggregation contract is exercised end-to-end (spec=... would
+        # otherwise stub _checkpoint_gb_per_rank to an empty iterable).
+        bm._checkpoint_gb_per_rank = (
+            lambda: CheckpointingBenchmark._checkpoint_gb_per_rank(bm)
+        )
 
-        # llama3-8b: ZeroLevel=3 (sharded across all ranks), model=15, optimizer=90
-        # rank_gb[i] = (15 + 90) / 8 = 13.125 for each of 8 ranks
-        # sum = 105.0; expected = int(105.0 * 1024**3 * 3) = 338368201523 (approx)
+        # llama3-8b: ClosedGPUs=8, num_processes=8 (full mode) so
+        # per_rank = (model + optimizer) / ClosedGPUs is unaffected by
+        # #644's subset fix. Expected = sum(per_rank) * 1024**3 * 3.
         model_gb, optimizer_gb = LLM_SIZE_BY_RANK["llama3-8b"]
         per_rank = (model_gb + optimizer_gb) / 8
         expected = int(per_rank * 8 * 1024**3 * 3)

--- a/tests/unit/test_checkpoint_capacity_gate_subset.py
+++ b/tests/unit/test_checkpoint_capacity_gate_subset.py
@@ -1,0 +1,156 @@
+"""Tests for issue #644 — CAP-01 capacity-gate math in checkpointing subset mode.
+
+``CheckpointingBenchmark.required_bytes_for_capacity_gate`` (and the
+duplicated ``datasize`` printout) currently uses ``self.args.num_processes``
+as the divisor in the per-rank checkpoint-size math. That formula was
+written assuming ``num_processes == ClosedGPUs`` (full CLOSED run); in
+subset mode (``--num-processes < ClosedGPUs``), the per-rank share
+should still be computed against the full-run denominator ``ClosedGPUs``
+(zero_level=3) or ``ClosedGPUs`` for the optimizer term / ``GPUpDP`` for
+the model term (zero_level=1). The bug over-counts by a factor of
+``ClosedGPUs / num_processes`` and blocks legitimate subset runs at
+CAP-01.
+
+Reporter's specific case (llama3-70b, 8 procs, 10 checkpoints on a
+6.5 TB drive): current math reports ~9.1 TB required (blocks), correct
+math reports ~1.14 TB (would pass).
+
+Tests hit the arithmetic through the public
+``required_bytes_for_capacity_gate`` API and construct the bench via
+``__new__`` to bypass ``__init__``'s DLIO config loading (irrelevant to
+the byte-count math).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _make_bench(model: str, num_processes: int, num_ckpts: int):
+    """Construct a bare CheckpointingBenchmark whose only live state is
+    the args the size math consults. ``__new__`` bypasses ``__init__``
+    (which loads YAML DLIO configs, applies object-storage params, etc.)
+    since none of that matters to the per-rank GiB arithmetic."""
+    from mlpstorage_py.benchmarks.dlio import CheckpointingBenchmark
+    bench = CheckpointingBenchmark.__new__(CheckpointingBenchmark)
+    bench.args = SimpleNamespace(
+        model=model,
+        num_processes=num_processes,
+        num_checkpoints_write=num_ckpts,
+    )
+    return bench
+
+
+def _expected_bytes(model: str, num_processes: int, num_ckpts: int) -> int:
+    """Reference implementation of the CORRECT subset-aware math.
+    Reproduces the formula the fix should install; tests compare against
+    this rather than a hardcoded byte count so future model additions
+    don't require test edits."""
+    from mlpstorage_py.config import LLM_ALLOWED_VALUES, LLM_SIZE_BY_RANK
+    min_procs, zero_level, GPUpDP, ClosedGPUs = LLM_ALLOWED_VALUES[model]
+    model_gb, opt_gb = LLM_SIZE_BY_RANK[model]
+    rank_gb = []
+    for rank in range(num_processes):
+        if zero_level == 3:
+            rank_gb.append((model_gb + opt_gb) / ClosedGPUs)
+        elif zero_level == 1:
+            share = opt_gb / ClosedGPUs
+            if rank < GPUpDP:
+                share += model_gb / GPUpDP
+            rank_gb.append(share)
+        else:
+            raise ValueError(zero_level)
+    return int(sum(rank_gb) * 1024**3 * num_ckpts)
+
+
+class TestSubsetModeCapacityGate:
+    """Subset runs must scale required_bytes to ``num_processes /
+    ClosedGPUs`` of the full-mode total. RED on main because the current
+    formula uses ``/ num_processes`` in the denominator and yields the
+    full-mode total regardless of subset size."""
+
+    def test_llama3_70b_subset_reporter_case(self):
+        """Reporter's exact reproducer: 8 procs, 10 checkpoints. Correct
+        answer is ~1.14 TB; buggy answer is ~9.1 TB. This test locks the
+        byte count exactly so the regression is grep-able."""
+        bench = _make_bench("llama3-70b", num_processes=8, num_ckpts=10)
+        got = bench.required_bytes_for_capacity_gate()
+        want = _expected_bytes("llama3-70b", 8, 10)
+        assert got == want, (
+            f"llama3-70b subset (8 procs, 10 ckpts): got {got:,} "
+            f"({got / 1024**4:.2f} TiB), want {want:,} "
+            f"({want / 1024**4:.2f} TiB)"
+        )
+        # Sanity: the correct value must comfortably fit on the
+        # reporter's 6.5 TiB drive; a regression that reintroduces
+        # full-mode math would clear the 6.5 TiB threshold.
+        assert got < 2 * 1024**4, (
+            f"llama3-70b subset must not exceed 2 TiB; got {got:,}"
+        )
+
+    def test_llama3_405b_subset_zero_level_1(self):
+        """zero_level=1 subset (llama3-405b, 8 procs). Exercises the
+        second buggy branch — optimizer term uses ``/ num_processes``
+        instead of ``/ ClosedGPUs``. All 8 subset ranks are < GPUpDP=256
+        so all write the model term."""
+        bench = _make_bench("llama3-405b", num_processes=8, num_ckpts=10)
+        got = bench.required_bytes_for_capacity_gate()
+        want = _expected_bytes("llama3-405b", 8, 10)
+        assert got == want, (
+            f"llama3-405b subset (8 procs, 10 ckpts): got {got:,}, "
+            f"want {want:,}"
+        )
+
+    def test_llama3_1t_subset_zero_level_1(self):
+        """zero_level=1 subset on the largest model (llama3-1t, 8 procs,
+        ClosedGPUs=1024)."""
+        bench = _make_bench("llama3-1t", num_processes=8, num_ckpts=10)
+        got = bench.required_bytes_for_capacity_gate()
+        want = _expected_bytes("llama3-1t", 8, 10)
+        assert got == want
+
+
+class TestFullModeCapacityGateUnchanged:
+    """Full CLOSED runs (num_processes == ClosedGPUs) must be
+    unchanged. The fix should be a no-op in this regime because
+    ``1/ClosedGPUs == 1/num_processes`` when the two are equal. These
+    are GREEN on main and must stay GREEN after the fix — proves no
+    full-mode regression."""
+
+    @pytest.mark.parametrize(
+        "model,full_procs",
+        [
+            ("llama3-8b", 8),
+            ("llama3-70b", 64),
+            ("llama3-405b", 512),
+            ("llama3-1t", 1024),
+        ],
+    )
+    def test_full_mode_bytes_unchanged(self, model, full_procs):
+        bench = _make_bench(model, num_processes=full_procs, num_ckpts=10)
+        got = bench.required_bytes_for_capacity_gate()
+        want = _expected_bytes(model, full_procs, 10)
+        assert got == want, (
+            f"{model} full-mode ({full_procs} procs): got {got:,}, "
+            f"want {want:,}"
+        )
+
+
+class TestSubsetScalingInvariant:
+    """Cross-check the scaling relationship directly: subset bytes must
+    equal full-mode bytes × (num_processes / ClosedGPUs) for zero_level=3.
+    RED on main because subset returns == full."""
+
+    def test_llama3_70b_subset_is_one_eighth_of_full(self):
+        subset = _make_bench("llama3-70b", num_processes=8, num_ckpts=10)
+        full = _make_bench("llama3-70b", num_processes=64, num_ckpts=10)
+        subset_bytes = subset.required_bytes_for_capacity_gate()
+        full_bytes = full.required_bytes_for_capacity_gate()
+        # 8 / 64 = 1/8; subset should be one-eighth of full.
+        assert subset_bytes * 8 == full_bytes, (
+            f"llama3-70b subset (8) × 8 must equal full (64): "
+            f"subset={subset_bytes:,}, full={full_bytes:,}, "
+            f"ratio={full_bytes / subset_bytes if subset_bytes else 'inf'}"
+        )


### PR DESCRIPTION
Fixes #644.

## Summary

`CheckpointingBenchmark.required_bytes_for_capacity_gate` (and its code-copy in `datasize`) used `self.args.num_processes` as the denominator in the per-rank size math. For `zero_level=3` the formula collapses to `model_gb + optimizer_gb` regardless of `num_processes` — so subset runs on llama3-70b / -405b / -1t reported the FULL-mode required-bytes total and CAP-01 blocked legitimate runs.

Reporter's case (llama3-70b, 8 procs, 10 ckpts):
- old: 8.90 TiB → blocks on the reporter's 6.5 TiB drive
- new: 1.11 TiB → fits with headroom

## Fix

Extract `_checkpoint_gb_per_rank` as the single source of truth for the per-rank GiB math. Correct denominators:
- `zero_level=3`: `(model + optimizer) / ClosedGPUs`
- `zero_level=1`: `optimizer / ClosedGPUs` for all ranks, plus `model / GPUpDP` for `rank < GPUpDP`

Both `required_bytes_for_capacity_gate` (CAP-01) and `datasize` (per-rank printout) now delegate to the helper. Full-mode runs (`num_processes == ClosedGPUs`) are unchanged because the two denominators are equal there.

The retired "A7 lock" comment discipline turned out to already be rotting — its cross-reference (`dlio.py:593`) pointed at a `--config-dir=` string, not `datasize`. Shared code is the invariant now.

## Test plan

- [x] `test_checkpoint_capacity_gate_subset.py` (new): 4 RED tests reproduce the bug on `main` (subset cases + subset-should-be-1/8-of-full scaling invariant); 4 GREEN full-mode invariants prove no regression to full CLOSED runs
- [x] Reporter's exact case is a locked byte-count fixture — grep-able regression
- [x] `TestCheckpointingBenchmarkRequiredBytes` updated to delegate the new helper through to the real class method (spec=... would otherwise stub it empty)
- [x] Full unit + submission-checker + integration suite: 3375 pass, 13 deselected (slow markers)
- [ ] CI green

## Notes on scope

- Version bump deferred: `main` is at 3.0.28; PR #648 already bumps to 3.0.29 and isn't merged yet. Five open PRs now (#648, #649, #650, #652, this) — last to merge reconciles.
- Not related to #627 (training CAP-01 exemption). Checkpointing's disk-space math IS meaningful — this fix makes it correct rather than exempting it.