### PR TITLE
chore: bump 3.0.32 + DLIO PR #42 (fixes storage#667 rank-0 checkpoint LIST)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.31"
+version = "3.0.32"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -132,6 +132,10 @@ torchaudio = [{ index = "pytorch-cpu" }]
 # Pinned to a specific commit for reproducibility; bump by updating `rev` and
 # re-running `uv lock --upgrade-package dlio-benchmark`.
 # Commit history (most recent first):
+#   - DLIO PR #42 fix for storage #667: _checkpoint LIST once on rank 0
+#     and broadcast the count — prevents SlowDown/503 storms and spurious
+#     "0 checkpoints available" aborts at scale (llama3-405b, 512 ranks
+#     on S3). Also fixes a latent missing-f-string on the failure Exception.
 #   - DLIO PR #41 fix for storage #593: write integrity for obj_store_lib —
 #     opt-in verification, s3dlio 0.9.106
 #   - DLIO PR #39 fix for storage #567: O_DIRECT path triggers on
@@ -150,7 +154,7 @@ torchaudio = [{ index = "pytorch-cpu" }]
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
 #   - DLIO PR #21 fix for storage #391 part 1 (TorchIterableDatasetSimple gating)
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "f6796ed281e39ccc83a450e2b1f21b9c909d8fd0" }
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "c338e07412350df4d72279be985ff31b82407a80" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=f6796ed281e39ccc83a450e2b1f21b9c909d8fd0#f6796ed281e39ccc83a450e2b1f21b9c909d8fd0" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=c338e07412350df4d72279be985ff31b82407a80#c338e07412350df4d72279be985ff31b82407a80" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.31"
+version = "3.0.32"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=f6796ed281e39ccc83a450e2b1f21b9c909d8fd0" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=f6796ed281e39ccc83a450e2b1f21b9c909d8fd0" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=c338e07412350df4d72279be985ff31b82407a80" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=c338e07412350df4d72279be985ff31b82407a80" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary
- Closes #667 (post-merge cleanup). Advances the pinned \`dlio-benchmark\` rev to \`c338e074\` — the merge SHA of mlcommons/DLIO_local_changes#42, which lands the rank-0-guarded \`_checkpoint\` LIST + \`bcast\` and the companion latent f-string fix.
- Version bump 3.0.31 → 3.0.32.
- \`uv lock --upgrade-package dlio-benchmark\` regeneration. Only the \`mlpstorage\` and \`dlio-benchmark\` entries in \`uv.lock\` changed — no transitive-dep drift.

## Why the DLIO change matters (see #667 for the full report)
At scale (llama3-405b, 32 nodes × 16 ranks = 512 processes) DLIO's \`_checkpoint\` ran a full recursive LIST on **every** rank. ~16 pages × 512 ranks ≈ 8k concurrent recursive LISTs bombarded the S3 endpoint, tripped \`SlowDown\`/503, and — because \`ObjStoreLibStorage.list_objects\` swallowed the error into \`[]\` — aborted otherwise-intact reads with *"Number of checkpoints to be read: N is more than the number of checkpoints available: 0"*. The DLIO fix has rank-0 LIST once and \`bcast\` the count; every other \`walk_node\` caller in the DLIO tree was already rank-0-guarded (audit in the DLIO PR body).

## Sites changed
| File | Change |
|---|---|
| \`pyproject.toml\` | \`version\` 3.0.31 → 3.0.32; \`dlio-benchmark rev\` bumped; commit-history comment block gets a two-line note for PR #42 |
| \`uv.lock\` | Regenerated via \`uv lock --upgrade-package dlio-benchmark\`; only \`mlpstorage\` and \`dlio-benchmark\` lines change |

## Test plan
- [x] \`uv run pytest tests/unit\` — 2525 passed, 1 skipped
- [x] \`uv run pytest mlpstorage_py/tests\` — 822 passed
- [x] \`uv run pytest vdb_benchmark/tests\` — 155 passed
- [x] \`uv run pytest kv_cache_benchmark/tests\` — 238 passed
- [ ] Integration validation of the fix itself (llama3-405b at 512 ranks) is out of scope for this bump PR — it's already covered by the DLIO PR's test-plan.

Follows the pattern of prior DLIO-bump PRs (#636 for DLIO #41, #582 for DLIO #39, #533/#535 for DLIO #36).