### PR TITLE
fix(#655): add vector_database + kv_cache subtrees to DoD fixture

### DIFF
--- a/mlpstorage_py/submission_checker/checks/vdb_checks.py
+++ b/mlpstorage_py/submission_checker/checks/vdb_checks.py
@@ -147,12 +147,14 @@ class VdbCheck(BaseCheck):
     def _iter_run_files(self):
         """Yield run-summary tuples or empty iterable when the loader did not populate them.
 
-        Phase 4 land time: ``Loader.load()`` only fills ``run_files`` /
-        ``datagen_files`` for ``mode == "training"``; the ``else`` branch
-        fills ``checkpoint_files`` for everything else. For ``vector_database``
-        leaves this means ``run_files`` is ``None`` (the dataclass default).
-        Rule methods consume this iterator instead of touching ``run_files``
-        directly so they degrade to an empty walk without crashing.
+        Post-#612: ``Loader.load()`` fills ``run_files`` / ``datagen_files``
+        for ``mode == "vector_database"`` (loader.py:224-225) and for
+        ``mode == "kv_cache"`` (loader.py:198-199). This guard remains as a
+        defensive walk in case a future loader path or a test-time
+        ``SubmissionLogs`` fake leaves the field ``None`` (the dataclass
+        default) — rule methods can then consume this iterator instead of
+        touching ``run_files`` directly and degrade to an empty walk
+        without crashing.
         """
         run_files = self.submissions_logs.run_files
         if not run_files:

--- a/mlpstorage_py/tests/conftest.py
+++ b/mlpstorage_py/tests/conftest.py
@@ -430,6 +430,15 @@ def build_submission(tmp_path, **overrides) -> Path:
     run_data_dir = overrides.pop("run_data_dir", None)
     run_results_dir = overrides.pop("run_results_dir", None)
 
+    # storage#655: DoD fixture-coverage kwargs for vector_database + kv_cache.
+    # * include_vdb (bool)                       — adds vector_database/milvus/DISKANN/…
+    # * include_kv_cache (bool)                  — adds kv_cache/llama3.1-8b/…
+    # * vdb_missing_metric_field (str | None)    — pops the named field from the
+    #   vdb run summary.json to trip 5.3.4 vdbMetricsReported (bad-fixture knob).
+    include_vdb = overrides.pop("include_vdb", False)
+    include_kv_cache = overrides.pop("include_kv_cache", False)
+    vdb_missing_metric_field = overrides.pop("vdb_missing_metric_field", None)
+
     # Sealed-enum guard — any leftover key is unknown
     if overrides:
         raise TypeError(f"unknown override: {sorted(overrides)}")
@@ -787,6 +796,137 @@ def build_submission(tmp_path, **overrides) -> Path:
 
             if wrong_checkpointing_workload:
                 (chkpt_path / wrong_checkpointing_workload).mkdir()
+
+            # ---------------------------------------------------------------
+            # vector_database/<engine>/<index>/{datagen,run}/<ts>/  (storage#655)
+            # ---------------------------------------------------------------
+            #
+            # Loader shape per loader.py:207-238 — yields one SubmissionLogs
+            # per (engine, index) pair with LoaderMetadata.folder pointing at
+            # the index dir. VdbCheck's rule methods consume the resulting
+            # run_files / datagen_files iterators.
+            #
+            # Content is §5-conformant per test_vdb_checks.py::_summary_run
+            # and ::_summary_datagen so the good-fixture assertion (no §5
+            # rule tripped) holds.  vdb_missing_metric_field pops a named
+            # field from run summary.json to engineer 5.3.4 vdbMetricsReported.
+            if include_vdb:
+                vdb_path = sys_results / "vector_database"
+                vdb_path.mkdir()
+                engine_path = vdb_path / "milvus"
+                engine_path.mkdir()
+                index_path = engine_path / "DISKANN"
+                index_path.mkdir()
+
+                vdb_run_summary = {
+                    "num_vectors": 1_000_000,
+                    "dimension": 128,
+                    "index_type": "DISKANN",
+                    "recall": 0.95,
+                    "throughput_qps": 1000.0,
+                    "total_time_seconds": 60.0,
+                    "query_count": 60_000,
+                    "mean_latency_ms": 1.0,
+                    "p95_latency_ms": 2.0,
+                    "p99_latency_ms": 3.0,
+                    "p999_latency_ms": 4.0,
+                    "database": {"database": "milvus"},
+                }
+                if vdb_missing_metric_field is not None:
+                    vdb_run_summary.pop(vdb_missing_metric_field, None)
+
+                vdb_datagen_summary = {
+                    "num_vectors": 1_000_000,
+                    "dimension": 128,
+                    "index_type": "DISKANN",
+                    "inserted_vectors": 1_000_000,
+                }
+                vdb_meta = {
+                    "benchmark_type": "vector_database",
+                    "model": "DISKANN",
+                    "args": {
+                        "storage_root": "/vdb/data",
+                        "results_dir": "/vdb/results",
+                        "model": "DISKANN",
+                    },
+                    "override_parameters": {},
+                }
+
+                vdb_datagen_dir = index_path / "datagen"
+                vdb_datagen_dir.mkdir()
+                vdb_dg_ts = vdb_datagen_dir / "20250113_130000"
+                vdb_dg_ts.mkdir()
+                (vdb_dg_ts / "summary.json").write_text(
+                    json.dumps(vdb_datagen_summary), encoding="utf-8"
+                )
+                (vdb_dg_ts / "metadata.json").write_text(
+                    json.dumps(vdb_meta), encoding="utf-8"
+                )
+
+                # 5.3.1 vdbRunCount requires exactly 5 run timestamps.
+                # 5.4.2 vdbFilesystemCheck reads a CAP-03 fs_separation.json
+                # sidecar per timestamp (falls back to df-block parsing);
+                # the sidecar is the simpler path for a synthetic fixture.
+                vdb_run_dir = index_path / "run"
+                vdb_run_dir.mkdir()
+                for i in range(5):
+                    vdb_run_ts = vdb_run_dir / f"2025011{3 + i}_140000"
+                    vdb_run_ts.mkdir()
+                    (vdb_run_ts / "summary.json").write_text(
+                        json.dumps(vdb_run_summary), encoding="utf-8"
+                    )
+                    (vdb_run_ts / "metadata.json").write_text(
+                        json.dumps(vdb_meta), encoding="utf-8"
+                    )
+                    (vdb_run_ts / "fs_separation.json").write_text(
+                        json.dumps({"same_filesystem": False}), encoding="utf-8"
+                    )
+
+            # ---------------------------------------------------------------
+            # kv_cache/<model>/{datagen,run}/<ts>/  (storage#655)
+            # ---------------------------------------------------------------
+            #
+            # Loader shape per loader.py:191-205. KVCacheCheck is a stub
+            # (zero @rule bindings) so a valid subtree suffices to prove
+            # the loader recognizes the kv_cache mode without tripping
+            # [2.1.10 workloadCategories]. Once PR #602 gives §6 real
+            # bindings, a kv_cache_missing_field knob can mirror
+            # vdb_missing_metric_field above.
+            if include_kv_cache:
+                kv_path = sys_results / "kv_cache"
+                kv_path.mkdir()
+                kv_model_path = kv_path / "llama3.1-8b"
+                kv_model_path.mkdir()
+
+                kv_summary = {"aggregated_read_bandwidth_gbps": 12.5}
+                kv_meta = {
+                    "benchmark_type": "kv_cache",
+                    "model": "llama3.1-8b",
+                    "args": {"model": "llama3.1-8b"},
+                    "override_parameters": {},
+                }
+
+                kv_datagen_dir = kv_model_path / "datagen"
+                kv_datagen_dir.mkdir()
+                kv_dg_ts = kv_datagen_dir / "20250113_130000"
+                kv_dg_ts.mkdir()
+                (kv_dg_ts / "summary.json").write_text(
+                    json.dumps(kv_summary), encoding="utf-8"
+                )
+                (kv_dg_ts / "metadata.json").write_text(
+                    json.dumps(kv_meta), encoding="utf-8"
+                )
+
+                kv_run_dir = kv_model_path / "run"
+                kv_run_dir.mkdir()
+                kv_run_ts = kv_run_dir / "20250113_140000"
+                kv_run_ts.mkdir()
+                (kv_run_ts / "summary.json").write_text(
+                    json.dumps(kv_summary), encoding="utf-8"
+                )
+                (kv_run_ts / "metadata.json").write_text(
+                    json.dumps(kv_meta), encoding="utf-8"
+                )
 
             if unpaired_results_system:
                 (results_path / "no-yaml-for-this").mkdir(parents=True)

--- a/mlpstorage_py/tests/test_definition_of_done.py
+++ b/mlpstorage_py/tests/test_definition_of_done.py
@@ -448,3 +448,195 @@ class TestDefinitionOfDoneBad:
             f"--- stdout ---\n{result.stdout}\n"
             f"--- stderr ---\n{result.stderr}\n"
         )
+
+
+# ---------------------------------------------------------------------------
+# VDB / KVCache subtree tests (storage#655)
+# ---------------------------------------------------------------------------
+#
+# The Phase 3 vanilla ``build_submission`` fixture creates training +
+# checkpointing subtrees only. That means the DoD subprocess never routes
+# through ``VdbCheck`` (17 real §5 @rule bindings) or ``KVCacheCheck``
+# (§6 stub, will gain real bindings via PR #602) — a test escape called
+# out in storage#655.
+#
+# The kwargs below add per-benchmark subtrees on demand:
+#
+# * ``include_vdb=True`` → ``vector_database/milvus/DISKANN/{datagen,run}/…``
+#   with §5-conformant summary.json and metadata.json.
+# * ``include_kv_cache=True`` → ``kv_cache/llama3.1-8b/{datagen,run}/…``
+#   with a minimally-valid summary.json.
+# * ``vdb_missing_metric_field=<name>`` → pops the named field from the vdb
+#   run summary.json so 5.3.4 vdbMetricsReported fires (bad-fixture knob).
+#
+# We deliberately do NOT engineer a §6 bad case: ``KVCacheCheck`` is a
+# stub (zero @rule bindings), so there is no rule to trip. When PR #602
+# gives §6 real bindings, a follow-up can add a ``kv_cache_missing_field``
+# knob mirroring vdb.
+
+
+class TestBuildSubmissionVdbKvcacheSubtrees:
+    """Unit tests for the ``include_vdb`` / ``include_kv_cache`` kwargs.
+
+    Fast, no subprocess — verifies the sealed-kwargs guard accepts the new
+    keys and that the resulting tree matches the loader's expected shape
+    (mlpstorage_py/submission_checker/loader.py:191, 207).
+    """
+
+    def test_include_vdb_kwarg_creates_vector_database_subtree(self, tmp_path):
+        """include_vdb=True creates results/<sys>/vector_database/<engine>/<index>/…
+
+        Loader shape (loader.py:207-238): the ``vector_database`` mode
+        expects one <engine> subdir with one <index> subdir under it, and
+        {datagen,run}/<ts>/{summary.json, metadata.json} beneath.
+        """
+        root = build_submission(tmp_path, include_vdb=True)
+        vdb_root = (
+            root / "closed" / "Acme" / "results" / "acme-storage-v1"
+            / "vector_database"
+        )
+        assert vdb_root.is_dir(), (
+            "expected vector_database/ subtree under results/<sys>/ when "
+            f"include_vdb=True; tree under {root}:\n"
+            + "\n".join(str(p) for p in root.rglob("*") if "results" in str(p))
+        )
+        # At least one <engine>/<index>/run/<ts>/summary.json must exist.
+        summaries = list(vdb_root.glob("*/*/run/*/summary.json"))
+        assert summaries, (
+            "expected at least one vector_database/<engine>/<index>/run/<ts>/"
+            "summary.json; found none"
+        )
+
+    def test_include_kv_cache_kwarg_creates_kv_cache_subtree(self, tmp_path):
+        """include_kv_cache=True creates results/<sys>/kv_cache/<model>/…
+
+        Loader shape (loader.py:191-205): the ``kv_cache`` mode expects
+        <model>/{datagen,run}/<ts>/ leaves under the benchmark dir.
+        """
+        root = build_submission(tmp_path, include_kv_cache=True)
+        kv_root = (
+            root / "closed" / "Acme" / "results" / "acme-storage-v1"
+            / "kv_cache"
+        )
+        assert kv_root.is_dir(), (
+            "expected kv_cache/ subtree under results/<sys>/ when "
+            f"include_kv_cache=True; tree under {root}:\n"
+            + "\n".join(str(p) for p in root.rglob("*") if "results" in str(p))
+        )
+        summaries = list(kv_root.glob("*/run/*/summary.json"))
+        assert summaries, (
+            "expected at least one kv_cache/<model>/run/<ts>/summary.json; "
+            "found none"
+        )
+
+
+@pytest.mark.integration
+class TestDefinitionOfDoneVdb:
+    """End-to-end tests exercising VdbCheck via the DoD subprocess pipeline.
+
+    Together with TestBuildSubmissionVdbKvcacheSubtrees, closes the
+    storage#655 fixture-coverage gap for §5. Two cases:
+
+    * ``test_bad_vdb_fixture_trips_metrics_reported_rule`` — engineers
+      a missing ``p95_latency_ms`` field to trip 5.3.4, proving VdbCheck
+      fires end-to-end (loader mode routing → check instantiation →
+      log_violation → correct rule-ID prefix in stderr).
+    * ``test_good_vdb_fixture_does_not_trip_section_5_rules`` — the
+      absence case, guarding against a future retrofit that spuriously
+      trips §5 against a compliant fixture.
+    """
+
+    def test_bad_vdb_fixture_trips_metrics_reported_rule(self, tmp_path):
+        """A vdb summary.json missing p95_latency_ms trips 5.3.4.
+
+        Locks the end-to-end plumbing: loader recognizes mode==
+        vector_database → main.MODE_TO_CHECKERS routes to VdbCheck →
+        vdb_metrics_reported fires log_violation → BaseCheck emits the
+        [5.3.4 vdbMetricsReported] prefix → stderr surfaces to the caller.
+        """
+        root = build_submission(
+            tmp_path,
+            include_vdb=True,
+            vdb_missing_metric_field="p95_latency_ms",
+        )
+
+        result = _run_validator(root)
+        combined = _combined_output(result)
+        observed = _extract_error_rule_ids(combined)
+
+        assert "5.3.4" in observed, (
+            f"Bad vdb fixture did not trip 5.3.4 vdbMetricsReported. "
+            f"observed rule IDs: {sorted(observed)}\n"
+            f"Exit code: {result.returncode}\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}\n"
+        )
+
+    def test_good_vdb_fixture_does_not_trip_section_5_rules(self, tmp_path):
+        """A §5-conformant vdb subtree does not spuriously trip any §5 rule.
+
+        The vanilla fixture may still trip pre-existing structural noise
+        outside §5 (mirroring the Path-A relaxation on the training/
+        checkpointing DoD cases), so the assertion narrows to
+        ``no rule ID starting with '5.'``.
+        """
+        root = build_submission(tmp_path, include_vdb=True)
+
+        result = _run_validator(root)
+        combined = _combined_output(result)
+        observed = _extract_error_rule_ids(combined)
+        section_5 = {rid for rid in observed if rid.startswith("5.")}
+
+        assert section_5 == set(), (
+            f"Good vdb fixture tripped §5 rule(s) (expected none): "
+            f"{sorted(section_5)}.\n"
+            f"All observed rule IDs: {sorted(observed)}\n"
+            f"Exit code: {result.returncode}\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}\n"
+        )
+
+
+@pytest.mark.integration
+class TestDefinitionOfDoneKvcache:
+    """End-to-end test that the loader recognizes the kv_cache mode.
+
+    ``KVCacheCheck`` is a stub at present (no @rule bindings, no
+    log_violation calls). We cannot engineer a §6 bad-fixture case, but
+    we can prove the loader routes correctly by asserting that adding
+    the kv_cache subtree does NOT cause the [2.1.10 workloadCategories]
+    unrecognized-mode error to fire against it.
+
+    When PR #602 gives §6 real @rule bindings, a follow-up should add
+    a kv_cache bad-fixture case here mirroring the vdb one above.
+    """
+
+    def test_good_kv_cache_fixture_does_not_trigger_unrecognized_workload(
+        self, tmp_path
+    ):
+        """kv_cache subtree is a recognized mode, not an unknown-workload error.
+
+        Rule 2.1.10 workloadCategories fires when the loader encounters
+        a benchmark-type directory it does not recognize (see
+        SubmissionStructureCheck). If MODE_TO_CHECKERS is missing
+        "kv_cache", the subtree tripped 2.1.10 with a path ending in
+        ``/kv_cache``. This test guards that regression.
+        """
+        root = build_submission(tmp_path, include_kv_cache=True)
+
+        result = _run_validator(root)
+        combined = _combined_output(result)
+        pairs = _extract_error_rule_id_path_pairs(combined)
+
+        offending = [
+            (rid, path) for (rid, path) in pairs
+            if rid == "2.1.10" and path.endswith("/kv_cache")
+        ]
+        assert not offending, (
+            f"kv_cache subtree tripped [2.1.10 workloadCategories] as an "
+            f"unrecognized mode: {offending}. Loader routing regression: "
+            "check MODE_TO_CHECKERS in submission_checker/main.py.\n"
+            f"Exit code: {result.returncode}\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}\n"
+        )


### PR DESCRIPTION
Closes #655.

## Summary

The Definition-of-Done end-to-end test (`mlpstorage_py/tests/test_definition_of_done.py`) exercises the full validator pipeline as a subprocess against a fixture built by `conftest.build_submission`. That fixture only ever creates training + checkpointing subtrees, so `MODE_TO_CHECKERS` never routed to `VdbCheck` (17 real §5 `@rule` bindings) or `KVCacheCheck` (§6 stub, will gain real bindings via PR #602). Their unit tests in `test_vdb_checks.py` (41 tests, all passing) exercise them in isolation, but the loader → checker hand-off, the log-line format, and the origin-path binding were unverified end-to-end.

This PR adds three kwargs on `build_submission`:

- `include_vdb=True` — creates `results/<sys>/vector_database/milvus/DISKANN/{datagen,run}/<ts>/` per `loader.py:207-238`. Five run timestamps because 5.3.1 `vdbRunCount` requires exactly 5. Each run dir carries a §5-conformant `summary.json` + `metadata.json` + a CAP-03 `fs_separation.json` sidecar so 5.4.2 `vdbFilesystemCheck` passes.
- `include_kv_cache=True` — creates `results/<sys>/kv_cache/llama3.1-8b/{datagen,run}/<ts>/` per `loader.py:191-205`. Because `KVCacheCheck` is a stub, the good-fixture assertion only needs to prove the loader routes through `MODE_TO_CHECKERS` without tripping `[2.1.10 workloadCategories]`. The subtree is scaffolded so a follow-up (once PR #602 gives §6 real bindings) can add a `kv_cache_missing_field` knob mirroring `vdb_missing_metric_field`.
- `vdb_missing_metric_field=<name>` — pops the named field from the vdb run summary.json to engineer 5.3.4 `vdbMetricsReported` end-to-end (bad-fixture case).

## Also fixed: stale docstring

`vdb_checks.py:150-155` — the `_iter_run_files` docstring described "Phase 4 land time" behavior:

> Loader.load() only fills run_files / datagen_files for mode == "training"; the else branch fills checkpoint_files for everything else. For vector_database leaves this means run_files is None.

That was already outdated when #655 was filed — #612 added explicit `run_files` / `datagen_files` population for both `vector_database` (`loader.py:224-225`) and `kv_cache` (`loader.py:198-199`). Updated the docstring to reflect the current loader behavior; the empty-iterable guard remains as a defensive walk for test-time `SubmissionLogs` fakes.

## Follow-up not in this PR

- Once PR #602 gives §6 real `@rule` bindings, add a `kv_cache_missing_field` kwarg and a `TestDefinitionOfDoneKvcache` bad-fixture case mirroring the vdb structure.
- The vanilla-fixture "no §5 rules tripped" assertion only checks that no `5.x.y` prefix appears at ERROR level; it does not extend `TestDefinitionOfDoneGood.test_good_fixture_does_not_trip_bad_fixture_rule_ids` to add `5.3.4` to `_EXPECTED_BAD_FIXTURE_RULE_IDS`. Doing so would require a bad-fixture engineering of both §5.3.4 and one §6 rule (once those exist), so both live-fixture cases assert the same subset. Bundled into the same §6 follow-up.

## Test plan

TDD RED-first (per project convention):

- \`9224103 test(#655): RED — DoD fixture lacks vector_database and kv_cache subtrees\`
- \`97ac94a fix(#655): add vector_database and kv_cache subtrees to build_submission\`

All 5 new tests failed on RED with `TypeError: unknown override`; all pass on GREEN after two rounds (initial GREEN tripped 5.3.1 vdbRunCount + 5.4.2 vdbFilesystemCheck against my one-timestamp fixture; fixed by extending to 5 timestamps + adding fs_separation.json sidecars).

Parallel 4-suite sweep:

- \`tests/\` — 2611 passed
- \`mlpstorage_py/tests/\` — 821 passed (+9 vs pre-#656: 4 from #656 + 5 new #655 tests)
- \`vdb_benchmark/tests/\` — 155 passed
- \`kv_cache_benchmark/tests/\` — 238 passed
- **Total: 3825 passed, 0 failed**

## Related

- #656 — merged in the same review window; widened the log-line extractor regex to accept §5/§6 and 4-part IDs, which this PR's `_extract_error_rule_ids` usage depends on.
- #602 — will need a `kv_cache_missing_field` follow-up here once §6 gets real `@rule` bindings.
- #612 — closed the loader-side half of the escape; the docstring cleanup here reflects that fix.