### PR TITLE
fix(#681): coerce num_files_train to int in rule 3.3.1 before comparison

### DIFF
--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -354,7 +354,7 @@ class TrainingCheck(BaseCheck):
                 # 2.1.19 already flags missing summary; do not double-fire here.
                 continue
 
-            run_num_files_train = summary.get("num_files_train")
+            run_num_files_train = self._to_int(summary.get("num_files_train"))
             run_num_files_eval = summary.get("num_files_eval")
             run_data_dir = metadata.get("args", {}).get("data_dir")
 
@@ -411,6 +411,22 @@ class TrainingCheck(BaseCheck):
         return valid
 
     @staticmethod
+    def _to_int(v):
+        """Coerce v to int; return None if v is None or non-numeric.
+
+        JSON/YAML round-tripping can serialise integer values as strings
+        (e.g. ``"68090280"``). Using bare ``>`` / ``<`` between an int
+        and a str raises TypeError (issue #681), so callers must coerce
+        before comparing.
+        """
+        if v is None:
+            return None
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
     def _group_datasize_by_data_dir(datasize_files):
         """Group loaded datasize tuples by ``args.data_dir`` value.
 
@@ -426,7 +442,7 @@ class TrainingCheck(BaseCheck):
             data_dir = metadata.get("args", {}).get("data_dir")
             params = metadata.get("parameters", {}) or {}
             dataset_params = params.get("dataset", {}) or {}
-            num_files_train = dataset_params.get("num_files_train")
+            num_files_train = TrainingCheck._to_int(dataset_params.get("num_files_train"))
             grouped.setdefault(data_dir, []).append((num_files_train, ts))
         return grouped
 
@@ -450,7 +466,7 @@ class TrainingCheck(BaseCheck):
             return None, None
         params = latest_metadata.get("parameters", {}) or {}
         dataset_params = params.get("dataset", {}) or {}
-        num_files_train = dataset_params.get("num_files_train")
+        num_files_train = TrainingCheck._to_int(dataset_params.get("num_files_train"))
         data_dir = latest_metadata.get("args", {}).get("data_dir")
         return num_files_train, data_dir
 

--- a/mlpstorage_py/tests/test_training_check_issue681.py
+++ b/mlpstorage_py/tests/test_training_check_issue681.py
@@ -1,0 +1,139 @@
+"""
+Regression tests for issue #681 — TypeError in run_data_matches_datasize
+(rule 3.3.1) when num_files_train is serialised as a string in JSON/YAML.
+
+Root cause: summary.json and metadata.json may carry integer-valued fields
+as quoted strings after YAML→JSON round-tripping.  The `>` / `<` comparisons
+at training_checks.py:370,390 did not coerce types, raising:
+    TypeError: '>' not supported between instances of 'int' and 'str'
+
+Fix: _to_int() coerces at read time in _extract_latest_datagen_cardinality,
+_group_datasize_by_data_dir, and the run-loop read of run_num_files_train.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from mlpstorage_py.submission_checker.checks.training_checks import TrainingCheck
+from mlpstorage_py.submission_checker.configuration.configuration import Config
+from mlpstorage_py.submission_checker.loader import LoaderMetadata, SubmissionLogs
+
+
+# ---------------------------------------------------------------------------
+# _to_int unit tests
+# ---------------------------------------------------------------------------
+
+class TestToInt:
+    """TrainingCheck._to_int handles every value shape that JSON/YAML can produce."""
+
+    def test_int_passthrough(self):
+        assert TrainingCheck._to_int(68090280) == 68090280
+
+    def test_string_int_coerced(self):
+        assert TrainingCheck._to_int("68090280") == 68090280
+
+    def test_none_returns_none(self):
+        assert TrainingCheck._to_int(None) is None
+
+    def test_float_string_coerced(self):
+        assert TrainingCheck._to_int("100.0") is None
+
+    def test_garbage_string_returns_none(self):
+        assert TrainingCheck._to_int("not_a_number") is None
+
+    def test_zero(self):
+        assert TrainingCheck._to_int("0") == 0
+
+    def test_zero_int(self):
+        assert TrainingCheck._to_int(0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Helper — build a minimal TrainingCheck from crafted SubmissionLogs
+# ---------------------------------------------------------------------------
+
+def _make_check(tmp_path, mock_logger, datagen_files, run_files):
+    """Return a TrainingCheck wired with the given file tuples."""
+    config = Config(version="v2.0", submitters=["Acme"], skip_output_file=True)
+    lm = LoaderMetadata(
+        division="closed",
+        submitter="Acme",
+        system="sys",
+        mode="training",
+        benchmark="retinanet",
+        folder=str(tmp_path),
+    )
+    logs = SubmissionLogs(
+        datagen_files=datagen_files,
+        datasize_files=[],
+        run_files=run_files,
+        system_file=None,
+        loader_metadata=lm,
+    )
+    return TrainingCheck(log=mock_logger, config=config, submissions_logs=logs)
+
+
+def _datagen_meta(num_files_train):
+    """Build a minimal datagen metadata dict with the given num_files_train."""
+    return {
+        "args": {"data_dir": "/data/retinanet"},
+        "parameters": {
+            "dataset": {
+                "num_files_train": num_files_train,
+            }
+        },
+    }
+
+
+def _run_summary(num_files_train):
+    return {"num_files_train": num_files_train}
+
+
+def _run_meta():
+    return {"args": {"data_dir": "/data/retinanet"}}
+
+
+# ---------------------------------------------------------------------------
+# Issue #681 crash regression — string vs int comparisons must not TypeError
+# ---------------------------------------------------------------------------
+
+class TestRunDataMatchesDatasize_Issue681:
+    """rule 3.3.1 must not raise TypeError when num_files_train is a string."""
+
+    def test_string_run_int_datagen_no_crash(self, tmp_path, mock_logger):
+        """run summary has str num_files_train; datagen metadata has int — no crash."""
+        datagen_files = [(None, _datagen_meta(68090280), "20250111_130000")]
+        run_files = [(_run_summary("68090280"), _run_meta(), "20250111_140001")]
+        check = _make_check(tmp_path, mock_logger, datagen_files, run_files)
+        # Must not raise TypeError
+        result = check.run_data_matches_datasize()
+        assert result is True
+        assert mock_logger.errors == []
+
+    def test_int_run_string_datagen_no_crash(self, tmp_path, mock_logger):
+        """run summary has int num_files_train; datagen metadata has str — no crash."""
+        datagen_files = [(None, _datagen_meta("68090280"), "20250111_130000")]
+        run_files = [(_run_summary(68090280), _run_meta(), "20250111_140001")]
+        check = _make_check(tmp_path, mock_logger, datagen_files, run_files)
+        result = check.run_data_matches_datasize()
+        assert result is True
+        assert mock_logger.errors == []
+
+    def test_string_run_string_datagen_no_crash(self, tmp_path, mock_logger):
+        """Both sides are strings — no crash, no warnings."""
+        datagen_files = [(None, _datagen_meta("68090280"), "20250111_130000")]
+        run_files = [(_run_summary("68090280"), _run_meta(), "20250111_140001")]
+        check = _make_check(tmp_path, mock_logger, datagen_files, run_files)
+        result = check.run_data_matches_datasize()
+        assert result is True
+        assert mock_logger.errors == []
+
+    def test_overrun_still_warns_after_coercion(self, tmp_path, mock_logger):
+        """When run > datagen (both strings), DATAGEN-OVERRUN warning is still emitted."""
+        datagen_files = [(None, _datagen_meta("1000"), "20250111_130000")]
+        run_files = [(_run_summary("2000"), _run_meta(), "20250111_140001")]
+        check = _make_check(tmp_path, mock_logger, datagen_files, run_files)
+        check.run_data_matches_datasize()
+        assert any("DATAGEN-OVERRUN" in w for w in mock_logger.warnings), (
+            "Expected DATAGEN-OVERRUN warning when run > datagen"
+        )


### PR DESCRIPTION
## Summary

- Fixes crash in rule 3.3.1 (`trainingRunDataMatchesDatasize`) when `num_files_train` is serialised as a quoted string in `summary.json` or metadata `parameters.dataset`
- Adds `_to_int()` helper and applies it at all three read sites so comparisons never see a mixed `int`/`str` pair

## Root cause

JSON/YAML round-tripping (observed on retinanet submissions with `"num_files_train": "68090280"`) produces string-typed integers. The `>` / `<` comparisons at lines 370 and 390 of `training_checks.py` did not coerce types, raising:

```
TypeError: '>' not supported between instances of 'int' and 'str'
```

## Fix

Added `TrainingCheck._to_int(v)` — returns `int(v)` or `None` on `None`/non-numeric input — and applied it at the three `num_files_train` read sites:

- `run_num_files_train` (run loop, `summary.json`)
- `num_files_train` in `_extract_latest_datagen_cardinality` (datagen metadata)
- `num_files_train` in `_group_datasize_by_data_dir` (datasize metadata)

## Test plan

New file `test_training_check_issue681.py`:
- Unit tests for `_to_int` covering int, str, None, float-string, garbage
- Integration tests for all mixed int/str combinations — no crash
- Regression test confirming `DATAGEN-OVERRUN` warning still fires after coercion

Parallel 4-suite sweep: 3754 passed, 1 skipped, 0 failures.