### PR TITLE
fix(#669): aggregate host_memory_GB via sum(), not num_hosts × array[0]

### DIFF
--- a/mlpstorage_py/rules/models.py
+++ b/mlpstorage_py/rules/models.py
@@ -586,20 +586,55 @@ class ClusterInformation:
 
     @classmethod
     def from_dlio_summary_json(cls, summary, logger) -> Optional['ClusterInformation']:
-        """Create ClusterInformation from DLIO summary.json data."""
+        """Create ClusterInformation from DLIO summary.json data.
+
+        storage#669: DLIO's ``host_memory_GB`` and ``host_cpu_count``
+        arrays are populated via MPI SUM-Reduce keyed on
+        ``self.MPI.node()``. On multi-rank-per-host clusters where
+        ``MPI.node()`` doesn't map monotonically to
+        ``0..nnodes-1`` slots, some slots are doubled and some are
+        zero. Only the sums are authoritative; positional access is
+        not. We compute cluster-mean per-host values from the sums
+        and use ``num_hosts`` (which DLIO reports separately, correctly)
+        as the record count.
+        """
+        # Import lazily to avoid a top-level circular between
+        # rules/models.py and submission_checker/dlio_summary_helpers.py.
+        from mlpstorage_py.submission_checker.dlio_summary_helpers import (
+            cluster_total_host_memory_gb,
+        )
+
         host_memories = summary.get("host_memory_GB")
         host_cpus = summary.get("host_cpu_count")
         if host_memories is None or host_cpus is None:
             return None
 
+        num_hosts = int(summary.get("num_hosts", 0) or 0)
+        if num_hosts <= 0:
+            # Fall back to array length only when DLIO didn't report
+            # num_hosts. Length may be wrong (equals nnodes rather than
+            # unique physical hosts) but it's the best we have.
+            num_hosts = len(host_memories) if host_memories else 0
+        if num_hosts <= 0:
+            return None
+
+        total_memory_gb = cluster_total_host_memory_gb(summary)
+        per_host_memory_gb_ = total_memory_gb / num_hosts
+        # host_cpu_count uses the same SUM-Reduce pattern; the sum is
+        # authoritative but positional access is not.
+        try:
+            total_cpu_count = sum(int(c) for c in host_cpus if c is not None)
+        except (TypeError, ValueError):
+            total_cpu_count = 0
+        per_host_cpu_count = total_cpu_count // num_hosts if num_hosts else 0
+
         host_info_list = []
-        num_hosts = len(host_memories)
         for i in range(num_hosts):
-            memory_bytes = int(host_memories[i] * 1024 * 1024 * 1024)
+            memory_bytes = int(per_host_memory_gb_ * 1024 * 1024 * 1024)
             host_info = HostInfo(
                 hostname=f"host_{i}",
                 memory=HostMemoryInfo.from_total_mem_int(memory_bytes),
-                cpu=HostCPUInfo(num_cores=host_cpus[i]) if i < len(host_cpus) else None,
+                cpu=HostCPUInfo(num_cores=per_host_cpu_count) if per_host_cpu_count else None,
             )
             host_info_list.append(host_info)
 

--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -2,6 +2,7 @@
 from .base import BaseCheck
 from ..constants import *
 from ..configuration.configuration import Config
+from ..dlio_summary_helpers import per_host_memory_gb
 from ..loader import SubmissionLogs
 from ..rule_registry import rule
 from .helpers import (
@@ -130,7 +131,10 @@ class CheckpointingCheck(BaseCheck):
 
         for summary, metadata, _ in self._iter_valid_files():
             checkpoint_size_gb = summary.get("metric", {}).get("checkpoint_size_GB", 0)
-            host_memory_gb = summary.get("host_memory_GB", [0])[0]
+            # storage#669: use sum(host_memory_GB) / num_hosts rather than
+            # host_memory_GB[0]. DLIO's array is positionally malformed on
+            # multi-rank-per-host clusters; only the sum is authoritative.
+            host_memory_gb = per_host_memory_gb(summary) or 0.0
             num_hosts = summary.get("num_hosts", 1)
 
             if checkpoint_size_gb == 0 or host_memory_gb == 0:

--- a/mlpstorage_py/submission_checker/checks/submission_structure_checks.py
+++ b/mlpstorage_py/submission_checker/checks/submission_structure_checks.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from .base import BaseCheck
 from ..configuration.configuration import Config
+from ..dlio_summary_helpers import per_host_memory_gb
 from ..rule_registry import rule
 from ..tools.code_checksum import compute_code_tree_md5
 from ..tools.code_image import (
@@ -800,7 +801,7 @@ class SubmissionStructureCheck(BaseCheck):
                 )
                 valid = False
 
-        # Cross-check 2 — per-host memory (index-aligned when possible)
+        # Cross-check 2 — mean per-host memory vs system YAML nameplate.
         # ``memory_capacity`` in the system YAML is nameplate (GB) while
         # ``host_memory_GB`` in summary.json is the usable amount the OS
         # sees (GiB after DDR overhead, kernel reserve, BIOS-reserved
@@ -810,32 +811,37 @@ class SubmissionStructureCheck(BaseCheck):
         # Use a ±10% band: catches genuine config mismatches (e.g., a
         # 256 GB rig reporting against a 768 GB YAML — ~3x off) while
         # letting nameplate-vs-usable through.
+        #
+        # storage#669: prior versions iterated positionally over
+        # host_memory_GB[i], which is unreliable — DLIO's SUM-Reduce
+        # populates that array in slots keyed on self.MPI.node() and on
+        # multi-rank-per-host clusters some slots are doubled and some
+        # are zero. Only sum(array) is authoritative. We compare the
+        # cluster-mean per-host memory against the nameplate; that
+        # collapses the per-host granularity that the original check
+        # advertised, but that granularity was already fictional given
+        # the array shape.
         MEMORY_TOLERANCE = 0.10
-        host_memory_list = summary.get("host_memory_GB")
+        mean_per_host_memory = per_host_memory_gb(summary)
         if (
-            host_memory_list is not None
+            mean_per_host_memory is not None
+            and mean_per_host_memory > 0
             and expected_memory_per_host is not None
-            and isinstance(host_memory_list, list)
         ):
-            for i, mem in enumerate(host_memory_list):
-                try:
-                    mem_int = int(mem)
-                except (TypeError, ValueError):
-                    continue
-                lower = expected_memory_per_host * (1 - MEMORY_TOLERANCE)
-                upper = expected_memory_per_host * (1 + MEMORY_TOLERANCE)
-                if not (lower <= mem_int <= upper):
-                    self.log_violation(
-                        "2.1.9", "identicalSystemConfig",
-                        summary_path,
-                        "host_memory_GB[%d] mismatch: summary.json has %s GiB, "
-                        "system YAML client chassis.memory_capacity is %s GiB "
-                        "(outside ±%d%% tolerance)",
-                        i, mem_int, expected_memory_per_host,
-                        int(MEMORY_TOLERANCE * 100),
-                    )
-                    valid = False
-                    break  # one violation per summary.json per field is sufficient
+            lower = expected_memory_per_host * (1 - MEMORY_TOLERANCE)
+            upper = expected_memory_per_host * (1 + MEMORY_TOLERANCE)
+            if not (lower <= mean_per_host_memory <= upper):
+                self.log_violation(
+                    "2.1.9", "identicalSystemConfig",
+                    summary_path,
+                    "cluster-mean host memory mismatch: "
+                    "sum(summary.json host_memory_GB) / num_hosts = %.1f GiB, "
+                    "system YAML client chassis.memory_capacity is %s GiB "
+                    "(outside ±%d%% tolerance)",
+                    mean_per_host_memory, expected_memory_per_host,
+                    int(MEMORY_TOLERANCE * 100),
+                )
+                valid = False
 
         # Cross-check 3 — multi_host capability vs. num_hosts > 1
         if (

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -2,6 +2,7 @@
 from .base import BaseCheck
 from ..constants import *
 from ..configuration.configuration import Config
+from ..dlio_summary_helpers import cluster_total_host_memory_gb
 from ..loader import SubmissionLogs
 from ..rule_registry import rule
 from .helpers import (
@@ -165,7 +166,12 @@ class TrainingCheck(BaseCheck):
                 # From summary
                 num_accelerators = summary.get("num_accelerators", 1)
                 num_hosts = summary.get("num_hosts", 1)
-                host_memory_gb = summary.get("host_memory_GB", [0])[0]
+                # storage#669: DLIO's host_memory_GB array is populated by an
+                # MPI SUM-Reduce keyed on self.MPI.node(). On multi-rank-per-
+                # host clusters where MPI.node() doesn't map monotonically to
+                # 0..nnodes-1, some slots are doubled and some are zero. sum()
+                # is authoritative; array[0] * num_hosts is not.
+                total_host_memory = cluster_total_host_memory_gb(summary)
 
                 if record_length == 0:
                     self.log_violation(
@@ -180,8 +186,8 @@ class TrainingCheck(BaseCheck):
                                         num_files_train * num_samples_per_file // (batch_size * num_accelerators))
                 min_samples_steps = num_steps_per_epoch * batch_size * num_accelerators
 
-                # Calculate min samples from host memory
-                total_host_memory = num_hosts * host_memory_gb
+                # Calculate min samples from host memory. total_host_memory
+                # was aggregated via cluster_total_host_memory_gb above.
                 min_samples_memory = (total_host_memory * HOST_MEMORY_MULTIPLIER *
                                     1024 * 1024 * 1024 / record_length)
 

--- a/mlpstorage_py/submission_checker/dlio_summary_helpers.py
+++ b/mlpstorage_py/submission_checker/dlio_summary_helpers.py
@@ -1,0 +1,85 @@
+"""Helpers for interpreting DLIO ``summary.json`` fields that the raw
+array shape makes error-prone.
+
+Currently limited to ``host_memory_GB``. DLIO populates that field via
+an MPI ``SUM``-Reduce keyed on ``self.MPI.node()`` — one slot per
+"node index", filled once per host by that host's local-rank-0. On
+multi-rank-per-host clusters where ``self.MPI.node()`` does not
+monotonically map to distinct ``0..nnodes-1`` slots, the resulting
+array has some slots doubled (two hosts' local-rank-0 wrote to the
+same slot; the SUM combined them) and some slots at 0 (no host's
+local-rank-0 wrote there). The *sum* is always correct
+(SUM-reduce is total-preserving); *positional* access is not.
+
+See mlcommons/storage#669 for the reporter's evidence and the DLIO
+follow-up that will emit a clean one-value-per-host array upstream.
+Until that lands, every checker that needs to reason about cluster
+memory must aggregate the whole array. These helpers are the single
+place that aggregation lives so the anti-pattern
+(``num_hosts * host_memory_GB[0]``, or a positional per-host loop
+that trusts index alignment) cannot come back at a single call site.
+
+The helpers accept the raw ``summary`` dict (not a pre-extracted
+list) so callers uniformly go through this module rather than
+sometimes reading the field themselves.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+def cluster_total_host_memory_gb(summary: Mapping[str, Any]) -> float:
+    """Return the aggregate cluster host memory in GiB.
+
+    Uses ``sum(host_memory_GB)``, which is authoritative regardless of
+    DLIO's per-slot layout (see module docstring). Missing / non-list
+    / non-numeric entries collapse to 0 rather than raising, since
+    this helper is called on user-supplied summary.json content that
+    may be malformed for reasons unrelated to storage#669.
+
+    Args:
+        summary: The ``summary.json`` dict as loaded from disk.
+
+    Returns:
+        Cluster total host memory in GiB. Returns 0.0 if the field is
+        missing / empty / entirely non-numeric.
+    """
+    raw = summary.get("host_memory_GB")
+    if not isinstance(raw, (list, tuple)):
+        return 0.0
+    total = 0.0
+    for entry in raw:
+        try:
+            total += float(entry)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def per_host_memory_gb(summary: Mapping[str, Any]) -> Optional[float]:
+    """Return the per-host memory in GiB, computed as cluster total /
+    ``num_hosts``.
+
+    Assumes homogeneous hosts, which is required for CLOSED
+    submissions by rule 2.1.9 (``identicalSystemConfig``) and is the
+    only defensible reading of a positionally-broken DLIO array. On
+    heterogeneous OPEN submissions the returned value is the mean
+    per host, which is still the best available answer given the
+    input's information loss.
+
+    Args:
+        summary: The ``summary.json`` dict as loaded from disk.
+
+    Returns:
+        Per-host memory in GiB, or ``None`` if ``num_hosts`` is
+        missing / zero / non-numeric.
+    """
+    total = cluster_total_host_memory_gb(summary)
+    try:
+        num_hosts = int(summary.get("num_hosts", 0))
+    except (TypeError, ValueError):
+        return None
+    if num_hosts <= 0:
+        return None
+    return total / num_hosts

--- a/mlpstorage_py/tests/test_issue_669_host_memory_aggregation.py
+++ b/mlpstorage_py/tests/test_issue_669_host_memory_aggregation.py
@@ -1,0 +1,174 @@
+"""Regression tests for storage#669 — host_memory_GB aggregation.
+
+DLIO populates ``summary.json["host_memory_GB"]`` via an MPI SUM-Reduce
+across ranks: local-rank-0 on each host writes its per-host memory into
+a slot indexed by ``self.MPI.node()``, and the array is then summed
+across ranks. On multi-rank-per-host clusters where ``self.MPI.node()``
+does not monotonically map to distinct 0..nnodes-1 slots, the resulting
+array is malformed:
+
+* Some slots carry doubled values (two hosts' local-rank-0 wrote to the
+  same slot; the SUM combined them).
+* Some slots carry 0 (no host's local-rank-0 wrote there).
+
+The array's *sum* is always correct (SUM-reduce is total-preserving);
+*positional* access is not.
+
+Every mlpstorage_py caller that computed cluster memory as
+``num_hosts * host_memory_GB[0]`` — or that iterated positionally — was
+subject to a spurious 2x inflation or 0x collapse depending on which
+slot happened to land at index [0]. The primary caller is rule 3.1.2
+(``recalculate_dataset_size``), and the reporter's real submission
+(15 hosts, 30 accelerators, 2 ranks/host) was falsely rejected because
+``host_memory_GB[0]`` was a doubled entry, doubling the minimum-samples
+requirement.
+
+Reporter's exact evidence array (`storage#669`):
+
+    [376.18, 376.18, 376.18, 376.18, 376.18, 376.18, 376.18,
+     187.90, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+    sum(array)                         = 2821 GiB  (correct total)
+    15 * array[0] = 15 * 376.18        = 5642.7 GiB (2x inflation)
+    per-host truth = 2821 / 15         = 188.09 GiB
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mlpstorage_py.submission_checker.checks.training_checks import TrainingCheck
+from mlpstorage_py.submission_checker.configuration.configuration import Config
+from mlpstorage_py.submission_checker.loader import LoaderMetadata, SubmissionLogs
+
+
+# Reporter's exact evidence array (storage#669). Sum = 2821 GiB.
+REPORTER_MALFORMED_ARRAY = [
+    376.18, 376.18, 376.18, 376.18, 376.18, 376.18, 376.18,
+    187.90, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+]
+REPORTER_NUM_HOSTS = 15
+REPORTER_NUM_ACCELERATORS = 30              # 2 ranks per host
+REPORTER_RECORD_LENGTH_BYTES = 146_600_628  # unet3d record size
+REPORTER_NUM_FILES_TRAIN = 105_000          # what the submitter generated
+REPORTER_BATCH_SIZE = 7
+
+# The correct minimum from Rules.md 3.1.2 given real 2821 GiB cluster
+# memory: 2821 * 5 * 1024**3 / 146_600_628 ≈ 103_313 files. Submitter
+# generated 105_000 → PASS. Buggy code computes 15 * 376.18 = 5642 GiB
+# → ≈206_641 files → FAIL.
+REPORTER_TRUE_MIN_FILES = 103_313
+
+
+def _make_training_check(tmp_path, run_files):
+    log = MagicMock()
+    config = Config(version="v2.0", submitters=["Acme"], skip_output_file=True)
+    submissions_logs = SubmissionLogs(
+        datagen_files=[],
+        run_files=run_files,
+        system_file=None,
+        loader_metadata=LoaderMetadata(
+            division="closed",
+            submitter="Acme",
+            system="sys-v1",
+            mode="training",
+            benchmark="unet3d",
+            folder=str(tmp_path),
+        ),
+    )
+    return TrainingCheck(log=log, config=config, submissions_logs=submissions_logs), log
+
+
+def _reporter_summary_and_metadata():
+    """Build the exact summary + metadata pair the reporter submitted."""
+    summary = {
+        "num_hosts":        REPORTER_NUM_HOSTS,
+        "num_accelerators": REPORTER_NUM_ACCELERATORS,
+        "host_memory_GB":   list(REPORTER_MALFORMED_ARRAY),
+        "num_files_train":  REPORTER_NUM_FILES_TRAIN,
+        "num_files_eval":   0,
+        "metric": {
+            "train_au_meet_expectation":  "success",
+            "train_au_mean_percentage":   99.0,
+        },
+    }
+    metadata = {
+        "parameters": {
+            "dataset": {
+                "num_files_train":       REPORTER_NUM_FILES_TRAIN,
+                "num_samples_per_file":  1,
+                "record_length_bytes":   REPORTER_RECORD_LENGTH_BYTES,
+            },
+            "reader": {"batch_size": REPORTER_BATCH_SIZE},
+        },
+        "args": {"hosts": [f"h{i}" for i in range(REPORTER_NUM_HOSTS)],
+                 "data_dir": "/data", "results_dir": "/results"},
+        "verification": "closed",
+        "params_dict": {},
+    }
+    return summary, metadata
+
+
+class TestRule312DoesNotDoubleCountMalformedHostMemoryArray:
+    """storage#669 primary: rule 3.1.2 must aggregate the whole
+    host_memory_GB array (sum), not index [0] * num_hosts.
+
+    The reporter's real submission has 105_000 files, above the true
+    minimum of ~103_313 files given the real 2821 GiB cluster memory.
+    The buggy code inflates that minimum to ~206_641 files and falsely
+    logs a violation. This test class pins the correct behavior.
+    """
+
+    def test_reporter_scenario_passes_3_1_2(self, tmp_path):
+        """105k files against 2821 GiB real cluster memory must pass
+        Rules.md 3.1.2 (min ≈ 103_313 files), not falsely fail with the
+        2x-inflated 206_641-files minimum."""
+        summary, metadata = _reporter_summary_and_metadata()
+        run_files = [(summary, metadata, "20260703_120000")]
+        check, log = _make_training_check(tmp_path, run_files)
+
+        result = check.recalculate_dataset_size()
+
+        assert result is True, (
+            "storage#669: rule 3.1.2 must PASS for the reporter's real "
+            "submission (105_000 files vs true min ~103_313). The 2x "
+            "inflation from num_hosts*array[0] must not fire. "
+            f"log calls: {log.mock_calls}"
+        )
+
+    def test_true_undersized_submission_still_fails_3_1_2(self, tmp_path):
+        """Guardrail: an actually-undersized submission (fewer files
+        than the sum-based minimum) must still fail. This is the flip
+        side of the fix — we're moving the wall to the right place,
+        not tearing it down."""
+        summary, metadata = _reporter_summary_and_metadata()
+        # Cut num_files_train in half: 52_500 < 103_313 → must fail.
+        summary["num_files_train"] = 52_500
+        metadata["parameters"]["dataset"]["num_files_train"] = 52_500
+        run_files = [(summary, metadata, "20260703_120000")]
+        check, log = _make_training_check(tmp_path, run_files)
+
+        result = check.recalculate_dataset_size()
+
+        assert result is False, (
+            "Rule 3.1.2 must still fail for a genuinely undersized "
+            "dataset (52_500 files < true min ~103_313)."
+        )
+
+    def test_homogeneous_array_still_passes_3_1_2(self, tmp_path):
+        """Guardrail: the well-formed case must keep working. When the
+        DLIO array is clean (one entry per host, no zeros, no doubling),
+        sum(array) == num_hosts * array[0], so the fix is a no-op on
+        homogeneous input."""
+        summary, metadata = _reporter_summary_and_metadata()
+        # Replace with a clean 15-entry homogeneous array. Same total.
+        summary["host_memory_GB"] = [188.09] * REPORTER_NUM_HOSTS
+        run_files = [(summary, metadata, "20260703_120000")]
+        check, log = _make_training_check(tmp_path, run_files)
+
+        result = check.recalculate_dataset_size()
+
+        assert result is True, (
+            "Rule 3.1.2 must PASS for the well-formed-array equivalent "
+            "of the reporter's scenario (regression guard)."
+        )


### PR DESCRIPTION
## Summary
- Closes #669. Reporter (@mirajeev) surfaced that rule 3.1.2 (\`trainingRecalculateDatasetSize\`) was rejecting a genuinely compliant submission (105,000 files) with a doubled minimum-samples requirement (~206,641).
- Root cause: DLIO populates \`summary.json[host_memory_GB]\` via an MPI \`SUM\`-Reduce keyed on \`self.MPI.node()\`. On multi-rank-per-host clusters where \`MPI.node()\` doesn't map monotonically to \`0..nnodes-1\` slots, some slots are doubled (two hosts' local-rank-0 wrote to the same slot) and some are 0 (no host's local-rank-0 wrote there). The array's *sum* is authoritative; *positional* access is not.
- Every mlpstorage caller that computed cluster memory as \`num_hosts × host_memory_GB[0]\` — or that iterated positionally — was subject to a 2× inflation or a 0× collapse depending on which slot happened to land at index \`[0]\`.

The reporter's exact evidence array (15 hosts, 30 accelerators, 2 ranks/host):
\`\`\`
[376.18 × 7, 187.90, 0.0 × 7]        sum = 2821 GiB (correct total)
                                    15 × array[0] = 5642.7 GiB (2× inflation)
\`\`\`

## The four sites that had the anti-pattern

Reporter flagged one; audit found three more:

| File | Rule | What went wrong | Fix |
|---|---|---|---|
| \`training_checks.py\` | **3.1.2** (\`trainingRecalculateDatasetSize\`) | Reporter's primary bug: \`total_host_memory = num_hosts × host_memory_GB[0]\` → 2× inflation → false rejection | Uses \`cluster_total_host_memory_gb(summary)\` |
| \`checkpointing_checks.py\` | **4.3.1** (\`checkpointDataSizeRatio\`) | Same anti-pattern: \`min_required = 3 × host_memory_GB[0]\` — 2×/0× under the same conditions | Uses \`per_host_memory_gb(summary)\` |
| \`submission_structure_checks.py\` | **2.1.9** (\`identicalSystemConfig\`) cross-check 2 | Iterated positionally, comparing each \`host_memory_GB[i]\` against the system-YAML nameplate in a ±10% band. On the reporter's array both the 376.18 and 0.0 slots fall outside band → spurious violation | Replaced with a mean-per-host comparison via \`per_host_memory_gb\`; the per-host granularity the original check advertised was already fictional given the array shape |
| \`rules/models.py\` \`ClusterInformation.from_dlio_summary_json\` | (not a rule itself; feeds downstream) | Built one \`HostInfo\` per array index with the malformed positional values (e.g. \`host_7=187.90 GiB\`, \`host_8..14=0 GiB\`) | Derives per-host memory and per-host CPU count from the sums / \`num_hosts\` so downstream sees \`num_hosts\` consistent records |

## Shared helper

New module \`mlpstorage_py/submission_checker/dlio_summary_helpers.py\` centralizes the aggregation so the anti-pattern can't come back at any single call site:

- \`cluster_total_host_memory_gb(summary) -> float\` — \`sum(host_memory_GB)\`
- \`per_host_memory_gb(summary) -> Optional[float]\` — cluster total / \`num_hosts\`

Both accept the raw \`summary\` dict so callers uniformly go through the helper rather than sometimes reading the field themselves.

## Follow-up
Filed a companion DLIO issue to fix the upstream data shape: \`statscounter.py\` should emit \`host_memory_GB\` (and the analogous \`host_cpu_count\`) as one clean value per unique physical host, so positional consumers stop being broken by construction. The storage-side fix defenses against the current bad shape and remains defensively correct after the DLIO fix lands.

## Back-compat
No risk. On well-formed \`host_memory_GB\` arrays (one clean entry per host, no zeros, no doubling — the DLIO-side ideal), \`sum(array) == num_hosts × array[0]\`, so the fix is a no-op. This is regression-tested in \`test_homogeneous_array_still_passes_3_1_2\`.

## TDD RED-first
- Commit 1 \`test(#669): RED\` adds tests using the reporter's exact evidence array. Verified failure against unpatched code with the *exact* violation string the reporter saw:
  > \`dataset size mismatch: actual files 105000 < minimum required 206643\`
- Commit 2 \`fix(#669): GREEN\` adds the helper module + fixes all four callers.

Also included a guardrail test (\`test_true_undersized_submission_still_fails_3_1_2\`) to ensure the fix moves the wall to the right place, not tears it down.

## Test plan
- [x] \`uv run pytest tests/unit\` — 2525 passed, 1 skipped
- [x] \`uv run pytest mlpstorage_py/tests\` — 825 passed
- [x] \`uv run pytest vdb_benchmark/tests\` — 155 passed
- [x] \`uv run pytest kv_cache_benchmark/tests\` — 238 passed
- [x] RED-first verified: reporter's exact scenario fails 3.1.2 on unpatched code, passes after the fix.
- [x] Homogeneous-array regression guard: well-formed \`[188.09] × 15\` still passes 3.1.2 after the fix.
- [x] Undersized-dataset guard: 52,500 files (half of true minimum) still fails 3.1.2 after the fix.