### PR TITLE
fix(#663): denylist 4 more MPI per-rank/per-invocation env vars

### DIFF
--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -1287,6 +1287,15 @@ _ENV_RUNTIME_DENYLIST: Final[frozenset] = frozenset({
     "OMPI_MCA_orte_ess_node_rank",
     "OMPI_MCA_orte_node_regex",
     "OMPI_MCA_orte_top_session_dir",
+    # Issue #663 — Open-MPI vars the #643 audit missed. Three are set only
+    # on non-rank-0 processes (asymmetric fingerprint → breaks quantity:N
+    # dedup); OMPI_MCA_orte_parent_uri also carries a random per-mpirun
+    # job id + TCP port and independently trips SystemDriftError on
+    # legitimate re-runs.
+    "OMPI_MCA_ess_base_num_procs",
+    "OMPI_MCA_orte_parent_uri",
+    "OMPI_MCA_plm",
+    "OMPI_MCA_routed",
 })
 
 
@@ -2271,6 +2280,12 @@ _ENV_RUNTIME_DENYLIST = (
     "OMPI_MCA_orte_ess_node_rank",
     "OMPI_MCA_orte_node_regex",
     "OMPI_MCA_orte_top_session_dir",
+    # Issue #663 — Open-MPI vars the #643 audit missed. Mirror of module
+    # copy above; TestEnvironmentMPIScriptParity enforces lockstep.
+    "OMPI_MCA_ess_base_num_procs",
+    "OMPI_MCA_orte_parent_uri",
+    "OMPI_MCA_plm",
+    "OMPI_MCA_routed",
 )
 
 

--- a/tests/unit/test_cluster_collector.py
+++ b/tests/unit/test_cluster_collector.py
@@ -3202,6 +3202,54 @@ class TestEnvironmentRuntimeDenylistExpanded643:
             )
 
 
+class TestEnvironmentRuntimeDenylistExpanded663:
+    """Follow-up expansion (storage#663): four Open-MPI vars missed by the
+    #643 audit — three are set only on non-rank-0 processes (asymmetric
+    fingerprint defeats ``quantity: N`` dedup) and one carries a randomly-
+    generated per-invocation URI (job id + TCP port) that also trips
+    ``SystemDriftError`` on legitimate re-runs.
+
+    Kept in its own class so the #663 expansion is documented and grepable
+    like the #643 one before it. Uses the same ``_env_allowlist_match``
+    exclusion mechanism.
+    """
+
+    _RUNTIME_VOLATILE_VARS_ADDED_IN_663 = [
+        "OMPI_MCA_ess_base_num_procs",
+        "OMPI_MCA_orte_parent_uri",
+        "OMPI_MCA_plm",
+        "OMPI_MCA_routed",
+    ]
+
+    @pytest.mark.parametrize("varname", _RUNTIME_VOLATILE_VARS_ADDED_IN_663)
+    def test_var_excluded_from_collect_environment(self, monkeypatch, varname):
+        """Each newly-denylisted var must NOT appear in collect_environment
+        output even when live in ``os.environ`` (the state non-rank-0
+        processes see under ``mpirun``)."""
+        from mlpstorage_py.cluster_collector import collect_environment
+
+        _clear_env_allowlist_vars(monkeypatch)
+        monkeypatch.setenv(varname, "some-per-rank-value-12345")
+        out = collect_environment()
+        names = {e["name"] for e in out}
+        assert varname not in names, (
+            f"{varname} is a per-rank / per-invocation launcher variable "
+            "and must be excluded from the fingerprint to prevent asymmetric "
+            "rank fingerprints (breaking quantity: N dedup) and spurious "
+            "SystemDriftError on legitimate re-runs (#663)."
+        )
+
+    @pytest.mark.parametrize("varname", _RUNTIME_VOLATILE_VARS_ADDED_IN_663)
+    def test_var_denied_by_env_allowlist_match(self, monkeypatch, varname):
+        """Name-level assertion at the allowlist boundary — decoupled from
+        the collect_environment machinery so a refactor that reshapes the
+        outer collector still surfaces a regression here."""
+        from mlpstorage_py.cluster_collector import _env_allowlist_match
+        assert _env_allowlist_match(varname) is False, (
+            f"{varname} must be denied by _env_allowlist_match (#663)."
+        )
+
+
 class TestEnvironmentMPIScriptParity:
     """Pattern B (D-36): collect_environment + _env_allowlist_match +
     _mask_credential_id + _redact_secret live inline in MPI_COLLECTOR_SCRIPT.


### PR DESCRIPTION
## Summary
- Closes #663. Follow-up to #643: reporter (@xutao00090) surfaced four Open-MPI env vars the #643 audit missed. Adds them to \`_ENV_RUNTIME_DENYLIST\` in lockstep across both copies (module-level frozenset at \`cluster_collector.py:1265\` and the MPI collector script tuple at \`:2255\`).
- \`TestEnvironmentMPIScriptParity\` enforces the two copies remain byte-for-byte identical.

## The 4 vars
| Variable | Reason |
|---|---|
| \`OMPI_MCA_orte_parent_uri\` | Random per-\`mpirun\` URI (job id + TCP port); also only on non-rank-0 processes. Independently trips \`SystemDriftError\` **and** breaks \`quantity: N\` dedup. |
| \`OMPI_MCA_ess_base_num_procs\` | Non-rank-0-only. |
| \`OMPI_MCA_plm\` | Non-rank-0-only (process launch manager name). |
| \`OMPI_MCA_routed\` | Non-rank-0-only (routing framework name). |

## Failure modes fixed
1. **Same-config re-run → \`SystemDriftError\`.** \`OMPI_MCA_orte_parent_uri\` carries a fresh random job id + TCP port on every \`mpirun\` invocation. The reporter's evidence: two runs on identical hardware produced \`systemname.yaml\` files that differed **only** in the 15 occurrences (one per non-rank-0 stanza) of this variable.
2. **\`quantity: N\` dedup defeated.** The three non-rank-0-only vars produce an asymmetric fingerprint — rank-0's env list is 4 entries shorter than every other rank's — so 16 identically-configured MPI processes generate 16 separate client stanzas instead of one \`quantity: 16\` stanza.

## TDD RED-first
- Commit 1 \`test(#663): RED\` adds \`TestEnvironmentRuntimeDenylistExpanded663\` (mirror of \`Expanded643\`'s shape) — parametrized per-var tests at both the \`collect_environment\` output boundary and the \`_env_allowlist_match\` name boundary. 8 failures on unpatched code.
- Commit 2 \`fix(#663): GREEN\` adds the four entries to both denylist copies.

## Out of scope
Reporter also noted \`STORAGE_*\` env vars are only on rank-0 (not propagated via \`mpirun\`). They correctly parked this as a separate issue — it defeats \`quantity: N\` dedup but doesn't cause \`SystemDriftError\` (rank-0's \`STORAGE_*\` values are stable across invocations). Deferring per reporter's own scoping.

## Test plan
- [x] \`uv run pytest tests/unit\` — 2524 passed, 1 skipped
- [x] \`uv run pytest mlpstorage_py/tests\` — 822 passed
- [x] \`uv run pytest vdb_benchmark/tests\` — 155 passed
- [x] \`uv run pytest kv_cache_benchmark/tests\` — 238 passed
- [x] RED-first verified: 8/8 new tests fail against unpatched denylist, then all pass after the 2-site fix.
- [x] Existing \`TestEnvironmentRuntimeDenylist\`, \`TestEnvironmentRuntimeDenylistExpanded643\`, and \`TestEnvironmentMPIScriptParity\` classes still green — no regression on the #643 baseline or the byte-for-byte parity contract.