### PR TITLE
fix(#658): advertise PR #602 §6 KVCache rules in coverage_mapping

### DIFF
--- a/mlpstorage_py/submission_checker/checks/kvcache_checks.py
+++ b/mlpstorage_py/submission_checker/checks/kvcache_checks.py
@@ -1,10 +1,16 @@
 """KVCacheCheck — Rules.md §6 (KVCache) extension stub.
 
-Rules.md §6 is empty at Phase 3 land time. STUB-02 establishes the
+Rules.md §6 was empty at Phase 3 land time. STUB-02 established the
 extension point so ``main.py`` can instantiate the class identically to
 ``DirectoryCheck`` / ``TrainingCheck`` / ``CheckpointingCheck`` (D-S4),
 and so a future phase can fill in real checks without touching the
 ``main.py`` wiring shape.
+
+PR #602 lands the §6 rules; the companion coverage-mapping change
+(mlcommons/storage#658) advertises the seventeen enforceable IDs via
+``STUB_COVERAGE['KVCacheCheck']`` in ``coverage_mapping.py`` while this
+class is still a stub. Real ``@rule``-decorated methods are a follow-up
+phase.
 
 Design constraints (Phase 3 CONTEXT.md):
 
@@ -31,9 +37,10 @@ class KVCacheCheck(BaseCheck):
     ``for checker in checkers:`` loop in ``main.py`` (Plan 03-04) can
     instantiate ``KVCacheCheck`` without any special-casing.
 
-    Emits zero violations. Future phase populates
-    ``STUB_COVERAGE['KVCacheCheck']`` in ``coverage_mapping.py`` when
-    Rules.md §6 gains IDs.
+    Emits zero violations. ``STUB_COVERAGE['KVCacheCheck']`` in
+    ``coverage_mapping.py`` advertises the seventeen §6 IDs added by
+    PR #602 so the coverage gate does not flag them as unmapped; a
+    follow-up phase replaces this stub with real ``@rule`` methods.
     """
 
     def __init__(self, log, config: Config, submissions_logs: SubmissionLogs):
@@ -56,10 +63,11 @@ class KVCacheCheck(BaseCheck):
     def init_checks(self):
         """Register the placeholder no-op (D-S2).
 
-        Rules.md §6 (KVCache) is empty at Phase 3 land time. When that
-        section gains IDs, a future phase fills in real ``@rule``-decorated
-        check methods here and populates ``STUB_COVERAGE['KVCacheCheck']``
-        in ``coverage_mapping.py``.
+        Rules.md §6 (KVCache) gained IDs via PR #602;
+        ``STUB_COVERAGE['KVCacheCheck']`` in ``coverage_mapping.py``
+        advertises them so the coverage gate stays clean. A follow-up
+        phase replaces the placeholder with real ``@rule``-decorated
+        check methods.
         """
         self.checks = [self._section_unimplemented]
 

--- a/mlpstorage_py/submission_checker/coverage_mapping.py
+++ b/mlpstorage_py/submission_checker/coverage_mapping.py
@@ -4,19 +4,19 @@
 Two top-level constants:
 
 * ``OUT_OF_SCOPE_RULES`` — Rules.md IDs deliberately skipped, with a
-  free-text reason string. Empty at Phase 3 land time because the
-  aggressive retrofit (D-R1, D-R2) covers every current Rules.md §2/§3/§4
-  ID via ``@rule``-decorated check methods. The dict exists so future
-  contributors can record deliberate skips (e.g., "v2 milestone", "object
-  API deferred") in one place instead of scattering ``# TODO`` comments.
+  free-text reason string. Populated on 2026-07-02 with the two §6
+  KVCache rules whose content is descriptive/narrative rather than a
+  submission-validator contract (§6.4.2 I/O model, §6.6.3 OPEN example
+  invocation). See mlcommons/storage#658 and PR #602.
 * ``STUB_COVERAGE`` — maps stub-class name → list of Rules.md IDs the
-  stub *advertises* as covered. Both lists are empty at Phase 3 land
-  time because Rules.md §5 (VDB) and §6 (KVCache) are empty. The
-  structure exists so future contributors can fill in the IDs (e.g.,
-  ``"5.1.1"``, ``"6.2.3"``) when Rules.md gains those sections — the
-  ``rules_coverage`` tool consumes ``STUB_COVERAGE`` to report the IDs
-  as "covered by stub" without the stubs themselves needing to know
-  about the coverage tool (D-S3 decoupling).
+  stub *advertises* as covered. ``VdbCheck`` has been retired here
+  (Phase 4 gave it real ``@rule`` bindings for §5). ``KVCacheCheck``
+  now advertises the seventeen enforceable §6 KVCache rules added by
+  PR #602; real ``@rule`` bindings are a follow-up phase (~800–1000 LOC
+  checker + ~800–1200 LOC tests + emitter changes for
+  ``aggregated_device_{read,write}_p95_ms`` under §6.3.4.3). Until then
+  PR #602's own enforcement-status note applies: the §6 rules are
+  enforced by the run-time CLI locks (6.3.2.1) and manual review.
 
 This module has **no imports** and exposes **no functions** — it is a
 pure data module consumed by ``rules_coverage`` (Plan 03-04). Stubs in
@@ -24,12 +24,28 @@ pure data module consumed by ``rules_coverage`` (Plan 03-04). Stubs in
 depend on this module (D-S3).
 """
 
-# D-A1: empty at land time because the aggressive retrofit (D-R1/D-R2)
-# covers every current Rules.md §2/§3/§4 ID. Populate with entries of the
-# shape:
-#   "rule_id": "free-text reason"
-# (e.g., ``"6.5.1": "object API deferred to v2 milestone"``).
-OUT_OF_SCOPE_RULES: dict[str, str] = {}
+# §6.4.2 and §6.6.3 are descriptive/narrative sections of Rules.md §6
+# (KVCache) that carry no submission-validator contract. §6.4.2
+# documents the POSIX I/O model (.npy files, np.save+fsync, np.load
+# after POSIX_FADV_DONTNEED); §6.6.3 shows an example direct
+# ``kv-cache.py`` invocation for OPEN submissions with latency tracing
+# / RAG / BurstGPT. The "must record the exact invocation" clause of
+# §6.6.3 is satisfied by the OPEN run's normal metadata capture, not a
+# distinct check. See mlcommons/storage#658.
+OUT_OF_SCOPE_RULES: dict[str, str] = {
+    "6.4.2": (
+        "descriptive — Rules.md §6.4.2 documents the KVCache POSIX I/O "
+        "model (.npy files, np.save+fsync, np.load after "
+        "POSIX_FADV_DONTNEED). No submission-level enforcement contract."
+    ),
+    "6.6.3": (
+        "OPEN-narrative — Rules.md §6.6.3 shows an example direct "
+        "kv-cache.py invocation for OPEN submissions with "
+        "--enable-latency-tracing / --enable-rag / --use-burst-trace. "
+        "The 'record exact invocation' clause is satisfied by the OPEN "
+        "run's normal metadata capture, not a distinct validator check."
+    ),
+}
 
 
 # Stub-class coverage advertisement: maps stub class name -> list of Rules.md
@@ -37,7 +53,34 @@ OUT_OF_SCOPE_RULES: dict[str, str] = {}
 # §5 was empty; after Phase 4 Plan 04-02 (D-01) it carries real
 # ``@rule``-decorated methods for every §5 ID (5.1.1-5.6.5) and
 # ``discover_rules`` picks them up directly, so the VdbCheck entry has been
-# removed. KVCacheCheck stays until Rules.md §6 (KVCache) gains IDs.
+# removed. ``KVCacheCheck`` advertises the seventeen enforceable §6 IDs
+# added by PR #602; the descriptive §6.4.2 and §6.6.3 sit in
+# ``OUT_OF_SCOPE_RULES`` above. See mlcommons/storage#658.
 STUB_COVERAGE: dict[str, list[str]] = {
-    "KVCacheCheck": [],   # populated when Rules.md §6 (KVCache) gains IDs
+    "KVCacheCheck": [
+        # §6.3.1 Sanctioned workload Options
+        "6.3.1.1",
+        # §6.3.2 CLOSED sequence locks
+        "6.3.2.1",
+        "6.3.2.2",
+        # §6.3.3 Client scaling
+        "6.3.3.1",
+        "6.3.3.2",
+        "6.3.3.3",
+        "6.3.3.4",
+        # §6.3.4 Result aggregation
+        "6.3.4.1",
+        "6.3.4.2",
+        "6.3.4.3",
+        "6.3.4.4",
+        "6.3.4.5",
+        # §6.4 POSIX Access (§6.4.2 → OUT_OF_SCOPE)
+        "6.4.1",
+        # §6.5 Object Access
+        "6.5.1",
+        "6.5.2",
+        # §6.6 OPEN versus CLOSED (§6.6.3 → OUT_OF_SCOPE)
+        "6.6.1",
+        "6.6.2",
+    ],
 }

--- a/mlpstorage_py/tests/test_rules_coverage.py
+++ b/mlpstorage_py/tests/test_rules_coverage.py
@@ -202,21 +202,47 @@ class TestRulesCoverageReconciliation:
             )
         )
 
-    def test_baseline_no_stale_entries(self):
-        """At Phase 3 land time both registries are empty → no stale entries.
+    def test_baseline_no_unexpected_stale_entries(self):
+        """Drift guard: no stale entries beyond the PR #602 anticipation window.
 
-        Locks the Phase-3 invariant: a future contributor who adds an entry
-        to either registry that doesn't appear in Rules.md will fail this
-        test (and the drift warning will fire in CI).
+        Storage#658 populates ``STUB_COVERAGE['KVCacheCheck']`` and
+        ``OUT_OF_SCOPE_RULES`` with §6 IDs *before* PR #602 lands, so the
+        two registries carry IDs that do not yet appear in live Rules.md.
+        Those anticipated IDs are allow-listed here; the drift warnings
+        for them fire in CI (log.warning, non-fatal) as an intentional
+        signal until PR #602 merges, at which point this allow-list
+        collapses to the empty set automatically.
+
+        Any *other* stale entry (a contributor adds an ID that never
+        appears in Rules.md) still fails this test.
         """
+        # PR #602 §6 anticipation window (storage#658). These entries are
+        # correct-in-advance and stop being flagged as stale the moment
+        # PR #602 lands in Rules.md.
+        pr602_pending_oos = {"6.4.2", "6.6.3"}
+        pr602_pending_stub = {
+            "6.3.1.1", "6.3.2.1", "6.3.2.2",
+            "6.3.3.1", "6.3.3.2", "6.3.3.3", "6.3.3.4",
+            "6.3.4.1", "6.3.4.2", "6.3.4.3", "6.3.4.4", "6.3.4.5",
+            "6.4.1",
+            "6.5.1", "6.5.2",
+            "6.6.1", "6.6.2",
+        }
+
         result = reconcile()
-        assert result["stale_oos"] == set(), (
-            "Expected no stale OUT_OF_SCOPE_RULES entries at Phase 3 land "
-            "time, got {}".format(sorted(result["stale_oos"]))
+        unexpected_oos = result["stale_oos"] - pr602_pending_oos
+        assert unexpected_oos == set(), (
+            "Unexpected stale OUT_OF_SCOPE_RULES entries (not part of the "
+            "PR #602 anticipation window): {}".format(sorted(unexpected_oos))
         )
-        assert result["stale_stubs"] == {}, (
-            "Expected no stale STUB_COVERAGE entries at Phase 3 land time, "
-            "got {}".format(result["stale_stubs"])
+        unexpected_stubs = {
+            cls: sorted(set(rids) - pr602_pending_stub)
+            for cls, rids in result["stale_stubs"].items()
+            if set(rids) - pr602_pending_stub
+        }
+        assert unexpected_stubs == {}, (
+            "Unexpected stale STUB_COVERAGE entries (not part of the PR "
+            "#602 anticipation window): {}".format(unexpected_stubs)
         )
 
     def test_drift_stale_oos_emits_warning_and_keeps_exit_0(

--- a/mlpstorage_py/tests/test_rules_coverage.py
+++ b/mlpstorage_py/tests/test_rules_coverage.py
@@ -147,6 +147,61 @@ class TestRulesCoverageReconciliation:
             "discoverable), got {}".format(sorted(result["unmapped"]))
         )
 
+    def test_pr602_section_6_ids_are_all_mapped(self, tmp_path):
+        """Companion-PR guard for storage#658 (unblocks PR #602 merge).
+
+        Simulates PR #602's ``Rules.md`` state by appending the 19 §6
+        rule-ID lines the PR adds, then asserts none of them surface in
+        ``reconcile()['unmapped']``. RED against an unpopulated
+        ``coverage_mapping.py`` (both registries empty for §6), GREEN once
+        ``STUB_COVERAGE['KVCacheCheck']`` and ``OUT_OF_SCOPE_RULES`` are
+        populated for the seventeen enforceable and two descriptive rules.
+
+        The synthetic lines are minimal (``ID. **name** -- placeholder``)
+        because the enumerator only reads ``id`` and ``name``; the fixture
+        is not sensitive to PR #602's prose or table content.
+        """
+        pr602_section_6_ids = [
+            ("6.3.1.1", "kvcacheFixedWorkloadPerOption"),
+            ("6.3.2.1", "kvcacheClosedSequenceLocks"),
+            ("6.3.2.2", "kvcacheAutoscalingProhibited"),
+            ("6.3.3.1", "kvcacheClientDefinition"),
+            ("6.3.3.2", "kvcacheScaleUpModel"),
+            ("6.3.3.3", "kvcachePerClientIsolation"),
+            ("6.3.3.4", "kvcacheSharedResultsDir"),
+            ("6.3.4.1", "kvcacheAggregateBandwidth"),
+            ("6.3.4.2", "kvcacheAggregateThroughput"),
+            ("6.3.4.3", "kvcacheAggregateDeviceLatency"),
+            ("6.3.4.4", "kvcacheLatencyValidity"),
+            ("6.3.4.5", "kvcacheHeadlineResult"),
+            ("6.4.1", "kvcachePosixCacheDir"),
+            ("6.4.2", "kvcachePosixIoModel"),
+            ("6.5.1", "kvcacheObjectViaGateway"),
+            ("6.5.2", "kvcacheObjectLatencyScope"),
+            ("6.6.1", "kvcacheClosedImmutable"),
+            ("6.6.2", "kvcacheOpenAllowances"),
+            ("6.6.3", "kvcacheOpenInvocationNote"),
+        ]
+        appended = "\n" + "\n".join(
+            "{}. **{}** -- placeholder for testing".format(rid, name)
+            for rid, name in pr602_section_6_ids
+        ) + "\n"
+        fake_md = tmp_path / "fake_rules_with_pr602_section6.md"
+        original = RULES_MD_PATH.read_text(encoding="utf-8")
+        fake_md.write_text(original + appended, encoding="utf-8")
+
+        result = reconcile(rules_md_path=str(fake_md))
+
+        pr602_ids = {rid for rid, _ in pr602_section_6_ids}
+        unmapped_from_pr602 = pr602_ids & result["unmapped"]
+        assert unmapped_from_pr602 == set(), (
+            "PR #602 §6 IDs must all be mapped (via STUB_COVERAGE or "
+            "OUT_OF_SCOPE_RULES) so the coverage gate does not fail when "
+            "PR #602 merges. Unmapped IDs: {}".format(
+                sorted(unmapped_from_pr602)
+            )
+        )
+
     def test_baseline_no_stale_entries(self):
         """At Phase 3 land time both registries are empty → no stale entries.
 


### PR DESCRIPTION
Closes #658. Companion PR that unblocks #602 (KV cache Rules for closed and open submission).

## Why this exists

The moment PR #602 merges into `main`, `test_reconcile_returns_no_unmapped_ids` will fail with 19 unmapped rule IDs — the new §6 KVCache rules have no `@rule` binding, `SCHEMA_ERROR_RULE_MAP` entry, `STUB_COVERAGE` entry, or `OUT_OF_SCOPE_RULES` entry. #656 fixed the discovery regex so the 4-part IDs (`6.3.1.1`, `6.3.4.5`, …) are enumerated; this PR gives every enumerated ID a disposition.

## Classification (19 IDs)

**`STUB_COVERAGE['KVCacheCheck']` — 17 enforceable IDs**

`6.3.1.1`, `6.3.2.1`, `6.3.2.2`, `6.3.3.1–4`, `6.3.4.1–5`, `6.4.1`, `6.5.1`, `6.5.2`, `6.6.1`, `6.6.2`.

`KVCacheCheck` is still a stub (`_section_unimplemented` → `True`), so no §6 violation actually fires in production yet. This matches PR #602's own enforcement-status note: *"the kvcache submission checker is currently a stub, so today these are enforced by the run-time CLI locks (6.3.2.1) and by manual review until the checker is implemented."* Real `@rule` bindings are a follow-up phase (surveyed at ~800–1000 LOC checker + ~800–1200 LOC tests + emitter changes for `aggregated_device_{read,write}_p95_ms` under §6.3.4.3).

**`OUT_OF_SCOPE_RULES` — 2 descriptive IDs**

* `6.4.2` `kvcachePosixIoModel` — documents the POSIX I/O model (`.npy` files, `np.save`+`fsync`, `np.load` after `POSIX_FADV_DONTNEED`). No validator contract.
* `6.6.3` `kvcacheOpenInvocationNote` — shows an example direct `kv-cache.py` invocation for OPEN with `--enable-latency-tracing` / `--enable-rag` / `--use-burst-trace`. The "record exact invocation" clause is satisfied by the OPEN run's normal metadata capture, not a distinct check.

## RED-first commits

* `test(#658): RED` — synthesises PR #602's Rules.md by appending the 19 §6 lines to a temp Rules.md and asserts `reconcile()['unmapped']` contains none of them. Fails before this PR.
* `fix(#658): GREEN` — populates the registries and updates the rename-sensitive `test_baseline_no_stale_entries` invariant + `KVCacheCheck` docstrings.

## Interim drift warnings (intentional)

Because this PR lands before #602, live `Rules.md` on `main` does not yet contain the 19 IDs, so `reconcile()` emits 19 `log.warning` lines through `rules_coverage`'s stale-entry path. Those are informational (exit code unchanged). They stop firing the moment #602 merges. `test_baseline_no_unexpected_stale_entries` explicitly allow-lists this anticipation window; any *other* stale entry still fails the test.

## Test sweep

All four suites clean (2611 + 822 + 155 + 238 = 3826 pass, 0 fail).

## Merge ordering

Land this PR first, then #602 can merge without regressing the coverage gate.