### PR TITLE
fix(#664): move CLOSED --inter-option-delay from 20 s to 90 s

### DIFF
--- a/ManPage.md
+++ b/ManPage.md
@@ -763,7 +763,7 @@ Open/whatif VectorDB extras:
 
 KV-cache has no model positional; the model is selected with `--model` (open/whatif only — closed pins it internally).
 
-Closed pins the following at fixed values and does not expose flags to change them: `--gpu-mem-gb=16.0`, `--cpu-mem-gb=32.0`, `--duration=60`, `--generation-mode=realistic`, `--performance-profile=throughput`, `--disable-multi-turn=False`, `--disable-prefix-caching=False`, `--enable-rag=True`, `--rag-num-docs=10`, `--enable-autoscaling=True`, `--autoscaler-mode=qos`, `--seed=42`, `--trials=3`, `--inter-option-delay=20`.
+Closed pins the following at fixed values and does not expose flags to change them: `--gpu-mem-gb=16.0`, `--cpu-mem-gb=32.0`, `--duration=60`, `--generation-mode=realistic`, `--performance-profile=throughput`, `--disable-multi-turn=False`, `--disable-prefix-caching=False`, `--enable-rag=True`, `--rag-num-docs=10`, `--enable-autoscaling=True`, `--autoscaler-mode=qos`, `--seed=42`, `--trials=3`, `--inter-option-delay=90`.
 
 Common:
 

--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -244,10 +244,10 @@ class KVCacheBenchmark(Benchmark):
             return 1
 
         inter_option_delay_arg = getattr(self.args, 'inter_option_delay', None)
-        if is_closed and inter_option_delay_arg is not None and inter_option_delay_arg != 20:
+        if is_closed and inter_option_delay_arg is not None and inter_option_delay_arg != 90:
             self.logger.error(
                 f"--inter-option-delay cannot be changed in a CLOSED submission "
-                f"(must be 20, got {inter_option_delay_arg})"
+                f"(must be 90, got {inter_option_delay_arg})"
             )
             return 1
 
@@ -259,7 +259,7 @@ class KVCacheBenchmark(Benchmark):
         # Resolve effective values, applying mandated defaults
         seed = seed_arg if seed_arg is not None else 42
         trials = trials_arg if trials_arg is not None else 3
-        inter_option_delay = inter_option_delay_arg if inter_option_delay_arg is not None else 20
+        inter_option_delay = inter_option_delay_arg if inter_option_delay_arg is not None else 90
         config = config_arg
 
         hosts = getattr(self.args, 'hosts', None) or ['localhost']

--- a/mlpstorage_py/cli/help_formatter.py
+++ b/mlpstorage_py/cli/help_formatter.py
@@ -458,7 +458,7 @@ KV_RUN_CLOSED
   + CORE_STD
   Note: the following are fixed in closed and not shown:
     duration=60s, generation-mode=realistic, performance-profile=throughput,
-    seed=42, trials=3, inter-option-delay=20s,
+    seed=42, trials=3, inter-option-delay=90s,
     disable-multi-turn=False, disable-prefix-caching=False,
     enable-rag=True, rag-num-docs=10,
     enable-autoscaling=True, autoscaler-mode=qos

--- a/mlpstorage_py/cli/kvcache_args.py
+++ b/mlpstorage_py/cli/kvcache_args.py
@@ -211,7 +211,7 @@ def _add_kvcache_cache_arguments(parser, mode):
             autoscaler_mode='qos',
             seed=42,
             trials=3,
-            inter_option_delay=20,
+            inter_option_delay=90,
             allow_invalid_params=False,
             params='',
             max_concurrent_allocs=None,

--- a/mlpstorage_py/run_summary.py
+++ b/mlpstorage_py/run_summary.py
@@ -456,7 +456,7 @@ def _print_kvcache_section(args, lines: List[str]) -> None:
     # (the closed-mode mandate; open-mode default if user passed None).
     lines.append(_row("seed (effective):",               _kvcache_effective(args, 'seed', 42)))
     lines.append(_row("trials (effective):",             _kvcache_effective(args, 'trials', 3)))
-    lines.append(_row("inter_option_delay (effective):", _kvcache_effective(args, 'inter_option_delay', 20)))
+    lines.append(_row("inter_option_delay (effective):", _kvcache_effective(args, 'inter_option_delay', 90)))
 
     total_ranks = _kvcache_total_ranks(args)
     if total_ranks is not None:

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -398,7 +398,7 @@ def _make_run_benchmark(tmp_path, what_if=False):
         seed=42,
         cache_dir='/tmp/kv',
         trials=3,
-        inter_option_delay=20,
+        inter_option_delay=90,
         kvcache_bin_path=None,
         config=None,
         hosts=['localhost'],
@@ -1154,6 +1154,27 @@ class TestClosedEnforcement:
         bm.args.mode = 'closed'
         return bm
 
+    @pytest.fixture(autouse=True)
+    def _no_subprocess_fork(self, request):
+        # Defense in depth. The `*_returns_1` tests below expect the CLOSED
+        # guard to short-circuit before any subprocess launches, so they do
+        # not patch _execute_run's collaborators. If the runtime and the
+        # test ever drift (as happened during the storage#664 rename), the
+        # guard misses and _execute_run falls into the real mpirun /
+        # ssh-probe / aggregation path. On localhost with mocked
+        # kvcache_bin_path=None that expands into a fork storm heavy enough
+        # to OOM the host. This autouse fixture neutralizes the dangerous
+        # collaborators for the whole class so a guard miss can only cause
+        # a clean assertion failure, never a runaway fork.
+        if 'bm' not in request.fixturenames:
+            yield
+            return
+        bm = request.getfixturevalue('bm')
+        with patch.object(bm, '_execute_command', return_value=('', '', 0)), \
+             patch.object(bm, '_probe_results_dir_shared'), \
+             patch.object(bm, '_interruptible_sleep'):
+            yield
+
     def test_closed_seed_non_42_returns_1(self, bm):
         """CLOSED: --seed != 42 must hard-fail with return code 1."""
         bm.args.seed = 99
@@ -1163,7 +1184,7 @@ class TestClosedEnforcement:
     def test_closed_seed_42_is_allowed(self, bm, tmp_path):
         """CLOSED: --seed 42 (the mandated value) must not fail."""
         bm.args.seed = 42
-        # Keep trials=3 and inter_option_delay=20 (CLOSED mandated values from fixture)
+        # Keep trials=3 and inter_option_delay=90 (CLOSED mandated values from fixture)
         _agg = {
             'option': 1, 'aggregated_read_bandwidth_gbps': 0.0,
             'aggregated_write_bandwidth_gbps': 0.0,
@@ -1184,7 +1205,7 @@ class TestClosedEnforcement:
     def test_closed_seed_none_uses_default_42(self, bm, tmp_path):
         """CLOSED: seed=None (not set by user) must not fail (default 42 applies)."""
         bm.args.seed = None
-        # Keep trials=3 and inter_option_delay=20 (CLOSED mandated values from fixture)
+        # Keep trials=3 and inter_option_delay=90 (CLOSED mandated values from fixture)
         _agg = {
             'option': 1, 'aggregated_read_bandwidth_gbps': 0.0,
             'aggregated_write_bandwidth_gbps': 0.0,
@@ -1208,9 +1229,15 @@ class TestClosedEnforcement:
         rc = bm._execute_run()
         assert rc == 1
 
-    def test_closed_inter_option_delay_non_20_returns_1(self, bm):
-        """CLOSED: --inter-option-delay != 20 must hard-fail with return code 1."""
-        bm.args.inter_option_delay = 10
+    def test_closed_inter_option_delay_non_90_returns_1(self, bm):
+        """CLOSED: --inter-option-delay != 90 must hard-fail with return code 1.
+
+        Uses 20 as the non-90 value (storage#664) to guard against a
+        regression to the pre-#664 enforcement of 20 — if someone reverts
+        the enforced value back to 20, the previously-mandated 20 would
+        pass and this test would fire.
+        """
+        bm.args.inter_option_delay = 20
         rc = bm._execute_run()
         assert rc == 1
 
@@ -1535,7 +1562,7 @@ class TestWrapperCommandForwardsPerOptionArgs:
     def test_closed_option1_wrapper_cmd_contains_8b_model(self, tmp_path):
         bm = _make_run_benchmark(tmp_path)
         bm.args.mode = 'closed'
-        # CLOSED requires trials=3 and inter_option_delay=20 (the fixture's
+        # CLOSED requires trials=3 and inter_option_delay=90 (the fixture's
         # values); overriding them would trigger CLOSED enforcement and
         # short-circuit before any command is built.
         cmd0 = self._capture_first_cmd(bm, self._fake_agg())

--- a/tests/unit/test_cli_kvcache.py
+++ b/tests/unit/test_cli_kvcache.py
@@ -422,7 +422,7 @@ class TestKVCacheClosedMode:
         args = parser.parse_args(['run', '--results-dir', '/tmp', '--systemname', 'sys-v1'])
         assert args.seed == 42
         assert args.trials == 3
-        assert args.inter_option_delay == 20
+        assert args.inter_option_delay == 90
 
     def test_closed_mode_rejects_gpu_mem_gb(self, parser):
         """Closed kvcache must reject --gpu-mem-gb (open/whatif only)."""


### PR DESCRIPTION
## Summary
- Closes #664. Aligns the CLOSED `--inter-option-delay` enforcement / defaults / help / manpage with PR #602 §6.3.2.1 (author `@hazemawadalla` confirmed 90 s on 2026-07-03). Runtime and tests were still on the temporary 20 s reconciliation from before the confirmation.
- Adds a class-level autouse fixture on `TestClosedEnforcement` that patches `_execute_command`, `_probe_results_dir_shared`, and `_interruptible_sleep`. The `*_returns_1` tests rely on the CLOSED guard short-circuiting before any subprocess launches; when the runtime and tests drift (as they did during this rename), the guard misses and `_execute_run` falls into the real `mpirun` / ssh-probe / aggregation path — on localhost with `kvcache_bin_path=None` that expands into a fork storm heavy enough to OOM a 32 GB host. The fixture ensures a future guard miss can only produce a clean assertion failure, never a runaway fork.

## Behavior change
CLOSED submissions that previously would have accepted `--inter-option-delay 20` will now hard-fail; they must use 90. Consistent with the merged §6.3.2.1 text on PR #602.

## Sites changed
Runtime code:
- `mlpstorage_py/benchmarks/kvcache.py` — CLOSED hard-fail, error text, and effective-value fallback: 20 → 90
- `mlpstorage_py/cli/kvcache_args.py` — closed `set_defaults`: 20 → 90
- `mlpstorage_py/run_summary.py` — effective-value fallback: 20 → 90
- `mlpstorage_py/cli/help_formatter.py` — CLOSED pinned-defaults help text: 20s → 90s
- `ManPage.md` — closed pins list: 20 → 90

Tests:
- `tests/unit/test_cli_kvcache.py` — closed `set_defaults` assertion: 20 → 90
- `tests/unit/test_benchmarks_kvcache.py` — CLOSED fixture: 20 → 90; renamed `test_closed_inter_option_delay_non_20_returns_1` → `_non_90_returns_1` (deliberately uses 20 as the non-90 value to catch a regression back to 20); autouse fork-storm safety net on `TestClosedEnforcement`.

`Rules.md` §6.3.2.1 is updated on PR #602's branch as a companion change (not touched here — this PR ships the runtime alignment independently so #602 can rebase and pass CI cleanly).

## Test plan
- [x] `uv run pytest tests/unit` — 2516 passed, 1 skipped
- [x] `uv run pytest mlpstorage_py/tests` — 822 passed
- [x] `uv run pytest vdb_benchmark/tests` — 155 passed
- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed
- [x] RED-first verified: with runtime stashed, `test_closed_inter_option_delay_non_90_returns_1` and 5 sibling tests fail cleanly (assertion errors, no subprocess spawn) — safety-net fixture works as designed