### PR TITLE
chore: bump 3.0.33 -> 3.0.34; DLIO pin -> PR #43; uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.33"
+version = "3.0.34"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -132,6 +132,9 @@ torchaudio = [{ index = "pytorch-cpu" }]
 # Pinned to a specific commit for reproducibility; bump by updating `rev` and
 # re-running `uv lock --upgrade-package dlio-benchmark`.
 # Commit history (most recent first):
+#   - DLIO PR #43 fix for storage #671: env-var fallback for OpenMPI
+#     COMM_TYPE_SHARED collapse — prevents num_hosts = MPI-rank-count on
+#     Ubuntu 24.04 / kernel 6.8+ / OpenMPI 4.1.6
 #   - DLIO PR #42 fix for storage #667: _checkpoint LIST once on rank 0
 #     and broadcast the count — prevents SlowDown/503 storms and spurious
 #     "0 checkpoints available" aborts at scale (llama3-405b, 512 ranks
@@ -154,7 +157,7 @@ torchaudio = [{ index = "pytorch-cpu" }]
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
 #   - DLIO PR #21 fix for storage #391 part 1 (TorchIterableDatasetSimple gating)
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "c338e07412350df4d72279be985ff31b82407a80" }
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "59f94801f9816c5fac436b4b288195a817fce871" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=c338e07412350df4d72279be985ff31b82407a80#c338e07412350df4d72279be985ff31b82407a80" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=59f94801f9816c5fac436b4b288195a817fce871#59f94801f9816c5fac436b4b288195a817fce871" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.33"
+version = "3.0.34"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=c338e07412350df4d72279be985ff31b82407a80" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=c338e07412350df4d72279be985ff31b82407a80" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=59f94801f9816c5fac436b4b288195a817fce871" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=59f94801f9816c5fac436b4b288195a817fce871" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary

- Bump package version `3.0.33` → `3.0.34`
- Advance DLIO pin from PR #42 (`c338e074`) → PR #43 (`59f94801`) — env-var fallback for OpenMPI `COMM_TYPE_SHARED` collapse (storage#671)
- Regenerate `uv.lock`

## Test plan

- [ ] CI passes