### PR TITLE
fix(#653): allow N-part rule IDs in rules_coverage + violation-log parsers

### DIFF
--- a/mlpstorage_py/submission_checker/tools/rules_coverage.py
+++ b/mlpstorage_py/submission_checker/tools/rules_coverage.py
@@ -47,11 +47,13 @@ log = logging.getLogger("rules_coverage")
 
 
 # D-A3: locked regex for Rules.md §2/§3/§4/§5/§6 ID enumeration.
-# §5 covers vectordb (VdbCheck, Phase 4); §6 reserved for kvcache rules
-# landing soon. Extending the character class preemptively avoids
-# repeating Phase 4's miss where the regex shipped behind the actual
-# Rules.md scope.
-_RULE_ID_PATTERN = re.compile(r"^([23456]\.\d+\.\d+)\.\s+\*\*([a-zA-Z][a-zA-Z0-9]+)\*\*")
+# §5 covers vectordb (VdbCheck, Phase 4); §6 covers kvcache (PR #602),
+# which introduces 4-part IDs (e.g. 6.3.1.1, 6.3.4.5). The dotted-tail
+# group `(?:\.\d+)+` accepts 3-, 4-, or deeper nested IDs; all consumers
+# (STUB_COVERAGE lookup, unmapped-set membership, CLI table rendering)
+# treat the ID as an opaque string, so the relaxation is a strict
+# superset of the prior 3-part-only behavior. See storage#653.
+_RULE_ID_PATTERN = re.compile(r"^([23456]\.\d+(?:\.\d+)+)\.\s+\*\*([a-zA-Z][a-zA-Z0-9]+)\*\*")
 
 
 def _default_rules_md_path() -> str:

--- a/mlpstorage_py/tests/test_definition_of_done.py
+++ b/mlpstorage_py/tests/test_definition_of_done.py
@@ -126,7 +126,7 @@ def _extract_error_rule_ids(combined: str) -> set[str]:
     for line in combined.splitlines():
         if "ERROR]" not in line:
             continue
-        m = re.search(r"\[([234]\.\d+\.\d+) ", line)
+        m = re.search(r"\[([23456]\.\d+(?:\.\d+)+) ", line)
         if m:
             ids.add(m.group(1))
     return ids
@@ -147,7 +147,7 @@ def _extract_error_rule_id_path_pairs(combined: str) -> list[tuple[str, str]]:
     containing a colon).
     """
     pairs: list[tuple[str, str]] = []
-    pattern = re.compile(r"\[([234]\.\d+\.\d+) [a-zA-Z][a-zA-Z0-9]*\] (.+?): ")
+    pattern = re.compile(r"\[([23456]\.\d+(?:\.\d+)+) [a-zA-Z][a-zA-Z0-9]*\] (.+?): ")
     for line in combined.splitlines():
         if "ERROR]" not in line:
             continue

--- a/mlpstorage_py/tests/test_definition_of_done.py
+++ b/mlpstorage_py/tests/test_definition_of_done.py
@@ -158,6 +158,74 @@ def _extract_error_rule_id_path_pairs(combined: str) -> list[tuple[str, str]]:
 
 
 # ---------------------------------------------------------------------------
+# Extractor regex unit tests (storage#653 follow-up)
+# ---------------------------------------------------------------------------
+#
+# The two extractor helpers above parse violation log lines emitted by
+# BaseCheck.log_violation. Before storage#653, the regex tail was
+# ``[234]\.\d+\.\d+`` — restricted to §2/§3/§4 and 3-part IDs. That
+# silently drops:
+#
+# * §5 (VDB, live since Phase 4) violations — a real bug: the good/bad
+#   fixture assertions would miss any vdb_checks.py violation entirely.
+# * §6 (KVCache, per PR #602) 3-part violations (6.4.x, 6.5.x, 6.6.x).
+# * Any 4-part ID such as PR #602's §6.3.x.x rules (6.3.1.1 etc.).
+#
+# The relaxed regex ``[23456]\.\d+(?:\.\d+)+`` mirrors the rules_coverage
+# relaxation in the same series and pins parity between violation-log
+# parsing and Rules.md discovery.
+
+
+class TestExtractorRegexParity:
+    """Regression guard for storage#653 follow-up.
+
+    Unit-tests the module-level extractors against synthetic log lines so
+    the fix is exercised without spinning up the full validator pipeline.
+    Uses the locked BaseCheck.log_violation format
+    ``[<rule_id> <rule_name>] <path>: <msg>`` per checks/base.py:36.
+    """
+
+    _LINE_FMT = (
+        "2026-07-02 12:00:00 base.py:36 ERROR] "
+        "[{rule_id} {rule_name}] /path/to/results: message"
+    )
+
+    def _line(self, rule_id: str, rule_name: str) -> str:
+        return self._LINE_FMT.format(rule_id=rule_id, rule_name=rule_name)
+
+    def test_extract_ids_captures_sections_5_and_6(self):
+        """Character-class widening — pre-fix, [234] dropped §5 and §6."""
+        combined = "\n".join([
+            self._line("5.3.4", "vdbMetricsReported"),
+            self._line("6.6.1", "kvcacheClosedImmutable"),
+        ])
+        assert _extract_error_rule_ids(combined) == {"5.3.4", "6.6.1"}
+
+    def test_extract_ids_captures_four_part_id(self):
+        """Dotted-tail relaxation — pre-fix, `\\.\\d+\\.\\d+` dropped 4-part."""
+        combined = self._line("6.3.1.1", "kvcacheFixedWorkloadPerOption")
+        assert _extract_error_rule_ids(combined) == {"6.3.1.1"}
+
+    def test_extract_pairs_captures_sections_5_and_6(self):
+        """Same character-class widening on the (rule_id, path) extractor."""
+        combined = "\n".join([
+            self._line("5.3.4", "vdbMetricsReported"),
+            self._line("6.6.1", "kvcacheClosedImmutable"),
+        ])
+        assert _extract_error_rule_id_path_pairs(combined) == [
+            ("5.3.4", "/path/to/results"),
+            ("6.6.1", "/path/to/results"),
+        ]
+
+    def test_extract_pairs_captures_four_part_id(self):
+        """Same dotted-tail relaxation on the (rule_id, path) extractor."""
+        combined = self._line("6.3.1.1", "kvcacheFixedWorkloadPerOption")
+        assert _extract_error_rule_id_path_pairs(combined) == [
+            ("6.3.1.1", "/path/to/results"),
+        ]
+
+
+# ---------------------------------------------------------------------------
 # Good-fixture test class (D-E4 / ROADMAP success criterion #3)
 # ---------------------------------------------------------------------------
 

--- a/mlpstorage_py/tests/test_rules_coverage.py
+++ b/mlpstorage_py/tests/test_rules_coverage.py
@@ -114,7 +114,7 @@ class TestRulesCoverageReconciliation:
         """
         fake_md = tmp_path / "fake.md"
         original = RULES_MD_PATH.read_text(encoding="utf-8")
-        # Locked regex: ^([23456]\.\d+\.\d+)\.\s+\*\*([a-zA-Z][a-zA-Z0-9]+)\*\*
+        # Locked regex: ^([23456]\.\d+(?:\.\d+)+)\.\s+\*\*([a-zA-Z][a-zA-Z0-9]+)\*\*
         fake_md.write_text(
             original + "\n2.1.99. **fakeRule** -- placeholder for testing\n",
             encoding="utf-8",

--- a/mlpstorage_py/tests/test_rules_coverage.py
+++ b/mlpstorage_py/tests/test_rules_coverage.py
@@ -126,6 +126,27 @@ class TestRulesCoverageReconciliation:
             )
         )
 
+    def test_inject_four_part_unmapped_id_returns_in_unmapped_set(self, tmp_path):
+        """4-part IDs (e.g., 6.3.1.1) must be discovered by the regex.
+
+        Regression guard for storage#653: the original regex only accepted
+        3-part IDs, so PR #602's twelve §6.3.x.x rules were silently skipped
+        — undiscovered rather than unmapped, so the coverage gate could
+        never enforce them. The relaxed regex accepts N-part IDs; this test
+        pins that behavior for the smallest interesting case.
+        """
+        fake_md = tmp_path / "fake.md"
+        original = RULES_MD_PATH.read_text(encoding="utf-8")
+        fake_md.write_text(
+            original + "\n6.3.99.1. **fakeFourPartRule** -- placeholder for testing\n",
+            encoding="utf-8",
+        )
+        result = reconcile(rules_md_path=str(fake_md))
+        assert "6.3.99.1" in result["unmapped"], (
+            "Expected 6.3.99.1 in unmapped set (4-part IDs must be "
+            "discoverable), got {}".format(sorted(result["unmapped"]))
+        )
+
     def test_baseline_no_stale_entries(self):
         """At Phase 3 land time both registries are empty → no stale entries.
 


### PR DESCRIPTION
Closes #653.

## Summary

Two regexes assumed 3-part Rules.md IDs (`X.Y.Z`) and would silently drop the 4-part IDs (`X.Y.Z.W`) that PR #602 adds under §6.3. This PR relaxes both.

- **`rules_coverage.py:54`** — discovery regex used by the CI `test_rules_coverage.py` gate. Tail `\.\d+\.\d+` → `\.\d+(?:\.\d+)+`. Downstream consumers (`STUB_COVERAGE` lookup, unmapped-set membership, CLI table rendering) all treat the ID as an opaque string, so the relaxation is a strict superset of the prior 3-part-only behavior.
- **`test_definition_of_done.py:129,150`** — the two violation-log-line extractors (`_extract_error_rule_ids`, `_extract_error_rule_id_path_pairs`). Same tail relaxation, plus character-class widening `[234]` → `[23456]` so §5 (VDB) and §6 (KVCache) IDs parse in addition to 4-part IDs.

## Framing correction

My RED-commit body for the second half (`test(#653): RED — violation-log extractors drop §5/§6 and 4-part IDs`) called the `[234]` limit a "live regression, not a speculative future concern." That was wrong. On closer inspection:

- §5 (VDB) `@rule` methods are real and well-tested in isolation (17 bindings in `vdb_checks.py`, 41 tests passing in `test_vdb_checks.py`).
- But `mlpstorage_py/tests/conftest.py::build_submission` — the fixture the DoD subprocess runs against — never creates a `vector_database/` or `kv_cache/` subtree, so `MODE_TO_CHECKERS` never routes to `VdbCheck` / `KVCacheCheck`, so no §5 violation ever reaches the extractor.
- The `[234]` limit is therefore a **latent** blind spot, not an **active** regression. This PR still fixes it prophylactically, but the underlying fixture-coverage gap is filed as #655 (larger scope: extend `build_submission` with vector_database/kv_cache subtrees so the DoD path exercises those checkers end-to-end).

Also flagged in #655: `vdb_checks.py:150-155` `_iter_run_files` docstring is stale — it describes "Phase 4 land time" behavior, but #612 has since added explicit `run_files` population for both `kv_cache` and `vector_database` at `loader.py:198-199` and `224-225`. Small comment cleanup, mentioned in the issue as an ancillary fix.

## Follow-up not in this PR

- #655 — extend `build_submission` with vdb / kv_cache subtrees + matching `TestDefinitionOfDone*` cases so the fixture-coverage gap closes.
- PR #602 — needs a small companion PR on `main` to populate `coverage_mapping.py` for the 19 new §6 rule IDs once this lands (the CI test in #602 was previously listing 7 unmapped IDs; after #653 lands and the coverage tool discovers the twelve §6.3.x.x 4-part IDs too, that list will be 19).

## Test plan

Pre-existing 4-suite parallel sweep (tests/, mlpstorage_py/tests/, vdb_benchmark/tests/, kv_cache_benchmark/tests/) — all green:

- \`tests/\` — 2552 passed
- \`mlpstorage_py/tests/\` — 816 passed (was 812; +5 new tests: one 4-part case in \`test_rules_coverage.py\`, four in \`test_definition_of_done.py::TestExtractorRegexParity\`)
- \`vdb_benchmark/tests/\` — 155 passed
- \`kv_cache_benchmark/tests/\` — 238 passed
- Total: **3761 passed, 0 failed**

TDD RED-first pattern preserved across four commits:

- \`9d685bc test(#653): RED — rules_coverage regex silently skips 4-part IDs\`
- \`9921a46 fix(#653): allow N-part IDs in rules_coverage discovery regex\`
- \`56026ff test(#653): RED — violation-log extractors drop §5/§6 and 4-part IDs\`
- \`34977f4 fix(#653): allow §5/§6 and N-part IDs in violation-log extractors\`

Each RED commit was verified to fail on the pre-fix regex; each GREEN commit was verified to pass and to leave the full 4-suite sweep clean.