### PR TITLE
checkpoint: make writer start method selectable (fork/forkserver) with backend-aware default (#682)

### DIFF
--- a/docs/Streaming-Chkpt-Guide.md
+++ b/docs/Streaming-Chkpt-Guide.md
@@ -212,6 +212,41 @@ checkpoint.save('s3://bucket/key', total_size)
 checkpoint.save('/nvme/checkpoint.pt', total_size)
 ```
 
+### Writer subprocess start method (`fork` vs `forkserver`)
+
+The streaming writer runs in a subprocess. The multiprocessing **start
+method** used to create it is selectable, with a **backend-aware default**:
+
+| Target | `'auto'` default | Rationale |
+|---|---|---|
+| POSIX file (`backend='file'`, or a scheme-less / `file://` path) | `fork` | The parent never starts s3dlio's Tokio runtime, so `fork` is safe **and** ~40% faster — it keeps the parent's copy-on-write warm state and CPU/NUMA locality with the shared-memory buffers ([#682](https://github.com/mlcommons/storage/issues/682)). |
+| Object storage (`s3dlio`, `direct_fs`, `s3torchconnector`, `minio`, or any `s3://`/`az://`/`gs://`/`direct://` URI) | `forkserver` | The parent has a live s3dlio Tokio runtime (via `ObjStoreLibStorage._preflight()`) by the time the writer is created; `fork()` copies that mutex state and the writer futex-deadlocks ([#642](https://github.com/mlcommons/storage/issues/642)). `forkserver` gets a clean interpreter without `spawn`'s `__main__` re-import (which hangs MPI ranks). |
+
+Leave `mp_start_method='auto'` (the default) and each backend gets the right
+method automatically. To override:
+
+```python
+# Constructor argument (highest precedence)
+checkpoint = StreamingCheckpointing(
+    backend='file',
+    mp_start_method='forkserver',   # 'auto' | 'fork' | 'forkserver' | 'spawn'
+)
+```
+
+```bash
+# Or via environment variable (constructor arg wins if both are set)
+export MLPS_CHECKPOINT_MP_START_METHOD=fork
+```
+
+Notes:
+- Requesting `mp_start_method='fork'` on an **object-storage** target raises a
+  `ValueError` (citing #642) rather than deadlocking.
+- If the platform lacks the requested method (e.g. no `fork`/`forkserver` on
+  Windows/macOS), it degrades gracefully: `fork` → `forkserver` → `spawn`.
+- `save()` logs the resolved method, e.g.
+  `[Main] Writer start method: fork (policy='auto', backend=file)`, so each run
+  records which method produced its result.
+
 ## Feature 4: Multi-Endpoint Load Balancing
 
 ### What It Does

--- a/mlpstorage_py/checkpointing/streaming_checkpoint.py
+++ b/mlpstorage_py/checkpointing/streaming_checkpoint.py
@@ -60,37 +60,111 @@ def _local_ranks_per_node(env=None):
     return 1
 
 
-def _writer_mp_context():
+# Selecting the streaming-checkpoint writer subprocess start method.
+#
+# The right method depends on the backend, so it is a *choice* with a
+# backend-aware default (issues #642 and #682):
+#
+#   * POSIX file backend (``backend='file'`` or a scheme-less / ``file://``
+#     path): the parent never starts s3dlio's Tokio runtime, so ``fork`` is
+#     safe *and* ~40% faster — it keeps the parent's copy-on-write warm state
+#     and CPU/NUMA locality with the shared-memory buffers (#682). Default:
+#     ``fork``.
+#   * Object-storage / s3dlio path (``s3dlio``, ``direct_fs``,
+#     ``s3torchconnector``, ``minio``, or any remote-scheme URI): the parent
+#     has already started s3dlio's Tokio runtime via
+#     ``ObjStoreLibStorage._preflight()`` → ``s3dlio.list()`` by the time the
+#     writer is created. ``fork()`` copies that mutex state without the
+#     threads holding the mutexes and the writer futex-deadlocks the first
+#     time it re-enters s3dlio (#642). Default: ``forkserver`` — the clean
+#     "no live Tokio" property of ``spawn`` without ``spawn``'s ``__main__``
+#     re-import (``spawn`` also hangs MPI ranks re-joining the OpenMPI
+#     communicator, the historical reason fork was chosen originally).
+#
+# Users may override the default with the ``mp_start_method`` constructor
+# argument or the ``MLPS_CHECKPOINT_MP_START_METHOD`` environment variable
+# (constructor arg wins). Explicitly requesting ``fork`` on the object-storage
+# path is refused rather than silently honored, because it deadlocks (#642).
+MP_START_METHOD_ENV = "MLPS_CHECKPOINT_MP_START_METHOD"
+_VALID_MP_START_METHODS = ("auto", "fork", "forkserver", "spawn")
+
+
+def _is_posix_file_backend(backend=None, uri_or_path=None):
+    """True when the writer targets a local POSIX file — the only path where
+    forking the writer is safe (no parent-side s3dlio Tokio runtime).
+
+    Mirrors ``StorageWriterFactory``'s own resolution: an explicit
+    ``backend='file'`` is POSIX; with no explicit backend, a scheme-less or
+    ``file://`` path auto-detects to the local file writer, anything else
+    (``s3://``, ``az://``, ``gs://``, ``direct://``, …) is object storage.
+    """
+    if backend:
+        return backend == "file"
+    uri = uri_or_path or ""
+    if "://" not in uri:
+        return True
+    return uri.startswith("file://")
+
+
+def _resolve_mp_start_method(start_method="auto", *, backend=None, uri_or_path=None):
+    """Resolve a requested start method to a concrete ``fork`` / ``forkserver``
+    / ``spawn``, applying the backend-aware default and the #642 guardrail.
+
+    ``start_method='auto'`` (the default) picks ``fork`` on the POSIX file
+    backend and ``forkserver`` on the object-storage path. An explicit value
+    is honored, except ``fork`` on the object-storage path which raises rather
+    than deadlock.
+    """
+    method = (start_method or "auto").lower()
+    if method not in _VALID_MP_START_METHODS:
+        raise ValueError(
+            f"invalid checkpoint writer start method {start_method!r}; choose "
+            f"one of {_VALID_MP_START_METHODS[1:]} or 'auto' "
+            f"(via mp_start_method= or ${MP_START_METHOD_ENV})"
+        )
+
+    posix_file = _is_posix_file_backend(backend, uri_or_path)
+
+    if method == "auto":
+        return "fork" if posix_file else "forkserver"
+
+    if method == "fork" and not posix_file:
+        raise ValueError(
+            f"checkpoint writer start method 'fork' is unsafe on the "
+            f"object-storage backend ({(backend or uri_or_path)!r}): fork() "
+            f"after s3dlio's Tokio runtime is live deadlocks the writer "
+            f"(issue #642). Use 'forkserver' (the default there) or 'auto'."
+        )
+    return method
+
+
+def _mp_availability_fallback(method):
+    """Platform-availability fallback order for a resolved method (NOT a policy
+    choice): degrade only when the OS can't provide the requested context —
+    fork→forkserver→spawn, forkserver→spawn, spawn→spawn."""
+    if method == "fork":
+        return ("fork", "forkserver", "spawn")
+    if method == "forkserver":
+        return ("forkserver", "spawn")
+    return ("spawn",)
+
+
+def _writer_mp_context(start_method="auto", *, backend=None, uri_or_path=None):
     """Return the multiprocessing context for the streaming-checkpoint writer.
 
-    Prefers ``forkserver`` — children fork from a clean, early-started
-    interpreter with no live Tokio runtime — falling back to ``spawn``
-    only on platforms without ``forkserver`` (Windows/macOS). ``fork``
-    is intentionally never used.
-
-    Issue #642: before this fix, ``save()`` used ``mp.get_context('fork')``.
-    On the s3dlio object-storage path the parent has already started
-    s3dlio's Tokio runtime via ``ObjStoreLibStorage._preflight()`` →
-    ``s3dlio.list()`` by the time the writer subprocess is created;
-    ``fork()`` then copies the parent's mutex state without the threads
-    holding those mutexes and the writer futex-deadlocks the first time
-    it re-enters s3dlio. The old code comment claimed fork was safe
-    "because the writer child creates fresh StorageWriter instances after
-    fork so Tokio/Rayon are initialized cleanly in the child" — that
-    reasoning holds for what the child does, not for the mutex state the
-    child inherits.
-
-    ``spawn`` is a fallback rather than the primary choice because it
-    re-imports ``__main__`` and blocks MPI ranks re-joining the
-    OpenMPI communicator (the historical reason the pre-#642 code
-    picked ``fork`` over ``spawn`` in the first place). ``forkserver``
-    gets the "clean interpreter, no live Tokio" property of ``spawn``
-    without ``spawn``'s ``__main__`` re-import.
+    ``start_method`` selects the policy (see ``_resolve_mp_start_method``);
+    the resolved method then degrades gracefully if the platform cannot
+    provide it (e.g. no ``fork``/``forkserver`` on Windows/macOS).
     """
-    try:
-        return mp.get_context('forkserver')
-    except ValueError:
-        return mp.get_context('spawn')
+    method = _resolve_mp_start_method(
+        start_method, backend=backend, uri_or_path=uri_or_path
+    )
+    for candidate in _mp_availability_fallback(method):
+        try:
+            return mp.get_context(candidate)
+        except ValueError:
+            continue
+    return mp.get_context("spawn")
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import shared_memory
 from typing import Optional, Dict, Any
@@ -150,6 +224,7 @@ class StreamingCheckpointing:
         fadvise_mode: str = 'none',
         num_parallel_readers: int = 8,
         read_chunk_size: Optional[int] = None,
+        mp_start_method: Optional[str] = None,
         **backend_kwargs
     ):
         """Initialize streaming checkpoint configuration.
@@ -165,6 +240,13 @@ class StreamingCheckpointing:
             read_chunk_size: Chunk size for read range-GETs in bytes (default: 4 × chunk_size).
                              Larger values reduce per-request HTTP overhead at the cost of
                              more RAM per reader thread (peak = num_parallel_readers × read_chunk_size).
+            mp_start_method: Writer subprocess start method — 'auto' (default),
+                             'fork', 'forkserver', or 'spawn'. 'auto' picks 'fork'
+                             on the POSIX file backend (fast, #682) and 'forkserver'
+                             on the object-storage / s3dlio path (fork deadlocks
+                             there, #642). Overrides the ``MLPS_CHECKPOINT_MP_START_METHOD``
+                             environment variable; if both are None, defaults to 'auto'.
+                             Requesting 'fork' on the object-storage path is refused.
             **backend_kwargs: Additional backend-specific options
         """
         self.chunk_size = chunk_size
@@ -175,6 +257,14 @@ class StreamingCheckpointing:
         self.fadvise_mode = fadvise_mode
         self.num_parallel_readers = num_parallel_readers
         self.read_chunk_size = read_chunk_size if read_chunk_size is not None else chunk_size * 4
+        # Writer start-method policy: explicit arg > env var > 'auto'
+        # (backend-aware). Resolved to a concrete method at save() time, when
+        # the target filepath/backend is known. See _writer_mp_context.
+        self.mp_start_method = (
+            mp_start_method
+            or os.environ.get(MP_START_METHOD_ENV)
+            or "auto"
+        )
         self.backend_kwargs = backend_kwargs
         
         # dgen-py is REQUIRED if no custom generator will be provided
@@ -254,11 +344,14 @@ class StreamingCheckpointing:
         if self.use_direct_io:
             print(f"[Main] ⚠ Disabling O_DIRECT (shared_memory buffers not page-aligned)")
         
-        # Writer subprocess context — see `_writer_mp_context` at module
-        # scope for the forkserver-over-fork rationale (#642: fork after
-        # live s3dlio Tokio deadlocks; forkserver avoids re-importing
-        # __main__, which is what makes spawn hang MPI ranks re-joining
-        # the OpenMPI communicator).
+        # Writer subprocess context — see the module-scope helpers for the
+        # backend-aware default: 'fork' on the POSIX file backend (fast, #682),
+        # 'forkserver' on the object-storage / s3dlio path (fork after live
+        # Tokio deadlocks, #642). self.mp_start_method (constructor arg or
+        # $MLPS_CHECKPOINT_MP_START_METHOD) overrides the default; 'fork' on
+        # the object-storage path is refused rather than silently deadlocked.
+        # The backend is resolved from self.backend, falling back to the
+        # target filepath's URI scheme when backend is auto-detect (None).
         #
         # CRITICAL: IPC objects (Queue, Event) MUST be created from the SAME
         # context as the child process — mixing contexts (e.g. fork-context
@@ -266,7 +359,11 @@ class StreamingCheckpointing:
         #   RuntimeError: A SemLock created in a fork context is being shared
         #                 with a process in a spawn context.
         # Always create IPC objects from ctx BEFORE ctx.Process().
-        ctx = _writer_mp_context()
+        ctx = _writer_mp_context(
+            self.mp_start_method, backend=self.backend, uri_or_path=filepath
+        )
+        print(f"[Main] Writer start method: {ctx.get_start_method()} "
+              f"(policy={self.mp_start_method!r}, backend={self.backend or 'auto'})")
 
         # Setup IPC using the same context as the child process.
         buffer_queue = ctx.Queue(maxsize=self.num_buffers)

--- a/tests/unit/test_streaming_checkpoint_mp_context.py
+++ b/tests/unit/test_streaming_checkpoint_mp_context.py
@@ -1,25 +1,29 @@
-"""Tests for issue #642 — streaming checkpoint writer must not fork after
-the parent's s3dlio Tokio runtime is live.
+"""Tests for the streaming-checkpoint writer start-method selection.
 
-``StreamingCheckpointing.save()`` previously created its writer subprocess
-with ``mp.get_context('fork')``. On the s3dlio object-storage path the
-parent has already started s3dlio's Tokio runtime (via
-``ObjStoreLibStorage._preflight()`` → ``s3dlio.list()``) by the time
-``save()`` runs, so ``fork()`` copies the parent's mutex state without
-the threads holding those mutexes. The writer futex-deadlocks the moment
-it re-enters s3dlio, the producer blocks on a full queue, and all ranks
-sit at ~0% CPU right after ``[Writer] Attached to N buffers``.
+Two issues shape the contract:
 
-The fix uses ``forkserver`` — children fork from a clean, early-started
-interpreter with no live Tokio — falling back to ``spawn`` on platforms
-without ``forkserver`` (Windows/macOS). ``spawn`` is a fallback rather
-than the primary choice because it re-imports ``__main__``, which the
-in-code comment history records as the source of an MPI-rejoin hang.
-``fork`` is intentionally NEVER used.
+* **#642** — on the s3dlio object-storage path the parent has already
+  started s3dlio's Tokio runtime (``ObjStoreLibStorage._preflight()`` →
+  ``s3dlio.list()``) by the time ``save()`` creates the writer subprocess.
+  ``fork()`` copies that mutex state without the threads holding the
+  mutexes and the writer futex-deadlocks the moment it re-enters s3dlio.
+  So the object-storage path must **never** fork.
 
-These tests lock the contract at the helper boundary
-(``_writer_mp_context``) so a future refactor cannot silently regress
-the choice.
+* **#682** — on the POSIX file backend the parent never starts a Tokio
+  runtime, so ``fork`` is safe there *and* ~40% faster than the
+  ``forkserver`` that #642 applied unconditionally (it keeps the parent's
+  copy-on-write warm state and CPU/NUMA locality with the shared-memory
+  buffers). So the file backend should fork by default.
+
+The resolution is a **selectable** start method with a **backend-aware
+default** (``mp_start_method`` constructor arg / ``$MLPS_CHECKPOINT_MP_START_METHOD``):
+``'auto'`` → ``'fork'`` on the file backend, ``'forkserver'`` on object
+storage; an explicit value is honored, except ``'fork'`` on object storage,
+which is refused rather than allowed to deadlock.
+
+These tests lock that policy at the helper boundary so a future refactor
+cannot silently regress either the #642 safety property or the #682
+performance default.
 """
 
 from __future__ import annotations
@@ -27,29 +31,90 @@ from __future__ import annotations
 import multiprocessing as mp
 from unittest.mock import patch
 
+import pytest
+
+from mlpstorage_py.checkpointing import streaming_checkpoint as sc
+from mlpstorage_py.checkpointing.streaming_checkpoint import (
+    _resolve_mp_start_method,
+    _writer_mp_context,
+)
+
+
+class TestResolveMPStartMethod:
+    """``_resolve_mp_start_method`` is the platform-independent policy: given a
+    requested method plus the target backend/URI, return the concrete method
+    to use (``fork`` / ``forkserver`` / ``spawn``) — or raise."""
+
+    # --- backend-aware 'auto' default ---------------------------------------
+
+    def test_auto_file_backend_forks(self):
+        """#682: explicit ``backend='file'`` forks by default."""
+        assert _resolve_mp_start_method('auto', backend='file') == 'fork'
+
+    def test_auto_object_store_backend_forkservers(self):
+        """#642: every s3dlio-backed backend uses forkserver by default."""
+        for backend in ('s3dlio', 'direct_fs', 's3torchconnector', 'minio'):
+            assert _resolve_mp_start_method('auto', backend=backend) == 'forkserver', backend
+
+    def test_auto_detects_file_from_scheme_less_or_file_uri(self):
+        """With no explicit backend, a scheme-less or file:// path is POSIX."""
+        assert _resolve_mp_start_method('auto', uri_or_path='/scratch/ckpt.dat') == 'fork'
+        assert _resolve_mp_start_method('auto', uri_or_path='file:///scratch/ckpt.dat') == 'fork'
+
+    def test_auto_detects_object_store_from_uri_scheme(self):
+        """With no explicit backend, a remote-scheme URI is object storage."""
+        for uri in ('s3://bucket/ckpt', 'az://c/ckpt', 'gs://b/ckpt', 'direct:///m/ckpt'):
+            assert _resolve_mp_start_method('auto', uri_or_path=uri) == 'forkserver', uri
+
+    # --- explicit override is honored ---------------------------------------
+
+    def test_explicit_fork_on_file_is_honored(self):
+        assert _resolve_mp_start_method('fork', backend='file') == 'fork'
+
+    def test_explicit_forkserver_on_file_is_honored(self):
+        """A user may still opt the file backend back onto forkserver."""
+        assert _resolve_mp_start_method('forkserver', backend='file') == 'forkserver'
+
+    def test_explicit_spawn_is_honored_on_both_backends(self):
+        assert _resolve_mp_start_method('spawn', backend='file') == 'spawn'
+        assert _resolve_mp_start_method('spawn', backend='s3dlio') == 'spawn'
+
+    # --- #642 guardrail: fork refused on the object-storage path ------------
+
+    def test_explicit_fork_on_object_store_backend_raises(self):
+        with pytest.raises(ValueError, match='642'):
+            _resolve_mp_start_method('fork', backend='s3dlio')
+
+    def test_explicit_fork_on_object_store_uri_raises(self):
+        with pytest.raises(ValueError, match='fork'):
+            _resolve_mp_start_method('fork', uri_or_path='s3://bucket/ckpt')
+
+    def test_invalid_method_raises(self):
+        with pytest.raises(ValueError):
+            _resolve_mp_start_method('threads', backend='file')
+
 
 class TestWriterMPContext:
-    """`_writer_mp_context` returns the multiprocessing context used to
-    spawn the writer subprocess. Prefers ``forkserver``; falls back to
-    ``spawn`` only when ``forkserver`` is unavailable; never returns
-    ``fork``."""
+    """``_writer_mp_context`` turns the resolved policy into a real
+    multiprocessing context, degrading only when the platform cannot provide
+    the requested method (availability fallback, never a policy change)."""
 
-    def test_returns_forkserver_on_linux(self):
-        """Linux (and any platform where forkserver is supported) must
-        get the forkserver context — the whole point of the fix."""
-        from mlpstorage_py.checkpointing.streaming_checkpoint import (
-            _writer_mp_context,
-        )
-        ctx = _writer_mp_context()
-        assert ctx.get_start_method() == 'forkserver', (
-            f"expected forkserver, got {ctx.get_start_method()!r}"
+    # --- #642 safety: object storage never forks ----------------------------
+
+    def test_object_store_never_forks(self):
+        ctx = _writer_mp_context('auto', backend='s3dlio')
+        assert ctx.get_start_method() != 'fork', (
+            "the writer must not fork after s3dlio's Tokio runtime is live (#642)"
         )
 
-    def test_falls_back_to_spawn_when_forkserver_unavailable(self):
-        """If ``forkserver`` raises ``ValueError`` (unsupported platform),
-        the helper must return the ``spawn`` context, not ``fork``."""
-        from mlpstorage_py.checkpointing import streaming_checkpoint as sc
+    def test_object_store_default_is_forkserver_where_available(self):
+        ctx = _writer_mp_context('auto', backend='s3dlio')
+        # forkserver on Linux/macOS; spawn-only on Windows.
+        assert ctx.get_start_method() in ('forkserver', 'spawn')
 
+    def test_object_store_falls_back_to_spawn_not_fork(self):
+        """If forkserver is unavailable the object-storage path must degrade to
+        spawn, never to fork."""
         real_get_context = mp.get_context
 
         def fake_get_context(name):
@@ -58,22 +123,33 @@ class TestWriterMPContext:
             return real_get_context(name)
 
         with patch.object(sc.mp, 'get_context', side_effect=fake_get_context):
-            ctx = sc._writer_mp_context()
+            ctx = sc._writer_mp_context('auto', backend='s3dlio')
+        assert ctx.get_start_method() == 'spawn'
 
-        assert ctx.get_start_method() == 'spawn', (
-            f"expected spawn fallback, got {ctx.get_start_method()!r}"
-        )
+    def test_explicit_fork_on_object_store_raises(self):
+        with pytest.raises(ValueError, match='642'):
+            _writer_mp_context('fork', backend='s3dlio')
 
-    def test_never_returns_fork(self):
-        """Regression guard: even in a hypothetical future where both
-        forkserver and spawn are unavailable, the helper must not silently
-        fall through to ``fork`` — the whole reason for this refactor is
-        that fork deadlocks on the s3dlio Tokio-live path."""
-        from mlpstorage_py.checkpointing.streaming_checkpoint import (
-            _writer_mp_context,
-        )
-        ctx = _writer_mp_context()
-        assert ctx.get_start_method() != 'fork', (
-            "the writer subprocess must not be forked from the parent "
-            "after s3dlio's Tokio runtime is live (#642)"
-        )
+    # --- #682 performance: file backend forks by default --------------------
+
+    @pytest.mark.skipif(
+        'fork' not in mp.get_all_start_methods(),
+        reason='fork not available on this platform',
+    )
+    def test_file_backend_default_forks(self):
+        ctx = _writer_mp_context('auto', backend='file')
+        assert ctx.get_start_method() == 'fork'
+
+    def test_file_backend_degrades_when_fork_unavailable(self):
+        """On a platform without fork (Windows), the file backend must still
+        yield a usable context, never crash."""
+        real_get_context = mp.get_context
+
+        def fake_get_context(name):
+            if name == 'fork':
+                raise ValueError("fork not available on this platform")
+            return real_get_context(name)
+
+        with patch.object(sc.mp, 'get_context', side_effect=fake_get_context):
+            ctx = sc._writer_mp_context('auto', backend='file')
+        assert ctx.get_start_method() in ('forkserver', 'spawn')


### PR DESCRIPTION
## Summary

Fixes the ~41% checkpoint-save regression reported in #682 by making the
streaming-checkpoint **writer subprocess start method** a *selectable option*
with a **backend-aware default**, instead of the unconditional `forkserver`
introduced by #650 (fix #642).

### Background

- **#642** was a correct fix: on the **s3dlio object-storage** path the parent
  already has a live Tokio runtime (`ObjStoreLibStorage._preflight()` →
  `s3dlio.list()`) by the time the writer subprocess is created, so `fork()`
  copies that mutex state and the writer futex-deadlocks the first time it
  re-enters s3dlio.
- **#682**: #650 applied `forkserver` **unconditionally**, including the POSIX
  `file` / `local_fs` path, which **never** starts a parent-side Tokio runtime
  and never had the deadlock. There, `forkserver` loses the parent's
  copy-on-write warm state and CPU/NUMA locality with the shared-memory
  buffers, regressing `llama3-8b` checkpoint save ~41% (~12.4 → ~7.4 GiB/s) —
  and it landed inside the submission window.

### Change

The start method is now a choice with a backend-aware default:

| Target | `'auto'` default | Why |
|---|---|---|
| `backend='file'` / `local_fs` / scheme-less / `file://` | **`fork`** | no parent Tokio → safe + ~40% faster (#682) |
| `s3dlio`, `direct_fs`, `s3torchconnector`, `minio`, `s3://`/`az://`/`gs://`/`direct://` | **`forkserver`** | fork-after-live-Tokio deadlocks (#642) |

- Override via `mp_start_method=` constructor arg or
  `MLPS_CHECKPOINT_MP_START_METHOD` env var (constructor arg wins).
- Explicit `fork` on the object-storage path is **refused** (`ValueError`
  citing #642) rather than silently deadlocked.
- Platform-availability fallback preserved: `fork` → `forkserver` → `spawn`.
- `save()` now logs the resolved method, e.g.
  `[Main] Writer start method: fork (policy='auto', backend=file)`, so each run
  records which method produced its result.

### Implementation

- `_is_posix_file_backend()` mirrors `StorageWriterFactory`'s own file-vs-object
  resolution.
- `_resolve_mp_start_method()` — pure, platform-independent policy (returns
  `fork`/`forkserver`/`spawn` or raises).
- `_writer_mp_context(start_method, backend, uri_or_path)` — resolves policy,
  then degrades only for platform availability.
- New `mp_start_method` argument on `StreamingCheckpointing.__init__`.

### Tests

`tests/unit/test_streaming_checkpoint_mp_context.py` rewritten to lock **both**
properties:
- **#642 safety** — object storage never forks; `forkserver`-unavailable
  degrades to `spawn` (not `fork`); explicit `fork` on object storage raises.
- **#682 default** — the file backend forks by default (where `fork` exists);
  explicit override honored; invalid method raises.

```
16 passed
```

### Note for the WG (submission comparability)

This restores POSIX performance without reintroducing the object-store deadlock.
Because the headline metric depends on the method, a tagged release / rules
should still **pin the canonical value per `storage_type`** (the knob is for
override/debug); the `save()` log line makes the method auditable per run.