### PR TITLE
fix(#666): promote prefetch_window to CLOSED-allowed; bump 3.0.31

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -430,6 +430,7 @@ root_folder (or any name you prefer)
 | *Storage parameters*         |                                                                                                                                     |          |
 | storage.storage_root         | The storage root directory                                                                                                          | ./       |
 | storage.storage_type         | The storage type                                                                                                                    | local_fs |
+| storage.storage_options.prefetch_window | Client-side s3dlio prefetch depth for object-storage runs. Same class of knob as `reader.read_threads`: tunes client I/O concurrency, not workload semantics (same bytes, same access pattern, same AU rule). Object-storage-only: on POSIX, prefetch flows through the reclaimable page cache and imposes no whole-record host-memory pressure; on object storage each prefetch slot pins a whole record until consumed, so the closed default may leave no valid operating point for large-record models. Uncapped, matching `reader.read_threads`. | s3dlio default |
 
 3.6.3. **trainingOpenSubmissionParameters** -- For OPEN submissions of this benchmark, only a few additional parameters can be modified over those allowed in CLOSED, and those additional parameters are listed in the table below.  Any other parameters being modified must generate a message and fail the validation.
 

--- a/mlpstorage_py/rules/run_checkers/training.py
+++ b/mlpstorage_py/rules/run_checkers/training.py
@@ -28,6 +28,15 @@ class TrainingRunRulesChecker(RunRulesChecker):
         'checkpoint.checkpoint_folder',
         'storage.storage_type',
         'storage.storage_root',
+        # Issue #666: s3dlio client-side prefetch depth for object-storage
+        # runs. Same class of knob as reader.read_threads — tunes client I/O
+        # concurrency, not workload semantics (same bytes, same access
+        # pattern, same AU rule). Promoted from OPEN-only (#629/#634) to
+        # CLOSED-allowed because on object storage each prefetch slot pins
+        # a whole record in host memory, and at the s3dlio default no
+        # CLOSED-valid operating point exists for unet3d on typical
+        # client-memory budgets. See Rules.md §3.6.2.
+        'storage.storage_options.prefetch_window',
     ]
 
     # Parameters allowed for OPEN submission (but not CLOSED)
@@ -36,11 +45,6 @@ class TrainingRunRulesChecker(RunRulesChecker):
         'dataset.format',
         'dataset.num_samples_per_file',
         'reader.data_loader',
-        # Issue #629: s3dlio client-side prefetch depth for object-storage
-        # runs. Documented as a tunable in docs/RetinaNet_NP_Scaling_Results.md
-        # (default 256). Tunes I/O concurrency, not the workload spec —
-        # OPEN-only so closed submissions stay comparable.
-        'storage.storage_options.prefetch_window',
     ]
 
     # Parameters that the mlpstorage tool injects into the DLIO config without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.30"
+version = "3.0.31"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/unit/test_rules_checkers.py
+++ b/tests/unit/test_rules_checkers.py
@@ -957,34 +957,46 @@ class TestTrainingParquetFormat:
                 f"dataset.format={format_value} should be OPEN category"
 
 
-class TestOpenStorageOptionsPrefetchWindowIssue629:
-    """Issue #629: `storage.storage_options.prefetch_window` is an s3dlio
-    client-side prefetch-depth knob (docs/RetinaNet_NP_Scaling_Results.md
-    documents it as a tunable, default 256). Tuning it changes I/O
-    concurrency, not the workload spec — so it belongs in OPEN's
-    allow-list. Before this fix it was absent from every allow-list and
-    was rejected as INVALID, aborting the reporter's OPEN run.
+class TestClosedStorageOptionsPrefetchWindowIssue666:
+    """Issue #666: `storage.storage_options.prefetch_window` is a client-side
+    I/O parallelism knob in exactly the same class as `reader.read_threads`
+    (which has always been CLOSED-tunable): same bytes, same access pattern,
+    same AU rule — it only tunes request concurrency, not workload semantics.
+
+    On object storage each prefetch slot pins a whole record in host memory
+    until consumed. For unet3d (~140 MiB records) at the s3dlio default
+    (min(prefetch_window, 64) = 64 concurrent GETs per worker), a single
+    read_thread pins ~18.5 GiB. That leaves no CLOSED-valid operating point
+    on typical unet3d client-memory budgets — lowering read_threads fails AU,
+    raising it OOMs the host. Reporter (bissantz) demonstrated the deadlock
+    and MEMBER russfellows +1'd 2026-07-03.
+
+    Issue #629 previously promoted this knob from INVALID to OPEN-only via
+    PR #634. Issue #666 promotes it further: from OPEN-only to CLOSED-allowed
+    (uncapped, matching read_threads' treatment). Rules.md §3.6.2 CLOSED
+    tunable-parameters table now lists it alongside the other
+    ``storage.*`` entries. This test class supersedes the #629 test class of
+    the same shape.
     """
 
     @pytest.fixture
     def mock_logger(self):
         return MagicMock()
 
-    def test_prefetch_window_override_is_open_category_issue_629(self, mock_logger):
-        """OPEN override of storage.storage_options.prefetch_window must
-        classify as OPEN, not INVALID.
+    def test_prefetch_window_override_is_closed_category_issue_666(self, mock_logger):
+        """CLOSED override of storage.storage_options.prefetch_window must
+        classify as CLOSED (permitted), not OPEN or INVALID.
 
-        Repro from issue #629:
-          mlpstorage open training unet3d run object \\
+        Post-#666:
+          mlpstorage closed training unet3d run object \\
             --params storage.storage_options.prefetch_window=8 ...
-          -> ERROR: INVALID: Disallowed parameter override:
-             storage.storage_options.prefetch_window = 8
+          -> CLOSED-allowed override; no message; not upgraded to OPEN.
         """
         data = BenchmarkRunData(
             benchmark_type=BENCHMARK_TYPES.training,
             model="unet3d",
             command="run",
-            run_datetime="20260701_195014",
+            run_datetime="20260704_120000",
             num_processes=1,
             parameters={
                 "dataset": {"num_files_train": 28271},
@@ -998,29 +1010,28 @@ class TestOpenStorageOptionsPrefetchWindowIssue629:
         checker = TrainingRunRulesChecker(run, logger=mock_logger)
         issues = checker.check_allowed_params()
 
-        assert len(issues) == 1
-        assert issues[0].validation == PARAM_VALIDATION.OPEN, (
-            f"Issue #629: storage.storage_options.prefetch_window must be "
-            f"OPEN-allowed, got {issues[0].validation!r}. Message: "
-            f"{issues[0].message!r}"
+        # CLOSED-allowed params produce no issue in check_allowed_params.
+        assert issues == [], (
+            f"Issue #666: storage.storage_options.prefetch_window must be "
+            f"CLOSED-allowed and produce zero issues, got {issues!r}"
         )
 
-    def test_prefetch_window_in_open_allowed_params_issue_629(self):
-        """Set-membership assertion: locks the allow-list entry."""
+    def test_prefetch_window_in_closed_allowed_params_issue_666(self):
+        """Set-membership assertion: locks the CLOSED allow-list entry."""
         assert (
             'storage.storage_options.prefetch_window'
-            in TrainingRunRulesChecker.OPEN_ALLOWED_PARAMS
+            in TrainingRunRulesChecker.CLOSED_ALLOWED_PARAMS
         )
 
-    def test_prefetch_window_not_in_closed_allowed_params_issue_629(self):
-        """Scope guard: prefetch_window must NOT be CLOSED-allowed.
+    def test_prefetch_window_not_in_open_allowed_params_issue_666(self):
+        """Scope guard: prefetch_window must appear ONLY in CLOSED after #666.
 
-        On CLOSED, all client tuning knobs affecting AU stay at their
-        defaults so submissions are comparable. Adding this to
-        CLOSED_ALLOWED_PARAMS would let closed submitters game AU by
-        cranking prefetch depth. This is an OPEN-only knob.
+        Duplicating it into OPEN_ALLOWED_PARAMS is not a bug per se — the
+        allow-list check would still admit it — but it would drift the
+        two lists' semantics ("what OPEN adds on top of CLOSED"). Keep
+        it in CLOSED only.
         """
         assert (
             'storage.storage_options.prefetch_window'
-            not in TrainingRunRulesChecker.CLOSED_ALLOWED_PARAMS
+            not in TrainingRunRulesChecker.OPEN_ALLOWED_PARAMS
         )

--- a/tests/unit/test_rules_checkers.py
+++ b/tests/unit/test_rules_checkers.py
@@ -1010,10 +1010,13 @@ class TestClosedStorageOptionsPrefetchWindowIssue666:
         checker = TrainingRunRulesChecker(run, logger=mock_logger)
         issues = checker.check_allowed_params()
 
-        # CLOSED-allowed params produce no issue in check_allowed_params.
-        assert issues == [], (
+        # check_allowed_params emits one PARAM_VALIDATION.CLOSED "override
+        # allowed" note per override; must not upgrade to OPEN or INVALID.
+        assert len(issues) == 1
+        assert issues[0].validation == PARAM_VALIDATION.CLOSED, (
             f"Issue #666: storage.storage_options.prefetch_window must be "
-            f"CLOSED-allowed and produce zero issues, got {issues!r}"
+            f"CLOSED-allowed, got {issues[0].validation!r}. Message: "
+            f"{issues[0].message!r}"
         )
 
     def test_prefetch_window_in_closed_allowed_params_issue_666(self):

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.30"
+version = "3.0.31"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
## Summary
- Closes #666. Reporter (@bissantz) surfaced that on object storage the s3dlio default \`prefetch_window\` pins ~140 MiB per slot × 64 concurrent GETs × N read threads, leaving no CLOSED-valid operating point for unet3d on typical client-memory budgets. Lowering \`read_threads\` fails AU; raising it OOMs the host. MEMBER @russfellows +1'd 2026-07-03.
- \`storage.storage_options.prefetch_window\` is the same class of knob as \`reader.read_threads\` — client-side I/O parallelism, no change to workload semantics (same bytes, same access pattern, same AU rule). \`reader.read_threads\` has always been CLOSED-tunable for exactly that reason.
- Promotes \`prefetch_window\` from OPEN-only (#629/#634) to CLOSED-allowed. **Uncapped**, matching \`read_threads\`.
- Companion Rules.md §3.6.2 edit: adds the parameter to the CLOSED tunable-parameters table with an explicit description of the object-storage-only motivation.

## Sites changed
| File | Change |
|---|---|
| \`mlpstorage_py/rules/run_checkers/training.py\` | Move \`storage.storage_options.prefetch_window\` from \`OPEN_ALLOWED_PARAMS\` to \`CLOSED_ALLOWED_PARAMS\`; refresh comment |
| \`Rules.md\` §3.6.2 | Add \`prefetch_window\` row to the CLOSED Training Workload Tunable Parameters table |
| \`tests/unit/test_rules_checkers.py\` | Rewrite the #629 test class into \`TestClosedStorageOptionsPrefetchWindowIssue666\` — 3 tests: CLOSED classification, membership in CLOSED_ALLOWED_PARAMS, non-membership in OPEN_ALLOWED_PARAMS |
| \`pyproject.toml\` + \`uv.lock\` | Bump 3.0.30 → 3.0.31 |

## Back-compat
No risk. Existing CLOSED submissions used the s3dlio default (\`min(prefetch_window, 64) = 64\` concurrent GETs per worker), which remains legal under the widened allow-list.

## TDD RED-first
- Commit 1 \`test(#666): RED\` rewrites the \`TestOpenStorageOptionsPrefetchWindowIssue629\` class into \`TestClosedStorageOptionsPrefetchWindowIssue666\`. 3 failures on unpatched code.
- Commit 2 \`fix(#666): GREEN\` moves the entry, updates Rules.md, bumps version, regenerates uv.lock, and tightens one assertion (\`check_allowed_params\` emits a \`PARAM_VALIDATION.CLOSED\` "override allowed" note per override rather than \`[]\`).

## Test plan
- [x] \`uv run pytest tests/unit\` — 2525 passed, 1 skipped
- [x] \`uv run pytest mlpstorage_py/tests\` — 822 passed
- [x] \`uv run pytest vdb_benchmark/tests\` — 155 passed
- [x] \`uv run pytest kv_cache_benchmark/tests\` — 238 passed
- [x] RED-first verified: 3/3 new tests fail against the unpatched allow-list; all pass after the one-line move.