### PR TITLE
chore(#677): bump s3dlio floor 0.9.102 -> 0.9.106; 3.0.32 -> 3.0.33

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.32"
+version = "3.0.33"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -23,7 +23,7 @@ dependencies = [
     "minio>=7.2.20",
     "s3torchconnector>=1.5.0",
     "python-dotenv>=1.0.0",
-    "s3dlio>=0.9.102",
+    "s3dlio>=0.9.106",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.32"
+version = "3.0.33"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -616,7 +616,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'vectordb-milvus'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'vectordb-pgvector'", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "s3dlio", specifier = ">=0.9.102" },
+    { name = "s3dlio", specifier = ">=0.9.106" },
     { name = "s3torchconnector", specifier = ">=1.5.0" },
     { name = "tabulate", marker = "extra == 'vectordb'", specifier = ">=0.9" },
     { name = "tabulate", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=0.9" },


### PR DESCRIPTION
## Summary

- Bumps the direct `s3dlio` floor in `pyproject.toml` from `>=0.9.102` to `>=0.9.106` to match the requirement in `DLIO_local_changes` at our pinned rev `f6796ed`.
- Bumps `mlpstorage` version `3.0.32 -> 3.0.33`.
- Refreshes `uv.lock` (no dependency graph churn — `uv` was already resolving `s3dlio` to `0.9.106` via DLIO's transitive floor).

## Why

Reported by @russfellows in #677. The pyproject comment on the `dlio-benchmark` git source pin already documented "s3dlio 0.9.106", but the direct `s3dlio` dep line still read `>=0.9.102` — the pin drifted from its own documentation and from DLIO's floor.

We depend on `s3dlio` directly from our own production code:

- `mlpstorage_py/checkpointing/storage_readers/s3dlio_reader.py`
- `mlpstorage_py/checkpointing/storage_writers/s3dlio_writer.py`
- `patches/s3_torch_storage.py`

so the direct pin stays declared rather than relying purely on DLIO's transitive.

## Wider sweep (per reporter's ask)

Cross-checked every dependency shared between `storage/pyproject.toml` and `DLIO_local_changes/pyproject.toml @ f6796ed`:

| Dep | storage | DLIO | Notes |
|---|---|---|---|
| **s3dlio** | `>=0.9.102` -> **`>=0.9.106`** | `>=0.9.106` | fixed here |
| psutil | `>=5.9` | `>=5.9.8` | trivially looser, harmless |
| pyyaml | `>=6.0` | `>=6.0.0` | equivalent |
| pyarrow | unpinned | `>=21.0.0` | de-facto >=21 via DLIO transitive |
| s3torchconnector | `>=1.5.0` | `>=1.5.0` | in sync |

Everything else DLIO declares (`dgen-py`, `h5py`, `mpi4py`, `numpy`, `omegaconf`, `pandas`, `Pillow`, `hydra-core`, `typing-extensions`, `torch`, `tensorflow`, `pydftracer`) is not directly imported by `mlpstorage_py`, so it correctly flows in transitively via `dlio-benchmark` and does not need re-declaring here.

`vdb_benchmark/pyproject.toml` and `kv_cache_benchmark/pyproject.toml` have no `s3dlio` references.

## Test plan

- [x] `uv lock` clean, no unrelated graph changes
- [x] `uv run pytest tests/` — 2620 passed, 1 skipped
- [x] `uv run pytest mlpstorage_py/tests` — 825 passed
- [x] `uv run pytest vdb_benchmark/tests` — 155 passed
- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed

Closes #677.