### PR TITLE
fix(#689): dgen-py generator threads use local rank count, not global

### DIFF
--- a/docs/Streaming-Chkpt-Guide.md
+++ b/docs/Streaming-Chkpt-Guide.md
@@ -382,6 +382,21 @@ generator = dgen_py.Generator(
 )
 ```
 
+**Generator thread count under MPI** ([#689](https://github.com/mlcommons/storage/issues/689)):
+`StreamingCheckpointing` throttles dgen-py's `max_threads` to
+`os.cpu_count() // <ranks sharing this node>`, so that N ranks on one host
+don't each spin up a thread per core and oversubscribe it. The divisor is
+the **local** rank count (`OMPI_COMM_WORLD_LOCAL_SIZE` / `MPI_LOCALNRANKS` /
+`MV2_COMM_WORLD_LOCAL_SIZE`, first one present), not the global MPI world
+size — dividing a per-node CPU count by a cluster-wide rank count starves
+generation on multi-node runs (e.g. 192 CPUs / 64 global ranks = 3
+threads, when only 4 ranks actually share that node and 192 / 4 = 48 is
+correct). If generation is showing up as the pipeline bottleneck
+(`bottleneck: "Generation"` in `save()`'s results, or a low
+`throughput_ratio`), check the reported `local_ranks_per_node` in the
+`[Main] Initializing dgen-py (...)` log line against how many ranks are
+actually launched per host.
+
 ### StreamingCheckpointing Tuning
 
 **Chunk Size**:

--- a/mlpstorage_py/checkpointing/streaming_checkpoint.py
+++ b/mlpstorage_py/checkpointing/streaming_checkpoint.py
@@ -9,6 +9,57 @@ import time
 import multiprocessing as mp
 
 
+# Per-node MPI rank count, used to size the dgen-py generator's thread pool.
+#
+# Issue #689: dgen-py's threads must be throttled so that N ranks sharing a
+# node don't each spin up threads = os.cpu_count() and oversubscribe the
+# host. The throttle divisor must be the number of ranks sharing THIS node
+# (local size) — os.cpu_count() is already a per-node figure. Dividing it by
+# the GLOBAL world size instead (the bug prior to this fix) starves
+# generation on any multi-node run: e.g. 192 local CPUs / 64 global ranks
+# (16 nodes x 4 ranks/node) = 3 threads/rank, when only 4 ranks actually
+# share the node and 192 / 4 = 48 threads/rank is correct. That exact
+# 3-thread figure is what issue #689's profiling observed, with generation
+# throughput consequently landing close to the storage write rate instead
+# of comfortably ahead of it.
+#
+# This mirrors DLIO_local_changes' storage#671 fix, which hit the identical
+# global-vs-local mismatch for per-node accounting (there, OpenMPI's
+# COMM_TYPE_SHARED split collapsing to size 1 on remote nodes; here, using
+# the wrong env var entirely) and fixed it the same way: prefer the
+# launcher's LOCAL size env var over any global/world figure.
+_LOCAL_SIZE_ENV_VARS = (
+    'OMPI_COMM_WORLD_LOCAL_SIZE',   # OpenMPI
+    'MPI_LOCALNRANKS',              # MPICH / Hydra
+    'MV2_COMM_WORLD_LOCAL_SIZE',    # MVAPICH2
+)
+
+
+def _local_ranks_per_node(env=None):
+    """Return the number of MPI ranks sharing this node (>= 1).
+
+    Checks the launcher-specific LOCAL size env vars in ``_LOCAL_SIZE_ENV_VARS``
+    (first present, parseable, positive value wins). Falls back to 1 — i.e.
+    "assume this rank has the node to itself" — when none are set (single-node
+    / non-MPI launches) or all are malformed. 1 is deliberately the safe
+    default: it never reproduces the #689 under-threading bug, and a rank
+    that turns out not to be alone simply shares CPU time with its
+    node-mates rather than being starved down to a handful of threads.
+    """
+    if env is None:
+        env = os.environ
+    for _env_var in _LOCAL_SIZE_ENV_VARS:
+        _v = env.get(_env_var)
+        if _v:
+            try:
+                parsed = int(_v)
+            except (TypeError, ValueError):
+                continue
+            if parsed >= 1:
+                return parsed
+    return 1
+
+
 def _writer_mp_context():
     """Return the multiprocessing context for the streaming-checkpoint writer.
 
@@ -303,20 +354,13 @@ class StreamingCheckpointing:
             )
         
         # Throttle dgen-py threads when running under MPI to avoid
-        # overloading the host with 8 ranks × N-all-CPU threads simultaneously.
-        # Detect MPI world size from common env vars (OpenMPI, MPICH, MVAPICH).
-        mpi_world_size = 1
-        for _env_var in ('OMPI_COMM_WORLD_SIZE', 'PMI_SIZE', 'MV2_COMM_WORLD_SIZE'):
-            _v = os.environ.get(_env_var)
-            if _v:
-                try:
-                    mpi_world_size = max(1, int(_v))
-                    break
-                except ValueError:
-                    pass
+        # overloading the host with N ranks x all-CPU threads simultaneously.
+        # Divide by the ranks sharing THIS node (#689), not the global world
+        # size — see _local_ranks_per_node for why that distinction matters.
+        local_ranks = _local_ranks_per_node()
         total_cpus = os.cpu_count() or 4
-        max_threads = max(1, total_cpus // mpi_world_size)
-        print(f"[Main] Initializing dgen-py (MPI world_size={mpi_world_size}, threads={max_threads}/{total_cpus} CPUs)...")
+        max_threads = max(1, total_cpus // local_ranks)
+        print(f"[Main] Initializing dgen-py (local_ranks_per_node={local_ranks}, threads={max_threads}/{total_cpus} CPUs)...")
         try:
             generator = dgen_py.Generator(
                 size=total_size_bytes,
@@ -324,7 +368,7 @@ class StreamingCheckpointing:
                 dedup_ratio=1.0,
                 compress_ratio=1.0,
                 numa_mode="auto",
-                max_threads=max_threads,  # Throttled by MPI world size
+                max_threads=max_threads,  # Throttled by local ranks-per-node (#689)
             )
             print(f"[Main] Generator ready")
             return generator

--- a/tests/unit/test_streaming_checkpoint_generator_threads.py
+++ b/tests/unit/test_streaming_checkpoint_generator_threads.py
@@ -1,0 +1,202 @@
+"""Tests for issue #689 — dgen-py generator under-threaded on multi-node runs.
+
+``StreamingCheckpointing._init_generator`` sizes dgen-py's thread pool as
+``os.cpu_count() // <mpi divisor>``. ``os.cpu_count()`` is a per-node figure
+(the CPUs on THIS host). Prior to this fix the divisor was the GLOBAL MPI
+world size (``OMPI_COMM_WORLD_SIZE`` et al.) — a units mismatch whenever a
+run spans more than one node, since it divides a per-node quantity by a
+total-across-all-nodes quantity.
+
+Reported symptom (mlcommons/storage#689): a `llama3-70b` checkpoint run on
+16 nodes x 4 ranks/node (64 global ranks), 192 vCPUs/node, computed
+``max_threads = 192 // 64 = 3``. With only 3 generator threads, CPU-side
+data generation ran close to the storage write rate and was profiled as the
+throughput bottleneck in ~35% of chunks — so the reported number partly
+measured client CPU generation speed rather than storage I/O.
+
+The fix divides by the ranks sharing THIS node instead (``_local_ranks_per_node``,
+via the launcher's LOCAL size env var), giving ``192 // 4 = 48`` threads/rank
+for the same run — a 16x increase, matching what the single-node case already
+computed correctly (world size == local size when there's only one node,
+so this fix does not change single-node behavior).
+
+Mirrors DLIO_local_changes' storage#671 fix, which hit the identical
+global-vs-local mismatch for per-node accounting and resolved it with the
+same technique: prefer the launcher's LOCAL size env var over any
+global/world figure.
+
+These tests lock the contract at two boundaries so a future refactor cannot
+silently regress either:
+  * the pure policy helper (``_local_ranks_per_node``)
+  * the call site that actually feeds dgen-py (``_init_generator`` ->
+    ``dgen_py.Generator(max_threads=...)``)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mlpstorage_py.checkpointing.streaming_checkpoint import (
+    StreamingCheckpointing,
+    _local_ranks_per_node,
+)
+
+
+class TestLocalRanksPerNode:
+    """``_local_ranks_per_node`` is the platform-independent policy: given an
+    env mapping, return the number of MPI ranks sharing this node."""
+
+    # --- no MPI info: safe single-rank default -------------------------
+
+    def test_no_env_defaults_to_one(self):
+        """No launcher env vars set (single-node / non-MPI run): 1."""
+        assert _local_ranks_per_node(env={}) == 1
+
+    # --- each supported launcher is read -------------------------------
+
+    def test_openmpi_local_size_used(self):
+        assert _local_ranks_per_node(env={'OMPI_COMM_WORLD_LOCAL_SIZE': '4'}) == 4
+
+    def test_mpich_localnranks_used(self):
+        assert _local_ranks_per_node(env={'MPI_LOCALNRANKS': '8'}) == 8
+
+    def test_mvapich2_local_size_used(self):
+        assert _local_ranks_per_node(env={'MV2_COMM_WORLD_LOCAL_SIZE': '2'}) == 2
+
+    # --- precedence: first-listed launcher wins when several are set ---
+
+    def test_openmpi_takes_precedence_over_others(self):
+        env = {
+            'OMPI_COMM_WORLD_LOCAL_SIZE': '4',
+            'MPI_LOCALNRANKS': '99',
+            'MV2_COMM_WORLD_LOCAL_SIZE': '99',
+        }
+        assert _local_ranks_per_node(env=env) == 4
+
+    def test_mpich_takes_precedence_over_mvapich2(self):
+        env = {'MPI_LOCALNRANKS': '8', 'MV2_COMM_WORLD_LOCAL_SIZE': '99'}
+        assert _local_ranks_per_node(env=env) == 8
+
+    # --- global world-size vars must NOT be consulted (the #689 bug) ---
+
+    def test_global_world_size_vars_are_ignored(self):
+        """The whole point of the fix: global size vars must never be read
+        as a stand-in for local size, even if they're the only thing set."""
+        env = {
+            'OMPI_COMM_WORLD_SIZE': '64',
+            'PMI_SIZE': '64',
+            'MV2_COMM_WORLD_SIZE': '64',
+        }
+        assert _local_ranks_per_node(env=env) == 1
+
+    # --- malformed / non-positive values are skipped, not fatal --------
+
+    def test_malformed_value_falls_through_to_next_var(self):
+        env = {'OMPI_COMM_WORLD_LOCAL_SIZE': 'not-a-number', 'MPI_LOCALNRANKS': '6'}
+        assert _local_ranks_per_node(env=env) == 6
+
+    def test_all_malformed_defaults_to_one(self):
+        env = {
+            'OMPI_COMM_WORLD_LOCAL_SIZE': 'x',
+            'MPI_LOCALNRANKS': '',
+            'MV2_COMM_WORLD_LOCAL_SIZE': 'nope',
+        }
+        assert _local_ranks_per_node(env=env) == 1
+
+    def test_zero_value_skipped(self):
+        """A local size of 0 is nonsensical (a rank always shares its own
+        node with at least itself) — treat as malformed, not as a divide-by-zero."""
+        env = {'OMPI_COMM_WORLD_LOCAL_SIZE': '0', 'MPI_LOCALNRANKS': '4'}
+        assert _local_ranks_per_node(env=env) == 4
+
+    def test_negative_value_skipped(self):
+        env = {'OMPI_COMM_WORLD_LOCAL_SIZE': '-1', 'MPI_LOCALNRANKS': '4'}
+        assert _local_ranks_per_node(env=env) == 4
+
+    def test_default_env_reads_os_environ(self):
+        """With env=None (the default), os.environ is consulted."""
+        with patch.dict('os.environ', {'OMPI_COMM_WORLD_LOCAL_SIZE': '4'}, clear=False):
+            assert _local_ranks_per_node() == 4
+
+
+class TestInitGeneratorThreadCount:
+    """``_init_generator`` is the actual call site that feeds dgen-py.
+    These tests patch ``dgen_py.Generator`` and ``os.cpu_count`` to lock the
+    real max_threads value passed to the generator — not just the pure
+    policy helper — so a future refactor of the wiring cannot silently
+    regress the fix even if ``_local_ranks_per_node`` itself stays correct.
+    """
+
+    def _make_checkpoint(self):
+        return StreamingCheckpointing(
+            chunk_size=1024 * 1024, num_buffers=2, use_dgen=True, backend='file',
+        )
+
+    def test_689_regression_16_nodes_4_ranks_per_node(self):
+        """The exact scenario from issue #689: 192 vCPUs/node, 16 nodes x 4
+        ranks/node (64 global ranks). Prior to the fix this computed
+        max_threads = 192 // 64 = 3 (the reported symptom). Fixed:
+        max_threads = 192 // 4 = 48."""
+        env = {
+            'OMPI_COMM_WORLD_LOCAL_SIZE': '4',   # ranks sharing this node
+            'OMPI_COMM_WORLD_SIZE': '64',        # global — must be ignored
+        }
+        ckpt = self._make_checkpoint()
+        with patch('mlpstorage_py.checkpointing.streaming_checkpoint.HAS_DGEN', True), \
+             patch('mlpstorage_py.checkpointing.streaming_checkpoint.dgen_py') as mock_dgen, \
+             patch('os.cpu_count', return_value=192), \
+             patch.dict('os.environ', env, clear=True):
+            mock_dgen.Generator.return_value = MagicMock()
+            ckpt._init_generator(total_size_bytes=1024 * 1024 * 1024)
+
+        assert mock_dgen.Generator.call_count == 1
+        kwargs = mock_dgen.Generator.call_args.kwargs
+        assert kwargs['max_threads'] == 48, (
+            f"max_threads={kwargs['max_threads']}; expected 48 (192 cpus / 4 "
+            f"local ranks). Got the pre-fix value (3 = 192 / 64 global ranks) "
+            f"if this regresses (#689)."
+        )
+
+    def test_single_node_no_mpi_uses_all_cpus(self):
+        """No MPI env at all (single-process run): use every CPU — this
+        must match pre-fix behavior exactly (world size defaulted to 1
+        too), so the fix must not change single-node/non-MPI behavior."""
+        ckpt = self._make_checkpoint()
+        with patch('mlpstorage_py.checkpointing.streaming_checkpoint.HAS_DGEN', True), \
+             patch('mlpstorage_py.checkpointing.streaming_checkpoint.dgen_py') as mock_dgen, \
+             patch('os.cpu_count', return_value=16), \
+             patch.dict('os.environ', {}, clear=True):
+            mock_dgen.Generator.return_value = MagicMock()
+            ckpt._init_generator(total_size_bytes=1024 * 1024)
+
+        assert mock_dgen.Generator.call_args.kwargs['max_threads'] == 16
+
+    def test_single_node_multi_rank_divides_by_local_size(self):
+        """Single node, 8 ranks on it, no global-size env set at all (a
+        launcher that only exposes local info): still throttles correctly."""
+        ckpt = self._make_checkpoint()
+        env = {'OMPI_COMM_WORLD_LOCAL_SIZE': '8'}
+        with patch('mlpstorage_py.checkpointing.streaming_checkpoint.HAS_DGEN', True), \
+             patch('mlpstorage_py.checkpointing.streaming_checkpoint.dgen_py') as mock_dgen, \
+             patch('os.cpu_count', return_value=64), \
+             patch.dict('os.environ', env, clear=True):
+            mock_dgen.Generator.return_value = MagicMock()
+            ckpt._init_generator(total_size_bytes=1024 * 1024)
+
+        assert mock_dgen.Generator.call_args.kwargs['max_threads'] == 8
+
+    def test_at_least_one_thread_even_with_more_ranks_than_cpus(self):
+        """Pathological oversubscription (more local ranks than CPUs) must
+        floor at 1 thread, never 0 or negative."""
+        ckpt = self._make_checkpoint()
+        env = {'OMPI_COMM_WORLD_LOCAL_SIZE': '32'}
+        with patch('mlpstorage_py.checkpointing.streaming_checkpoint.HAS_DGEN', True), \
+             patch('mlpstorage_py.checkpointing.streaming_checkpoint.dgen_py') as mock_dgen, \
+             patch('os.cpu_count', return_value=4), \
+             patch.dict('os.environ', env, clear=True):
+            mock_dgen.Generator.return_value = MagicMock()
+            ckpt._init_generator(total_size_bytes=1024)
+
+        assert mock_dgen.Generator.call_args.kwargs['max_threads'] == 1


### PR DESCRIPTION
## Summary

Fixes the checkpoint-generation-throughput bug reported in #689 — the
streaming-checkpoint producer's `dgen-py` thread count was computed from
the **global** MPI world size instead of the **local** (per-node) rank
count, severely under-threading generation on any multi-node run.

## Root cause

`StreamingCheckpointing._init_generator` sized dgen-py's thread pool as:

```python
max_threads = os.cpu_count() // mpi_world_size
```

where `mpi_world_size` came from `OMPI_COMM_WORLD_SIZE` / `PMI_SIZE` /
`MV2_COMM_WORLD_SIZE` — all **global**, cluster-wide rank counts.
`os.cpu_count()`, however, is a **per-node** figure (the CPUs on *this*
host). Dividing a per-node quantity by a cluster-wide quantity is a units
mismatch that only shows up once a run spans more than one node.

The numbers in #689 confirm this exactly: a `llama3-70b` checkpoint run on
**16 nodes × 4 ranks/node** (64 global ranks), **192 vCPUs/node**, computed:

```
max_threads = 192 // 64 = 3
```

— the precise `threads=3` figure the issue's profiling reported. With only
3 generator threads, CPU-side synthetic-data generation ran close to the
storage write rate and was profiled as the pipeline bottleneck on ~35% of
chunks (1,327 of 3,840), meaning the reported checkpoint throughput
partly measured client CPU generation speed rather than pure storage I/O.

## Fix

`_local_ranks_per_node()` reads the launcher's **local** size env var
instead — `OMPI_COMM_WORLD_LOCAL_SIZE` (OpenMPI) / `MPI_LOCALNRANKS`
(MPICH/Hydra) / `MV2_COMM_WORLD_LOCAL_SIZE` (MVAPICH2), first present
wins — and divides by that:

```python
max_threads = os.cpu_count() // local_ranks_per_node
```

For the #689 scenario this gives `192 // 4 = 48` threads/rank — a **16x**
increase. Falls back to `1` when no launcher env var is set (single-node
or non-MPI runs), which reproduces the exact single-node behavior the old
code already had (world size == local size when there's only one node),
so single-node behavior is unchanged.

This mirrors `DLIO_local_changes`' [storage#671](https://github.com/mlcommons/storage/issues/671) fix, which hit the
identical global-vs-local mismatch for per-node accounting (there,
OpenMPI's `COMM_TYPE_SHARED` split collapsing to size 1 on remote nodes;
here, simply reading the wrong env var) and resolved it the same way:
prefer the launcher's LOCAL size env var over any global/world figure.

## Tests

16 new tests in `tests/unit/test_streaming_checkpoint_generator_threads.py`:

**`TestLocalRanksPerNode`** (pure policy helper):
- Each supported launcher var read correctly (OpenMPI / MPICH / MVAPICH2)
- Precedence order when multiple are set
- Global world-size vars are correctly **ignored** (the core #689 property)
- Malformed / zero / negative values skipped, fall through safely
- No-env default (1) for single-node/non-MPI runs

**`TestInitGeneratorThreadCount`** (locks the real call site):
- Direct regression test reproducing the issue's exact 16-node /
  4-ranks-per-node / 192-vCPU scenario — asserts `dgen_py.Generator` is
  called with `max_threads=48`, not the pre-fix `3`
- Single-node/no-MPI behavior unchanged
- Floors at 1 thread under pathological oversubscription (more local
  ranks than CPUs)

Confirmed these aren't tautological: reverting the fix makes the test
module fail to even *import* (`_local_ranks_per_node` doesn't exist
pre-fix).

Full suite: **2541 passed, 1 skipped** (unchanged from baseline).

## Live verification — all 4 storage paths

Ran real (non-mocked) `StreamingCheckpointing.save()` calls simulating the
#689 scenario (`OMPI_COMM_WORLD_LOCAL_SIZE=4`, `OMPI_COMM_WORLD_SIZE=64`)
against real infrastructure, across every backend the class supports:

| Case | Backend | Result |
|---|---|---|
| Standard DLIO local path (`/`) | `file` | ✅ threaded off local rank count |
| s3dlio File (`file://`) | `s3dlio` | ✅ threaded off local rank count |
| s3dlio Direct I/O (`direct://`) | `direct_fs` | ✅ threaded off local rank count |
| s3dlio Object (`s3://`), live MinIO | `s3dlio` | ✅ threaded off local rank count |

All 4 correctly used the local rank count, not the global one — on the
28-CPU test machine used here the global-size bug would have floored to a
**single thread** (`max(1, 28 // 64)`), an even starker demonstration
than the reported 192-CPU case.

## Docs

Added a note to `docs/Streaming-Chkpt-Guide.md` under "dgen-py Tuning"
explaining the local-vs-global distinction and how to recognize it from
the `[Main] Initializing dgen-py (...)` log line if generation shows up
as the pipeline bottleneck again.

## Relationship to #700

Independent of #700 (writer subprocess start method) — this fix only
touches `_init_generator`, #700 only touches `_writer_mp_context` and
related helpers, no line overlap in `streaming_checkpoint.py`. Can merge
in either order.