### PR TITLE
Fix(vdb): gRPC message-size limit + loud-failure GT verdict (#572)

### DIFF
--- a/vdb_benchmark/tests/tests/test_issue_489_flat_gt_guard.py
+++ b/vdb_benchmark/tests/tests/test_issue_489_flat_gt_guard.py
@@ -243,10 +243,14 @@ class TestCoverageGuard:
             metric_type="COSINE",
         )
 
-        assert result is False, (
+        # create_flat_collection now returns a FlatSetupResult (issue #572).
+        # An insufficient-coverage abort must set ok=False so the caller renders
+        # an "invalid" verdict and exits non-zero.
+        assert result.ok is False, (
             "create_flat_collection must abort when the FLAT ground-truth "
             "collection covers ~0% of the source (issue #489)."
         )
+        assert result.coverage < 0.99
         # The empty FLAT collection must never reach index construction.
         flat_coll.create_index.assert_not_called()
 

--- a/vdb_benchmark/tests/tests/test_issue_572_grpc_and_verdict.py
+++ b/vdb_benchmark/tests/tests/test_issue_572_grpc_and_verdict.py
@@ -1,0 +1,139 @@
+"""
+Regression tests for issue #572:
+
+  * RESOURCE_EXHAUSTED when a FLAT ground-truth copy response exceeds the
+    pymilvus 256 MiB gRPC client default.
+  * "loud failure" validity verdict so users never have to grep logs to know
+    whether a run is trustworthy.
+
+These tests are dependency-free: they install a fake ``pymilvus`` before
+importing ``vdbbench`` so they run in CI without a Milvus client.
+"""
+
+import sys
+import json
+import tempfile
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _install_fake_pymilvus():
+    if "pymilvus" in sys.modules:
+        return
+    fake = MagicMock(name="pymilvus")
+    # connections.connect must record kwargs so we can assert on the gRPC limits.
+    fake.connections = MagicMock(name="connections")
+    sys.modules["pymilvus"] = fake
+
+
+_install_fake_pymilvus()
+
+from vdbbench.connection import (  # noqa: E402
+    MAX_GRPC_MESSAGE_LENGTH,
+    open_connection,
+)
+from vdbbench import simple_bench  # noqa: E402
+from vdbbench.simple_bench import (  # noqa: E402
+    FlatSetupResult,
+    emit_result_verdict,
+)
+
+
+class TestGrpcConnectionHelper:
+    """open_connection must always raise the gRPC message-size limits (#572)."""
+
+    def test_open_connection_sets_message_limits(self):
+        from vdbbench import connection as conn_mod
+
+        captured = {}
+
+        def fake_connect(**kwargs):
+            captured.update(kwargs)
+
+        conn_mod.connections.connect = fake_connect
+        open_connection(alias="flat_setup", host="127.0.0.1", port="19530")
+
+        assert captured["max_receive_message_length"] == MAX_GRPC_MESSAGE_LENGTH
+        assert captured["max_send_message_length"] == MAX_GRPC_MESSAGE_LENGTH
+        # Must exceed the observed 393631413-byte response in the issue and the
+        # 256 MiB (268435456) client default that caused the failure.
+        assert MAX_GRPC_MESSAGE_LENGTH > 393_631_413
+        assert MAX_GRPC_MESSAGE_LENGTH > 268_435_456
+
+    def test_limit_matches_config_declared_value(self):
+        # configs/*.yaml declare 514_983_574; the helper is the single source
+        # of truth those literals must match.
+        assert MAX_GRPC_MESSAGE_LENGTH == 514_983_574
+
+
+class TestResultVerdict:
+    """emit_result_verdict must classify runs unambiguously (#572)."""
+
+    def _verdict(self, flat_result, nqe):
+        d = tempfile.mkdtemp()
+        v = emit_result_verdict(
+            d, flat_result=flat_result, num_queries_evaluated=nqe
+        )
+        payload = json.load(open(os.path.join(d, "result_verdict.json")))
+        return v, payload
+
+    def test_full_coverage_is_valid(self):
+        fr = FlatSetupResult(
+            ok=True, coverage=1.0, total_vectors=1_000_000, copied_vectors=1_000_000
+        )
+        v, payload = self._verdict(fr, 1000)
+        assert v == "valid"
+        assert payload["valid"] is True
+
+    def test_recovered_full_coverage_is_valid_but_noted(self):
+        fr = FlatSetupResult(
+            ok=True,
+            coverage=1.0,
+            total_vectors=1_000_000,
+            copied_vectors=1_000_000,
+            had_recoverable_error=True,
+        )
+        v, payload = self._verdict(fr, 1000)
+        assert v.startswith("valid")
+        assert "recovered" in v
+        assert payload["valid"] is True
+
+    def test_partial_coverage_is_degraded(self):
+        # Above the 99% abort threshold but below 100%: recall was computed on
+        # an incomplete ground truth -> not trustworthy.
+        fr = FlatSetupResult(
+            ok=True, coverage=0.995, total_vectors=1_000_000, copied_vectors=995_000
+        )
+        v, payload = self._verdict(fr, 1000)
+        assert v.startswith("degraded")
+        assert payload["valid"] is False
+
+    def test_failed_setup_is_invalid(self):
+        fr = FlatSetupResult(ok=False, reason="coverage 0.00% below 99% minimum")
+        v, payload = self._verdict(fr, 0)
+        assert v.startswith("invalid")
+        assert payload["valid"] is False
+
+    def test_zero_queries_is_invalid_even_with_ok_flat(self):
+        fr = FlatSetupResult(
+            ok=True, coverage=1.0, total_vectors=10, copied_vectors=10
+        )
+        v, payload = self._verdict(fr, 0)
+        assert v == "invalid: 0 queries had valid ground truth"
+        assert payload["valid"] is False
+
+    def test_exactly_one_result_line(self, capsys):
+        fr = FlatSetupResult(
+            ok=True, coverage=1.0, total_vectors=10, copied_vectors=10
+        )
+        d = tempfile.mkdtemp()
+        emit_result_verdict(d, flat_result=fr, num_queries_evaluated=5)
+        out = capsys.readouterr().out
+        result_lines = [ln for ln in out.splitlines() if ln.startswith("RESULT:")]
+        assert len(result_lines) == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/vdb_benchmark/vdbbench/collection_mgr.py
+++ b/vdb_benchmark/vdbbench/collection_mgr.py
@@ -21,6 +21,8 @@ import numpy as np
 from pymilvus import Collection, connections, utility, DataType
 from tabulate import tabulate
 
+from vdbbench.connection import open_connection
+
 METRICS_PORT = 9091       # override with --metrics-port if needed
 
 ###############################################################################
@@ -31,7 +33,7 @@ def connect(host: str, port: int) -> bool:
     """Connect to Milvus server with error handling"""
     try:
         if not connections.has_connection("default"):
-            connections.connect("default", host=host, port=port)
+            open_connection("default", host=host, port=port)
         return True
     except Exception as e:
         print(f"❌ Connection failed: {e}")

--- a/vdb_benchmark/vdbbench/compact_and_watch.py
+++ b/vdb_benchmark/vdbbench/compact_and_watch.py
@@ -17,6 +17,7 @@ logging.basicConfig(
 # Add the parent directory to sys.path to import config_loader
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from vdbbench.config_loader import load_config, merge_config_with_args
+from vdbbench.connection import open_connection
 
 # Configure logging
 logging.basicConfig(
@@ -63,13 +64,7 @@ def parse_args():
 def connect_to_milvus(host, port):
     """Connect to Milvus server"""
     try:
-        connections.connect(
-            "default",
-            host=host,
-            port=port,
-            max_receive_message_length=514_983_574,
-            max_send_message_length=514_983_574
-        )
+        open_connection("default", host=host, port=port)
         logging.info(f"Connected to Milvus server at {host}:{port}")
         return True
     except Exception as e:

--- a/vdb_benchmark/vdbbench/connection.py
+++ b/vdb_benchmark/vdbbench/connection.py
@@ -1,0 +1,69 @@
+"""
+connection.py - Centralized Milvus/pymilvus connection setup for vdbbench.
+
+Every vdbbench module that opens a Milvus connection must go through
+``open_connection`` so the gRPC message-size limits are applied consistently.
+
+Background (issue #572)
+-----------------------
+pymilvus' gRPC client defaults ``max_receive_message_length`` to 256 MiB
+(268435456 bytes). For wide vectors (e.g. 1M x 1536-dim float32) the FLAT
+ground-truth copy path can make Milvus return a single response larger than
+that limit, raising::
+
+    StatusCode.RESOURCE_EXHAUSTED, grpc: trying to send message larger than
+    max (393631413 vs. 268435456)
+
+``load_vdb`` and ``compact_and_watch`` already raised the ceiling to
+``514_983_574`` (~491 MiB), but ``simple_bench``, ``enhanced_bench``,
+``collection_mgr``, ``list_collections`` and ``mpi_wrapper`` were still on the
+256 MiB default. Routing all of them through this single helper removes that
+inconsistency and prevents the limit from silently regressing again.
+
+The configs (e.g. ``configs/1m_diskann.yaml``) declare
+``max_receive_message_length: 514_983_574``; ``MAX_GRPC_MESSAGE_LENGTH`` here is
+the single source of truth those literals should match.
+"""
+
+from __future__ import annotations
+
+from pymilvus import connections
+
+# Single source of truth for the gRPC message-size ceiling (~491 MiB). Matches
+# the value used in load_vdb.py, compact_and_watch.py, the Milvus backend, and
+# the max_receive_message_length / max_send_message_length keys in configs/*.yaml.
+MAX_GRPC_MESSAGE_LENGTH = 514_983_574
+
+
+def open_connection(
+    alias: str = "default",
+    host: str = "127.0.0.1",
+    port: str = "19530",
+    *,
+    max_message_length: int = MAX_GRPC_MESSAGE_LENGTH,
+) -> None:
+    """
+    Open a Milvus connection with raised gRPC send/receive message limits.
+
+    This is a thin wrapper around ``pymilvus.connections.connect`` that always
+    supplies ``max_receive_message_length`` and ``max_send_message_length`` so
+    large FLAT ground-truth responses do not trip the 256 MiB client default
+    (see issue #572).
+
+    Parameters
+    ----------
+    alias:
+        Connection alias to register (e.g. ``"default"``, ``"flat_setup"``).
+    host, port:
+        Milvus server address.
+    max_message_length:
+        Override for the gRPC message-size ceiling in bytes. Defaults to
+        ``MAX_GRPC_MESSAGE_LENGTH``.
+    """
+    connections.connect(
+        alias=alias,
+        host=host,
+        port=str(port),
+        max_receive_message_length=max_message_length,
+        max_send_message_length=max_message_length,
+    )

--- a/vdb_benchmark/vdbbench/enhanced_bench.py
+++ b/vdb_benchmark/vdbbench/enhanced_bench.py
@@ -85,11 +85,29 @@ except ImportError:  # pragma: no cover - optional dependency
 
 try:
     from vdbbench.config_loader import load_config, merge_config_with_args
+    from vdbbench.connection import (
+        MAX_GRPC_MESSAGE_LENGTH,
+        open_connection,
+    )
     from vdbbench.list_collections import get_collection_info
 
     _VDBBENCH_PKG = True
 except ImportError:  # pragma: no cover - package import optional for direct runs
     _VDBBENCH_PKG = False
+
+    # Fallback so enhanced_bench still works when run as a bare script outside
+    # the vdbbench package. Mirrors vdbbench/connection.py exactly.
+    MAX_GRPC_MESSAGE_LENGTH = 514_983_574
+
+    def open_connection(alias="default", host="127.0.0.1", port="19530",
+                        *, max_message_length=MAX_GRPC_MESSAGE_LENGTH):
+        connections.connect(
+            alias=alias,
+            host=host,
+            port=str(port),
+            max_receive_message_length=max_message_length,
+            max_send_message_length=max_message_length,
+        )
 
 
 STAGGER_INTERVAL_SEC = 0.1
@@ -645,7 +663,7 @@ def generate_random_vector(dim: int) -> List[float]:
 def connect_to_milvus(host: str, port: str):
     """Establish a default connection to Milvus."""
     try:
-        connections.connect(alias="default", host=host, port=port)
+        open_connection(alias="default", host=host, port=port)
         return connections
     except Exception as e:
         print(f"Failed to connect to Milvus: {e}")
@@ -734,7 +752,7 @@ def validate_existing_flat_collection(
     conn_alias = f"flat_validate_{uuid.uuid4().hex[:8]}"
 
     try:
-        connections.connect(alias=conn_alias, host=host, port=port)
+        open_connection(alias=conn_alias, host=host, port=port)
     except Exception as exc:
         print(f"Failed to connect for FLAT collection validation: {exc}")
         return False
@@ -800,7 +818,7 @@ def create_flat_collection(
     conn_alias = f"flat_setup_{uuid.uuid4().hex[:8]}"
 
     try:
-        connections.connect(alias=conn_alias, host=host, port=port)
+        open_connection(alias=conn_alias, host=host, port=port)
     except Exception as e:
         print(f"Failed to connect for FLAT collection setup: {e}")
         return False
@@ -869,8 +887,18 @@ def create_flat_collection(
 
         if use_iterator:
             try:
+                # Cap the iterator batch size so a single gRPC response stays
+                # well under Milvus' default 256MB max-message limit. For wide
+                # vectors (e.g. 1536-dim float32 ~= 6KB/row) a 5000-row batch
+                # can exceed the limit and trigger RESOURCE_EXHAUSTED, forcing
+                # the fragile pk-cursor fallback. ~24MB/batch is a safe ceiling.
+                # (Ported from simple_bench.py; see issue #572 / PR #516.)
+                bytes_per_row = max(vector_dim * 4, 1)
+                safe_rows = max(1, (24 * 1024 * 1024) // bytes_per_row)
+                iter_batch_size = min(copy_batch_size, safe_rows, 16384)
+
                 iterator = source_coll.query_iterator(
-                    batch_size=copy_batch_size,
+                    batch_size=iter_batch_size,
                     output_fields=[src_pk_field, src_vec_field],
                 )
 
@@ -909,18 +937,32 @@ def create_flat_collection(
                 DataType.INT16,
                 DataType.INT8,
             )
-            last_pk: Union[int, str] = -(2**63) if is_int_pk else ""
+            # NOTE: do NOT initialize the int cursor at -2**63. The expression
+            # "pk > -9223372036854775808" makes Milvus parse the operand
+            # 9223372036854775808 (magnitude, before the sign) as int64, which
+            # overflows INT64_MAX by one and raises a parse error, breaking the
+            # copy loop with 0 vectors. Benchmark IDs are >= 0, so -1 is a safe
+            # in-range sentinel that yields the valid first-page expr "pk > -1".
+            # (Ported from simple_bench.py; see issue #489 / PR #516.)
+            last_pk: Union[int, str] = -1 if is_int_pk else ""
+            first_page = True
             page_limit = min(copy_batch_size, 16384)
 
             dummy_vec = np.random.random(vector_dim).astype(np.float32)
             dummy_vec = (dummy_vec / np.linalg.norm(dummy_vec)).tolist()
 
             while copied < total_vectors:
-                expr = (
-                    f"{src_pk_field} > {last_pk}"
-                    if is_int_pk
-                    else f'{src_pk_field} > "{last_pk}"'
-                )
+                if is_int_pk:
+                    expr = f"{src_pk_field} > {last_pk}"
+                else:
+                    # First page for VARCHAR PKs uses a closed lower bound so an
+                    # empty-string sentinel does not skip valid keys; subsequent
+                    # pages advance with a strict cursor on the last seen key.
+                    if first_page:
+                        expr = f'{src_pk_field} >= ""'
+                    else:
+                        expr = f'{src_pk_field} > "{last_pk}"'
+                first_page = False
 
                 try:
                     pk_batch = source_coll.query(
@@ -1060,7 +1102,7 @@ def precompute_ground_truth(
     conn_alias = f"gt_compute_{uuid.uuid4().hex[:8]}"
 
     try:
-        connections.connect(alias=conn_alias, host=host, port=port)
+        open_connection(alias=conn_alias, host=host, port=port)
     except Exception as e:
         print(f"Failed to connect for ground truth computation: {e}")
         return {}
@@ -1647,7 +1689,7 @@ def _worker_mp(
 ) -> None:
     alias = f"w{worker_id}_{uuid.uuid4().hex[:8]}"
     try:
-        connections.connect(alias=alias, host=host, port=port)
+        open_connection(alias=alias, host=host, port=port)
         col = Collection(collection_name, using=alias)
         col.load()
         params = make_search_params_full(metric_type, algo_params)
@@ -2890,7 +2932,7 @@ def main() -> None:
     # =========================================================================
     gt_cache_dir = Path(args.gt_cache_dir) if args.gt_cache_dir else None
 
-    connections.connect("default", host=args.host, port=args.port)
+    open_connection("default", host=args.host, port=args.port)
     if not utility.has_collection(args.collection):
         raise SystemExit(f"Collection not found: {args.collection}")
 
@@ -2935,7 +2977,7 @@ def main() -> None:
         if not flat_ok:
             raise SystemExit("Existing FLAT GT collection validation failed.")
 
-        connections.connect("default", host=args.host, port=args.port)
+        open_connection("default", host=args.host, port=args.port)
         col = Collection(args.collection)
         col.load()
 
@@ -2955,7 +2997,7 @@ def main() -> None:
             raise SystemExit("FLAT GT collection creation failed.")
 
         args.gt_collection = auto_gt_name
-        connections.connect("default", host=args.host, port=args.port)
+        open_connection("default", host=args.host, port=args.port)
         col = Collection(args.collection)
         col.load()
 

--- a/vdb_benchmark/vdbbench/list_collections.py
+++ b/vdb_benchmark/vdbbench/list_collections.py
@@ -30,6 +30,21 @@ except ImportError:
     sys.exit(1)
 
 try:
+    from vdbbench.connection import MAX_GRPC_MESSAGE_LENGTH, open_connection
+except ImportError:  # pragma: no cover - allow running as a bare script
+    MAX_GRPC_MESSAGE_LENGTH = 514_983_574
+
+    def open_connection(alias="default", host="127.0.0.1", port="19530",
+                        *, max_message_length=MAX_GRPC_MESSAGE_LENGTH):
+        connections.connect(
+            alias=alias,
+            host=host,
+            port=str(port),
+            max_receive_message_length=max_message_length,
+            max_send_message_length=max_message_length,
+        )
+
+try:
     from tabulate import tabulate
 except ImportError:
     logger.error("Error: tabulate package not found. Please install it with 'pip install tabulate'")
@@ -49,11 +64,7 @@ def parse_args():
 def connect_to_milvus(host, port):
     """Connect to Milvus server"""
     try:
-        connections.connect(
-            alias="default", 
-            host=host, 
-            port=port
-        )
+        open_connection(alias="default", host=host, port=port)
         logger.info(f"Connected to Milvus server at {host}:{port}")
         return True
     except Exception as e:

--- a/vdb_benchmark/vdbbench/load_vdb.py
+++ b/vdb_benchmark/vdbbench/load_vdb.py
@@ -7,6 +7,8 @@ import time
 import numpy as np
 from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType, utility
 
+from vdbbench.connection import open_connection
+
 # Add the parent directory to sys.path to import config_loader
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from vdbbench.config_loader import load_config, merge_config_with_args
@@ -133,13 +135,7 @@ def connect_to_milvus(host, port):
     """Connect to Milvus server"""
     try:
         logger.debug(f"Connecting to Milvus server at {host}:{port}")
-        connections.connect(
-            "default", 
-            host=host, 
-            port=port,
-            max_receive_message_length=514_983_574,
-            max_send_message_length=514_983_574
-        )
+        open_connection("default", host=host, port=port)
         logger.info(f"Connected to Milvus server at {host}:{port}")
         return True
 

--- a/vdb_benchmark/vdbbench/mpi_wrapper.py
+++ b/vdb_benchmark/vdbbench/mpi_wrapper.py
@@ -489,7 +489,9 @@ def _detect_metric_type(host: str, port: str, collection_name: str) -> str:
     try:
         from pymilvus import Collection, connections
 
-        connections.connect(alias="metric_detect", host=host, port=str(port))
+        from vdbbench.connection import open_connection
+
+        open_connection(alias="metric_detect", host=host, port=str(port))
         collection = Collection(collection_name, using="metric_detect")
 
         if collection.has_index():

--- a/vdb_benchmark/vdbbench/simple_bench.py
+++ b/vdb_benchmark/vdbbench/simple_bench.py
@@ -30,6 +30,7 @@ import os
 import signal
 import sys
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -38,6 +39,7 @@ import numpy as np
 from tabulate import tabulate
 
 from vdbbench.config_loader import load_config, merge_config_with_args
+from vdbbench.connection import open_connection
 from vdbbench.list_collections import get_collection_info
 
 try:
@@ -56,6 +58,117 @@ except ImportError:
 
 
 STAGGER_INTERVAL_SEC = 0.1
+
+# Minimum fraction of source vectors the FLAT ground-truth collection must
+# contain for recall to be considered valid (issue #489 / #572).
+MIN_FLAT_COVERAGE = 0.99
+
+
+@dataclass
+class FlatSetupResult:
+    """
+    Outcome of FLAT ground-truth setup, used to render an explicit end-of-run
+    validity verdict (issue #572).
+
+    ok:
+        True if a usable FLAT collection was produced (coverage >= threshold).
+    coverage:
+        Fraction of source vectors present in the FLAT collection (0.0-1.0).
+    total_vectors / copied_vectors:
+        Absolute counts behind ``coverage``.
+    had_recoverable_error:
+        True if a gRPC / iterator error was caught mid-setup and the code fell
+        back to another copy path. The run may still be valid, but this must be
+        surfaced in the final verdict rather than swallowed silently.
+    reason:
+        Human-readable explanation when ``ok`` is False (empty otherwise).
+    reused:
+        True if an existing, fully-covering FLAT collection was reused.
+    """
+
+    ok: bool
+    coverage: float = 0.0
+    total_vectors: int = 0
+    copied_vectors: int = 0
+    had_recoverable_error: bool = False
+    reason: str = ""
+    reused: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "coverage": self.coverage,
+            "total_vectors": self.total_vectors,
+            "copied_vectors": self.copied_vectors,
+            "had_recoverable_error": self.had_recoverable_error,
+            "reason": self.reason,
+            "reused": self.reused,
+        }
+
+
+def emit_result_verdict(
+    output_dir: str,
+    *,
+    flat_result: Optional["FlatSetupResult"],
+    num_queries_evaluated: int,
+) -> str:
+    """
+    Emit a single unambiguous validity verdict for the whole run.
+
+    Writes a ``result_verdict.json`` file, prints exactly one ``RESULT:`` line
+    to stdout, and returns the verdict string ("valid" / "degraded: ..." /
+    "invalid: ..."). Callers exit non-zero on any non-"valid" verdict.
+
+    The verdict is keyed on *coverage completeness*, not merely on whether an
+    exception was caught: a query_iterator failure that the pk-cursor fallback
+    fully recovers (100% coverage) is still a clean run. The states we must
+    distinguish (issue #572):
+
+      * valid    - full coverage and queries actually evaluated.
+      * degraded - coverage >= MIN_FLAT_COVERAGE but < 100% (recall computed on
+                   an incomplete ground truth; numbers are not trustworthy).
+      * invalid  - no queries evaluated, or a caught error left coverage below
+                   the minimum threshold.
+    """
+    if num_queries_evaluated <= 0:
+        verdict = "invalid: 0 queries had valid ground truth"
+    elif flat_result is None:
+        # No FLAT setup ran in this process (e.g. --no-create-flat worker that
+        # only validated a pre-existing collection). Coverage was checked
+        # elsewhere; treat a non-zero evaluated-query count as valid.
+        verdict = "valid"
+    elif not flat_result.ok:
+        verdict = f"invalid: {flat_result.reason or 'FLAT ground-truth setup failed'}"
+    elif flat_result.coverage < 1.0:
+        detail = (
+            f"FLAT ground-truth coverage {flat_result.coverage * 100:.2f}% "
+            f"({flat_result.copied_vectors}/{flat_result.total_vectors}); "
+            f"recall computed on an incomplete ground truth"
+        )
+        verdict = f"degraded: {detail}"
+    elif flat_result.had_recoverable_error:
+        # Full coverage was recovered after a caught error. Report valid, but
+        # note the recovery so the user knows the mid-run error was benign.
+        verdict = "valid (recovered from a caught gRPC error during GT setup)"
+    else:
+        verdict = "valid"
+
+    payload = {
+        "result": verdict,
+        "valid": verdict.startswith("valid"),
+        "num_queries_evaluated": int(num_queries_evaluated),
+        "flat_setup": flat_result.to_dict() if flat_result else None,
+    }
+    try:
+        with open(
+            os.path.join(output_dir, "result_verdict.json"), "w", encoding="utf-8"
+        ) as f:
+            json.dump(payload, f, indent=2)
+    except Exception as exc:  # pragma: no cover - diagnostics only
+        print(f"WARNING: could not write result_verdict.json: {exc}")
+
+    print(f"RESULT: {verdict}")
+    return verdict
 
 # Global flag for graceful shutdown.
 shutdown_flag = mp.Value("i", 0)
@@ -215,7 +328,7 @@ def validate_existing_flat_collection(
     conn_alias = "flat_validate"
 
     try:
-        connections.connect(alias=conn_alias, host=host, port=port)
+        open_connection(alias=conn_alias, host=host, port=port)
     except Exception as exc:
         print(f"Failed to connect for FLAT collection validation: {exc}")
         return False
@@ -277,21 +390,28 @@ def create_flat_collection(
     flat_collection_name: str,
     vector_dim: int,
     metric_type: str = "COSINE",
-) -> bool:
+) -> FlatSetupResult:
     """
     Create a duplicate collection with a FLAT index for ground truth.
 
     FLAT performs brute-force exact search. The FLAT collection preserves the
     source collection's primary key values, so FLAT result IDs match ANN result
     IDs from the source collection.
+
+    Returns a :class:`FlatSetupResult` describing coverage and whether a
+    recoverable gRPC error was caught during setup, so the caller can render an
+    explicit validity verdict (issue #572).
     """
     conn_alias = "flat_setup"
+    had_recoverable_error = False
 
     try:
-        connections.connect(alias=conn_alias, host=host, port=port)
+        open_connection(alias=conn_alias, host=host, port=port)
     except Exception as exc:
         print(f"Failed to connect for FLAT collection setup: {exc}")
-        return False
+        return FlatSetupResult(
+            ok=False, reason=f"could not connect to Milvus for FLAT setup: {exc}"
+        )
 
     try:
         if utility.has_collection(flat_collection_name, using=conn_alias):
@@ -306,7 +426,13 @@ def create_flat_collection(
                     f"with {flat_coll.num_entities} vectors, reusing it."
                 )
                 flat_coll.load()
-                return True
+                return FlatSetupResult(
+                    ok=True,
+                    coverage=1.0,
+                    total_vectors=source_coll.num_entities,
+                    copied_vectors=flat_coll.num_entities,
+                    reused=True,
+                )
 
             print(
                 f"FLAT collection exists but has {flat_coll.num_entities} vs "
@@ -329,7 +455,11 @@ def create_flat_collection(
                 f"ERROR: Source collection '{source_collection_name}' "
                 f"reports 0 vectors after flush. Cannot create ground truth."
             )
-            return False
+            return FlatSetupResult(
+                ok=False,
+                total_vectors=0,
+                reason=f"source collection '{source_collection_name}' has 0 vectors",
+            )
 
         src_pk_field, src_vec_field, src_pk_dtype = _detect_schema_fields(source_coll)
 
@@ -411,6 +541,7 @@ def create_flat_collection(
                     f"  query_iterator failed ({iter_err}), "
                     f"falling back to pk-cursor pagination..."
                 )
+                had_recoverable_error = True
                 use_iterator = False
                 copied = 0
 
@@ -572,18 +703,27 @@ def create_flat_collection(
         # source collection cannot produce valid recall. Without this guard the
         # function would build an empty FLAT index, return True, and let the
         # benchmark report a "successful" run with recall.num_queries_evaluated=0
-        # (see issue #489). Abort here so the caller's `if not flat_ok` fires.
+        # (see issue #489). Abort here so the caller's verdict fires.
         final_count = flat_coll.num_entities
         coverage = (final_count / total_vectors) if total_vectors else 0.0
-        MIN_COVERAGE = 0.99
-        if coverage < MIN_COVERAGE:
+        if coverage < MIN_FLAT_COVERAGE:
             print(
                 f"ERROR: FLAT ground-truth collection covers only "
                 f"{final_count}/{total_vectors} ({coverage * 100:.2f}%) of the "
-                f"source collection (minimum required: {MIN_COVERAGE * 100:.0f}%). "
+                f"source collection (minimum required: {MIN_FLAT_COVERAGE * 100:.0f}%). "
                 f"Cannot compute valid recall — aborting FLAT setup."
             )
-            return False
+            return FlatSetupResult(
+                ok=False,
+                coverage=coverage,
+                total_vectors=total_vectors,
+                copied_vectors=final_count,
+                had_recoverable_error=had_recoverable_error,
+                reason=(
+                    f"FLAT ground-truth coverage {coverage * 100:.2f}% is below the "
+                    f"{MIN_FLAT_COVERAGE * 100:.0f}% minimum"
+                ),
+            )
 
         print("Building FLAT index...")
         flat_coll.create_index(
@@ -601,14 +741,24 @@ def create_flat_collection(
             f"{flat_coll.num_entities} vectors."
         )
 
-        return True
+        return FlatSetupResult(
+            ok=True,
+            coverage=coverage,
+            total_vectors=total_vectors,
+            copied_vectors=final_count,
+            had_recoverable_error=had_recoverable_error,
+        )
 
     except Exception as exc:
         print(f"Error creating FLAT collection: {exc}")
         import traceback
 
         traceback.print_exc()
-        return False
+        return FlatSetupResult(
+            ok=False,
+            had_recoverable_error=had_recoverable_error,
+            reason=f"unhandled error during FLAT setup: {exc}",
+        )
 
     finally:
         try:
@@ -633,7 +783,7 @@ def precompute_ground_truth(
     conn_alias = "gt_compute"
 
     try:
-        connections.connect(alias=conn_alias, host=host, port=port)
+        open_connection(alias=conn_alias, host=host, port=port)
     except Exception as exc:
         print(f"Failed to connect for ground truth computation: {exc}")
         return {}
@@ -826,7 +976,7 @@ def generate_random_vector(dim: int) -> List[float]:
 def connect_to_milvus(host: str, port: str):
     """Establish connection to Milvus server."""
     try:
-        connections.connect(alias="default", host=host, port=port)
+        open_connection(alias="default", host=host, port=port)
         return connections
     except Exception as exc:
         print(f"Failed to connect to Milvus: {exc}")
@@ -1599,14 +1749,24 @@ def main():
     print(f"\nSetting up FLAT collection: {gt_collection_name}")
 
     if args.no_create_flat:
-        flat_ok = validate_existing_flat_collection(
+        validate_ok = validate_existing_flat_collection(
             host=args.host,
             port=args.port,
             source_collection_name=args.collection_name,
             flat_collection_name=gt_collection_name,
         )
+        # The validate-only worker path does not recompute coverage here; a
+        # successful validation means a pre-existing full FLAT collection was
+        # found. Represent it as a FlatSetupResult so the verdict logic is
+        # uniform. ok=False leaves reason blank; verdict will mark it invalid.
+        flat_result = FlatSetupResult(
+            ok=validate_ok,
+            coverage=1.0 if validate_ok else 0.0,
+            reused=validate_ok,
+            reason="" if validate_ok else "pre-existing FLAT collection validation failed",
+        )
     else:
-        flat_ok = create_flat_collection(
+        flat_result = create_flat_collection(
             host=args.host,
             port=args.port,
             source_collection_name=args.collection_name,
@@ -1615,8 +1775,13 @@ def main():
             metric_type=metric_type,
         )
 
-    if not flat_ok:
+    if not flat_result.ok:
         print("ERROR: FLAT collection setup failed. Cannot compute recall.")
+        emit_result_verdict(
+            output_dir,
+            flat_result=flat_result,
+            num_queries_evaluated=0,
+        )
         sys.exit(1)
 
     ground_truth = precompute_ground_truth(
@@ -1789,14 +1954,38 @@ def main():
     with open(recall_output_file, "w", encoding="utf-8") as f:
         json.dump(recall_stats, f, indent=2)
 
+    num_queries_evaluated = recall_stats.get("num_queries_evaluated", 0)
+
     # A run in which zero queries had valid ground truth produced no measurable
     # recall, so its QPS/latency numbers must not be reported as a successful
     # benchmark. recall_stats.json is written above for diagnostics, then we
     # abort with a non-zero exit code (issue #489).
-    if recall_stats.get("num_queries_evaluated", 0) == 0:
+    if num_queries_evaluated == 0:
         print(
             "ERROR: 0 queries had valid ground truth; recall is invalid. "
             "Marking run as FAILED (see recall_stats.json for details)."
+        )
+        emit_result_verdict(
+            output_dir,
+            flat_result=flat_result,
+            num_queries_evaluated=0,
+        )
+        sys.exit(1)
+
+    # Loud-failure verdict (issue #572): render a single, unambiguous validity
+    # line to stdout + JSON. "degraded" coverage (below 100% but above the
+    # abort threshold) means recall was computed on an incomplete ground truth,
+    # which is not a trustworthy result — exit non-zero so it cannot be mistaken
+    # for a clean run.
+    verdict = emit_result_verdict(
+        output_dir,
+        flat_result=flat_result,
+        num_queries_evaluated=num_queries_evaluated,
+    )
+    if not verdict.startswith("valid"):
+        print(
+            "ERROR: run marked invalid/degraded; results are not trustworthy. "
+            "See result_verdict.json and re-run."
         )
         sys.exit(1)
 


### PR DESCRIPTION
## Summary
Fixes #572 (RESOURCE_EXHAUSTED on single-host `vectordb run`). Closes the gap where `simple_bench`/`enhanced_bench` opened Milvus connections on the 256 MiB pymilvus default while `load_vdb`/`compact_and_watch`/`backend` use ~491 MiB. Centralizes connection setup and makes result validity explicit.

## Changes
1. New `_open_connection(alias, host, port)` helper sets `max_{receive,send}_message_length=514_983_574`; all ~15 connect sites in `simple_bench`, `enhanced_bench`, `collection_mgr`, `list_collections`, `mpi_wrapper` now route through it.
2. Port #516's `query_iterator` 24 MiB batch cap and `-1` int64 cursor sentinel int `enhanced_bench.create_flat_collection()` (sweep-mode parity; prevents the #489 silent-empty-FLAT failure for int64 PKs).
3. Loud-failure verdict: single `RESULT: valid | invalid: <reason> | degraded: <coverage>%` line in stdout + JSON, non-zero exit when GT coverage is incomplete or a caught gRPC error touched recall data.

## Validation
- Original #572 repro (1M × 1536-dim DISKANN, single host) no longer emits RESOURCE_EXHAUSTED; `RESULT: valid` with num_queries_evaluated=1000.
- `--mode sweep` int64-PK path no longer hits the uncapped iterator / cursor bugs.
- Forced-failure path exits non-zero with `invalid:`/`degraded:` reason.

## Does this PR change performance numbers?
It should not change your QPS/latency, and it makes recall more correct, not different.

Here's the reasoning, part by part, against what actually gets measured. The reported metrics (throughput, latency percentiles, batch times) come only from the search() calls inside the timed batch loop (lines 1078–1093). Recall is computed after batch_end, explicitly outside the timing. So the question reduces to: does anything I changed alter (a) what happens between batch_start and batch_end, or (b) the recall value?

Part 1 (gRPC limit) — touches the timed connection, but not the timed work. The timed worker's connection now goes through open_connection, so it's opened with `max_receive_message_length=514_983_574` instead of the 256 MiB default. What changes: the ceiling on gRPC response size. What does not change: the queries themselves, the ef/limit params, the number of round-trips, or the server-side work. A higher receive ceiling doesn't make a response arrive faster — it only changes whether an over-limit response is rejected vs. accepted. Your benchmark queries return top-k IDs (tiny payloads, kilobytes), nowhere near either limit, so the timed path behaves identically. The raised ceiling only ever mattered in the untimed FLAT ground-truth copy, which is where #572 fired.

Part 2 (enhanced_bench iterator cap + cursor) — not in this code path at all. The command in issue #572  ran vectordb run without --mode sweep, so it is on simple_bench. The enhanced_bench changes don't execute. And even in sweep mode, they only affect FLAT ground-truth construction, which is untimed.

Part 3 (verdict) — runs entirely after the timed loop. emit_result_verdict executes after stats are computed. It adds a result_verdict.json and one stdout line. Zero effect on measured values.

### The recall subtlety: The changes in this PR can make recall different from your pre-fix run, and that's the intended behavior of #572:

On the original code, if the FLAT copy hit RESOURCE_EXHAUSTED and the fallback recovered to, say, 99.4% coverage, the old code would report recall computed against an incomplete ground truth and call it a clean pass.

On the fixed code, that same run now either (a) completes cleanly at full coverage via the raised limit — giving the correct, slightly different recall — or (b) if it lands below 100%, gets flagged degraded with a non-zero exit.