### PR TITLE
chore: bump 3.0.34 -> 3.0.35; DLIO pin -> PR #45 (storage#699)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.34"
+version = "3.0.35"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -132,6 +132,12 @@ torchaudio = [{ index = "pytorch-cpu" }]
 # Pinned to a specific commit for reproducibility; bump by updating `rev` and
 # re-running `uv lock --upgrade-package dlio-benchmark`.
 # Commit history (most recent first):
+#   - DLIO PR #45 fix for storage #699: os.makedirs(exist_ok=True) race on
+#     multi-host checkpoint runs — exponential-backoff retry in
+#     _makedirs_race_safe(); applied to FileStorage, ObjStoreLibStorage,
+#     and SimpleStreamingCheckpointing
+#   - DLIO PR #44 fix for storage #690: checkpoint read double-prepends bucket
+#     for object storage — affects llama3-* checkpointing on S3/GCS/Azure
 #   - DLIO PR #43 fix for storage #671: env-var fallback for OpenMPI
 #     COMM_TYPE_SHARED collapse — prevents num_hosts = MPI-rank-count on
 #     Ubuntu 24.04 / kernel 6.8+ / OpenMPI 4.1.6
@@ -157,7 +163,7 @@ torchaudio = [{ index = "pytorch-cpu" }]
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
 #   - DLIO PR #21 fix for storage #391 part 1 (TorchIterableDatasetSimple gating)
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "59f94801f9816c5fac436b4b288195a817fce871" }
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "24b13d7630a12e3d08624e5db254694a09f71599" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=59f94801f9816c5fac436b4b288195a817fce871#59f94801f9816c5fac436b4b288195a817fce871" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=24b13d7630a12e3d08624e5db254694a09f71599#24b13d7630a12e3d08624e5db254694a09f71599" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.34"
+version = "3.0.35"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=59f94801f9816c5fac436b4b288195a817fce871" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=59f94801f9816c5fac436b4b288195a817fce871" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=24b13d7630a12e3d08624e5db254694a09f71599" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=24b13d7630a12e3d08624e5db254694a09f71599" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary

- Bump version `3.0.34` → `3.0.35`
- Advance DLIO pin from PR #43 head (`59f94801`) to PR #45 head (`24b13d76`), picking up:
  - **DLIO PR #44** fix for storage#690: checkpoint read double-prepends bucket for object storage
  - **DLIO PR #45** fix for storage#699: `os.makedirs(exist_ok=True)` race on multi-host checkpoint runs — exponential-backoff retry in `_makedirs_race_safe()` applied to `FileStorage`, `ObjStoreLibStorage`, and `SimpleStreamingCheckpointing`
- Regenerate `uv.lock`

## Test plan

- [ ] CI green (unit + integration tests unchanged from `origin/main`)
- [ ] `uv lock` resolves cleanly with new pin