### PR TITLE
Fix #705: vdb flush rate limit

### DIFF
--- a/vdb_benchmark/README.md
+++ b/vdb_benchmark/README.md
@@ -415,6 +415,7 @@ Estimated total: 798.72 GB
 - The `--config` argument refers to YAML files in `configs/vectordbbench/` without the `.yaml` extension.
 - The `--force` flag drops and recreates the collection if it already exists.
 - See [Dimension Consistency](#dimension-consistency) for important rules about keeping dimensions aligned between load and run.
+- If a distributed load fails with `rate limit exceeded[rate=0.1]`, see [Troubleshooting](#12-troubleshooting) — this is Milvus's per-collection flush rate limiter (issue #705), handled automatically by current benchmark versions.
 
 ---
 
@@ -1940,6 +1941,47 @@ Expected files:
 ### `vector dimension mismatch`
 
 The dimension used for load and run does not match. Use the same config for both `datagen` and `run`, or update the config to match the dimension passed to `datagen`.
+
+### `rate limit exceeded[rate=0.1]` during datagen
+
+Symptom (typically at high rank counts, e.g. `--npernode 4` across many hosts):
+
+```text
+pymilvus.exceptions.MilvusException: <MilvusException: (code=8, message=...
+failed to flush collection: ... rate limit exceeded[rate=0.1], request is
+rejected by grpc RateLimiter middleware, please retry later)>
+```
+
+Milvus 2.4+ ships a per-collection flush rate limiter enabled by default:
+
+```yaml
+quotaAndLimits:
+  flushRate:
+    collection:
+      max: 0.1   # one flush() per 10 seconds per collection
+```
+
+Older benchmark versions called `flush()` once per MPI rank on the same
+collection, so many concurrent ranks exhausted the pymilvus retry budget
+(~210 seconds) and failed with the error above, while smaller rank counts
+squeaked through. Since issue #705 was fixed, `datagen` flushes each
+collection exactly once (from rank 0, after all ranks finish inserting) and
+retries any rate-limited flush while respecting the limiter period, so no
+Milvus configuration change is needed.
+
+If you still hit this error:
+
+1. Update to a benchmark version that includes the issue #705 fix. The load
+   summary of a fixed version contains a top-level `collection_flush_seconds`
+   field.
+2. If external tooling flushes the benchmark collections concurrently, raise
+   or disable the limiter via `stacks/milvus/user.yaml.example` (MinIO stack,
+   mounted as `/milvus/configs/user.yaml`) or the commented
+   `QUOTAANDLIMITS_FLUSHRATE_COLLECTION_MAX` environment variable (S3 stack).
+
+The Milvus configuration is part of the system under test: keep the defaults
+for official submissions unless the rules state otherwise, and record any
+override in your system description.
 
 ### MPI launches only on one host
 

--- a/vdb_benchmark/stacks/milvus/standalone/minio/docker-compose.yml
+++ b/vdb_benchmark/stacks/milvus/standalone/minio/docker-compose.yml
@@ -50,6 +50,10 @@ services:
       ETCD_ENDPOINTS: ${ETCD_ENDPOINTS}
     volumes:
       - "${MILVUS_DATA_DIR}:/var/lib/milvus"
+      # Optional Milvus config overrides (see stacks/milvus/user.yaml.example,
+      # e.g. the flush rate limiter discussed in issue #705). Uncomment after
+      # copying user.yaml.example to user.yaml:
+      # - "../../user.yaml:/milvus/configs/user.yaml:ro"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${MILVUS_HTTP_PORT}/healthz"]
       interval: 30s

--- a/vdb_benchmark/stacks/milvus/standalone/s3/docker-compose.yml
+++ b/vdb_benchmark/stacks/milvus/standalone/s3/docker-compose.yml
@@ -37,6 +37,14 @@ services:
 
       # ---- Storage type ----
       COMMON_STORAGETYPE: "remote"
+
+      # ---- Optional: flush rate limiter override (issue #705) ----
+      # Milvus 2.4+ defaults quotaAndLimits.flushRate.collection.max to 0.1
+      # (one flush per 10 s per collection). The benchmark handles this
+      # limit; uncomment only if external tooling flushes the same
+      # collections concurrently. See stacks/milvus/user.yaml.example for
+      # details and the submission-comparability caveat.
+      # QUOTAANDLIMITS_FLUSHRATE_COLLECTION_MAX: "-1"
     ports:
       - "${MILVUS_GRPC_PORT}:${MILVUS_GRPC_PORT}"     # gRPC
       - "${MILVUS_HTTP_PORT}:${MILVUS_HTTP_PORT}"     # HTTP

--- a/vdb_benchmark/stacks/milvus/user.yaml.example
+++ b/vdb_benchmark/stacks/milvus/user.yaml.example
@@ -1,0 +1,35 @@
+# user.yaml.example — optional Milvus configuration overrides.
+#
+# Milvus merges this file over its built-in milvus.yaml defaults when it is
+# mounted at /milvus/configs/user.yaml inside the container. To use it:
+#
+#   cp user.yaml.example user.yaml
+#   # then uncomment the user.yaml volume line in the standalone service of
+#   # stacks/milvus/standalone/minio/docker-compose.yml or
+#   # stacks/milvus/standalone/s3/docker-compose.yml and restart the stack.
+#
+# -----------------------------------------------------------------------------
+# Flush rate limiter (issue #705)
+# -----------------------------------------------------------------------------
+# Milvus 2.4+ ships quotaAndLimits.flushRate.collection.max: 0.1 by default,
+# i.e. it admits ONE flush() per 10 seconds per collection and rejects the
+# rest with:
+#
+#   MilvusException: (code=8, message=... rate limit exceeded[rate=0.1],
+#   request is rejected by grpc RateLimiter middleware, please retry later)
+#
+# The benchmark itself no longer needs this override: since issue #705 was
+# fixed, datagen flushes each collection exactly once (from MPI rank 0) and
+# retries any rate-limited flush while respecting the limiter period. Raise
+# or disable the limiter here ONLY if external tooling outside the benchmark
+# flushes the same collections concurrently.
+#
+# COMPARABILITY NOTE: the Milvus configuration is part of the system under
+# test. Official MLPerf Storage submissions should keep Milvus defaults
+# unless the submission rules explicitly state otherwise; record any override
+# you do apply in your submission's system description.
+#
+# quotaAndLimits:
+#   flushRate:
+#     collection:
+#       max: -1   # -1 disables the per-collection flush rate limit

--- a/vdb_benchmark/tests/tests/test_issue_705_flush_rate_limit.py
+++ b/vdb_benchmark/tests/tests/test_issue_705_flush_rate_limit.py
@@ -1,0 +1,213 @@
+"""
+Regression tests for issue #705:
+
+    VectorDB datagen fails with gRPC RateLimiter errors when --npernode > 2.
+
+Root cause: every MPI rank in ``vdbbench/mpi_wrapper.py`` called
+``flush_collection`` on the same collection. Milvus 2.4+ ships
+``quotaAndLimits.flushRate.collection.max: 0.1`` (one flush per 10 s per
+collection), and pymilvus's built-in rate-limit retry budget
+(retry_times=75, back-off capped at 3 s => ~210 s) admits only ~21 flush
+tokens. With 7 hosts x --npernode 4 = 28 concurrent flushes, tail ranks
+exhaust the budget and raise MilvusException code 8; 14 ranks
+(--npernode 2) squeak through, matching the reported threshold.
+
+Fixes under test:
+
+  1. ``load_vdb.flush_collection`` retries flushes rejected by the rate
+     limiter (code 8), waits out the limiter period between attempts,
+     passes a time budget via ``timeout=``, respects its deadline, and
+     returns the flush wall time.
+  2. ``mpi_wrapper._load_phase`` no longer flushes per rank; the collection
+     is flushed exactly once by rank 0 after ``comm.gather``. Per-rank
+     payloads keep ``flush_seconds`` (now 0.0) for schema stability and the
+     load summary carries ``collection_flush_seconds``.
+
+These tests run WITHOUT a live Milvus or the pymilvus package: a minimal
+fake ``pymilvus`` is injected into ``sys.modules`` before importing the
+module under test.
+"""
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make the package importable regardless of where pytest is invoked from.
+# ---------------------------------------------------------------------------
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+# ---------------------------------------------------------------------------
+# load_vdb.py imports pymilvus at module load. CI may not have pymilvus
+# installed, so inject a fake module exposing exactly the names it imports.
+# ---------------------------------------------------------------------------
+class _FakeMilvusException(Exception):
+    def __init__(self, code=0, message=""):
+        super().__init__(message)
+        self.code = code
+        self.compatible_code = code
+        self.message = message
+
+
+def _install_fake_pymilvus():
+    if "pymilvus" in sys.modules:
+        mod = sys.modules["pymilvus"]
+        if not hasattr(mod, "MilvusException"):
+            mod.MilvusException = _FakeMilvusException
+        return
+
+    fake = types.ModuleType("pymilvus")
+    fake.connections = MagicMock()
+    fake.Collection = MagicMock()
+    fake.FieldSchema = MagicMock()
+    fake.CollectionSchema = MagicMock()
+    fake.DataType = MagicMock()
+    fake.utility = MagicMock()
+    fake.MilvusException = _FakeMilvusException
+    sys.modules["pymilvus"] = fake
+
+
+_install_fake_pymilvus()
+
+from vdbbench import load_vdb  # noqa: E402
+
+MilvusException = sys.modules["pymilvus"].MilvusException
+
+
+def _rate_limit_exc():
+    return MilvusException(
+        code=8,
+        message=(
+            "failed to flush collection: rate limit exceeded[rate=0.1], "
+            "request is rejected by grpc RateLimiter middleware, please "
+            "retry later"
+        ),
+    )
+
+
+class _FlushRecorder:
+    """Fake Collection whose flush() raises RateLimit N times, then succeeds."""
+
+    def __init__(self, rate_limit_rejections=0):
+        self.remaining_rejections = rate_limit_rejections
+        self.calls = []
+
+    def flush(self, timeout=None, **kwargs):
+        self.calls.append({"timeout": timeout, **kwargs})
+        if self.remaining_rejections > 0:
+            self.remaining_rejections -= 1
+            raise _rate_limit_exc()
+
+
+class TestIsRateLimitError:
+    def test_detects_code_8(self):
+        assert load_vdb._is_rate_limit_error(MilvusException(code=8, message="x"))
+
+    def test_detects_message_without_code(self):
+        # Real pymilvus exposes ``code`` as a read-only property, so build
+        # the non-rate-limit code state via the constructor only. code=0
+        # exercises the message-based fallback in _is_rate_limit_error.
+        exc = MilvusException(code=0, message="rate limit exceeded[rate=0.1]")
+        assert load_vdb._is_rate_limit_error(exc)
+
+    def test_rejects_other_errors(self):
+        exc = MilvusException(code=1, message="collection not found")
+        assert not load_vdb._is_rate_limit_error(exc)
+
+
+class TestFlushCollectionRateLimitRetry:
+    def test_succeeds_first_try_and_returns_duration(self):
+        coll = _FlushRecorder(rate_limit_rejections=0)
+        duration = load_vdb.flush_collection(coll, max_wait_s=60)
+        assert len(coll.calls) == 1
+        assert isinstance(duration, float) and duration >= 0.0
+
+    def test_passes_time_budget_to_pymilvus(self):
+        """timeout= switches pymilvus's retry loop from a 75-attempt budget
+        to a time budget; verify it is forwarded and positive."""
+        coll = _FlushRecorder()
+        load_vdb.flush_collection(coll, max_wait_s=120)
+        assert coll.calls[0]["timeout"] is not None
+        assert coll.calls[0]["timeout"] >= 30.0
+
+    def test_retries_after_rate_limit_rejection(self):
+        coll = _FlushRecorder(rate_limit_rejections=3)
+        with patch.object(load_vdb.time, "sleep") as mock_sleep:
+            duration = load_vdb.flush_collection(coll, max_wait_s=600)
+        assert len(coll.calls) == 4  # 3 rejections + 1 success
+        assert mock_sleep.call_count == 3
+        # Each wait must cover the limiter period (one flush per 10 s).
+        for c in mock_sleep.call_args_list:
+            assert c.args[0] >= load_vdb.MILVUS_FLUSH_LIMITER_PERIOD_S
+        assert duration >= 0.0
+
+    def test_gives_up_after_deadline(self):
+        coll = _FlushRecorder(rate_limit_rejections=10**6)
+        fake_now = [1000.0]
+
+        def fake_time():
+            return fake_now[0]
+
+        def fake_sleep(s):
+            fake_now[0] += s
+
+        with patch.object(load_vdb.time, "time", side_effect=fake_time), \
+             patch.object(load_vdb.time, "sleep", side_effect=fake_sleep):
+            with pytest.raises(MilvusException):
+                load_vdb.flush_collection(coll, max_wait_s=45)
+        # Bounded attempts: 45 s deadline / >=10 s limiter waits.
+        assert len(coll.calls) <= 6
+
+    def test_non_rate_limit_errors_propagate_immediately(self):
+        class _Boom:
+            def flush(self, timeout=None, **kwargs):
+                raise MilvusException(code=1, message="collection not found")
+
+        with patch.object(load_vdb.time, "sleep") as mock_sleep:
+            with pytest.raises(MilvusException):
+                load_vdb.flush_collection(_Boom(), max_wait_s=600)
+        mock_sleep.assert_not_called()
+
+
+class TestMpiWrapperSingleFlush:
+    """Source-level guards: the per-rank flush must not come back."""
+
+    @classmethod
+    def setup_class(cls):
+        path = os.path.join(ROOT, "vdbbench", "mpi_wrapper.py")
+        with open(path) as f:
+            cls.src = f.read()
+
+    def test_no_flush_between_insert_loop_and_gather(self):
+        """flush_collection must not be called in the per-rank insert
+        section (before comm.gather); it runs once on rank 0 afterwards."""
+        insert_section = self.src.split("comm.gather(payload, root=0)")[0]
+        # The per-rank section may reference flush_collection in imports or
+        # comments, but must not call it.
+        per_rank_calls = [
+            line
+            for line in insert_section.splitlines()
+            if "flush_collection(" in line
+            and "import" not in line
+            and not line.strip().startswith("#")
+            and "from" not in line
+        ]
+        assert per_rank_calls == [], (
+            "Per-rank flush reintroduced; this re-triggers Milvus's "
+            "per-collection flush rate limiter at scale (issue #705): "
+            f"{per_rank_calls}"
+        )
+
+    def test_single_flush_after_gather(self):
+        post_gather = self.src.split("comm.gather(payload, root=0)", 1)[1]
+        assert "flush_collection(" in post_gather
+        assert "collection_flush_seconds" in post_gather
+
+    def test_rank_payload_keeps_flush_seconds_field(self):
+        """Schema stability: rank_stats entries still carry flush_seconds."""
+        assert '"flush_seconds": 0.0' in self.src

--- a/vdb_benchmark/vdbbench/load_vdb.py
+++ b/vdb_benchmark/vdbbench/load_vdb.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 import argparse
 import logging
+import random
 import sys
 import os
 import time
 import numpy as np
-from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType, utility
+from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType, utility, MilvusException
 
 from vdbbench.connection import open_connection
 
@@ -254,12 +255,58 @@ def insert_data(collection, vectors, batch_size=10000, start_id=0):
     return total_inserted, time.time() - start_time
 
 
-def flush_collection(collection):
-    # Flush the collection
+# Milvus 2.4+ ships quotaAndLimits.flushRate.collection.max: 0.1 by default,
+# i.e. one flush() per 10 seconds per collection (issue #705). pymilvus does
+# retry on the resulting RateLimit (code 8) responses, but its default budget
+# (retry_times=75, back-off capped at 3 s => ~210 s) is exhausted when many
+# concurrent clients flush the same collection. This limiter period must be
+# respected between our own retries.
+MILVUS_FLUSH_LIMITER_PERIOD_S = 10.0
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    """True if exc is Milvus's RateLimit rejection (error code 8)."""
+    code = getattr(exc, "code", None)
+    compatible = getattr(exc, "compatible_code", None)
+    if code == 8 or compatible == 8:
+        return True
+    return "rate limit" in str(exc).lower()
+
+
+def flush_collection(collection, max_wait_s=900.0):
+    """Flush the collection, tolerating Milvus's per-collection flush
+    rate limiter (default 0.1 qps => one flush per 10 s per collection).
+
+    Passing timeout= to collection.flush() switches pymilvus's internal
+    retry loop from a fixed 75-attempt budget to a time budget; the outer
+    loop additionally waits out the limiter period between our own retries
+    so many concurrent flushers eventually all succeed (issue #705).
+
+    Returns the total flush wall time in seconds.
+    """
     flush_start = time.time()
-    collection.flush()
+    deadline = flush_start + max_wait_s
+    attempt = 0
+
+    while True:
+        attempt += 1
+        try:
+            collection.flush(timeout=max(30.0, deadline - time.time()))
+            break
+        except MilvusException as e:
+            if not _is_rate_limit_error(e) or time.time() >= deadline:
+                raise
+            sleep_s = MILVUS_FLUSH_LIMITER_PERIOD_S + random.uniform(0.0, 5.0)
+            logger.warning(
+                f"Flush attempt {attempt} rejected by Milvus flush rate "
+                f"limiter; retrying in {sleep_s:.1f} s "
+                f"(deadline in {deadline - time.time():.0f} s)"
+            )
+            time.sleep(sleep_s)
+
     flush_time = time.time() - flush_start
     logger.info(f"Flush completed in {flush_time:.2f} seconds")
+    return flush_time
 
 
 def create_index(collection, index_params):

--- a/vdb_benchmark/vdbbench/mpi_wrapper.py
+++ b/vdb_benchmark/vdbbench/mpi_wrapper.py
@@ -15,8 +15,9 @@ Coordination model:
     rank 0 creates collection/index
     bcast setup status
     Barrier
-    all ranks insert disjoint vector ID ranges
+    all ranks insert disjoint vector ID ranges (no per-rank flush; see #705)
     gather load metrics
+    rank 0 flushes the collection exactly once, then monitors index build
     rank 0 aggregates and emits summary JSON
 
   simple:
@@ -341,8 +342,7 @@ def _load_phase(args: argparse.Namespace) -> int:
 
     start_time = time.time()
     insert_start = start_time
-    flush_start = start_time
-    flush_end = start_time
+    insert_end = start_time
     inserted_total = 0
     error = None
 
@@ -391,9 +391,15 @@ def _load_phase(args: argparse.Namespace) -> int:
                     flush=True,
                 )
 
-            flush_start = time.time()
-            flush_collection(collection)
-            flush_end = time.time()
+            # NOTE(issue #705): do NOT flush here. Milvus's flush() is
+            # collection-scoped and rate limited to one call per 10 s per
+            # collection by default (quotaAndLimits.flushRate.collection.max:
+            # 0.1). With N ranks flushing the same collection concurrently,
+            # ranks at the back of the queue exhaust pymilvus's ~210 s retry
+            # budget and fail with RateLimit (code 8). A single flush on
+            # rank 0 after comm.gather(...) seals every rank's growing
+            # segments, so per-rank flushes are redundant as well as unsafe.
+            insert_end = time.time()
 
     except Exception as exc:
         error = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
@@ -420,8 +426,11 @@ def _load_phase(args: argparse.Namespace) -> int:
         "vector_id_end_exclusive": vector_id_start + rank_vector_count,
         "assigned_vectors": rank_vector_count,
         "inserted_vectors": inserted_total,
-        "insert_seconds": flush_start - insert_start,
-        "flush_seconds": flush_end - flush_start,
+        "insert_seconds": insert_end - insert_start,
+        # Kept for rank_stats schema stability. The collection is flushed
+        # exactly once, by rank 0 after the gather; see summary-level
+        # "collection_flush_seconds" (issue #705).
+        "flush_seconds": 0.0,
         "total_seconds": end_time - start_time,
         "return_code": 0 if error is None else 1,
         "error": error,
@@ -435,10 +444,23 @@ def _load_phase(args: argparse.Namespace) -> int:
 
     failed = [p for p in rank_payloads if int(p.get("return_code", 1)) != 0]
 
+    collection_flush_seconds: float | None = None
+
     if not failed:
         try:
             if connect_to_milvus(args.host, str(args.port)):
                 collection = Collection(args.collection_name)
+
+                # Single collection-wide flush (issue #705). comm.gather(...)
+                # above guarantees every rank has finished inserting, and one
+                # flush seals all growing segments regardless of which client
+                # connection inserted them. Scale the deadline with world
+                # size defensively in case other clients contend for the
+                # per-collection flush limiter token.
+                collection_flush_seconds = flush_collection(
+                    collection,
+                    max_wait_s=max(900.0, 60.0 + 15.0 * world_size),
+                )
 
                 monitor_progress(
                     args.collection_name,
@@ -475,6 +497,8 @@ def _load_phase(args: argparse.Namespace) -> int:
         rank_payloads,
         expected_ranks=expected_ranks,
     )
+
+    summary["collection_flush_seconds"] = collection_flush_seconds
 
     if failed:
         summary["mpi"]["partial_failure"] = True


### PR DESCRIPTION

Fixes #705
This PR also adds Docs follow-up to #705: document Milvus's per-collection flush rate limiter and optional stack overrides

## Problem

VectorDB `datagen` fails at high rank counts (e.g. 7 hosts × `--npernode 4` = 28 ranks) with:

    MilvusException: (code=8, message=... failed to flush collection: ...
    rate limit exceeded[rate=0.1], request is rejected by grpc RateLimiter
    middleware, please retry later)

while `--npernode 2` (14 ranks) succeeds on the same cluster.

## Root cause

Milvus 2.4+ (the stack pins `milvusdb/milvus:v2.6.7`) enables a per-collection
flush rate limiter by default:

    quotaAndLimits.flushRate.collection.max: 0.1   # one flush per 10 s per collection

`mpi_wrapper.py` called `flush_collection()` on the same collection **once per
MPI rank**. pymilvus retries RateLimit (code 8) responses, but its default
budget (`retry_times=75`, back-off capped at 3 s) is only ~210 s of wall time —
enough for ~21 flush tokens at 0.1 qps. 28 concurrent flushes cannot all be
served inside any rank's retry window, so tail ranks exhaust their retries and
raise; 14 ranks fit. This exactly matches the reported `--npernode` threshold.
The observed low storage I/O and high Milvus CPU are normal growing-segment
ingest and unrelated.

Milvus `flush()` is collection-scoped — it seals all growing segments
regardless of which client connection inserted them — so the per-rank flushes
were redundant as well as unsafe.

## Fix

1. **`vdbbench/mpi_wrapper.py`** — remove the per-rank flush. The collection is
   flushed exactly once by rank 0 in the existing post-`comm.gather` block,
   immediately before `monitor_progress`. The gather is the synchronization
   point guaranteeing all ranks finished inserting (no new barrier is
   introduced inside the insert `try`, which would deadlock if a rank raised).
   A flush failure lands in `failed_after_gather` via the existing exception
   handling, preserving `partial_failure` semantics.

2. **`vdbbench/load_vdb.py`** — `flush_collection()` is now rate-limit-aware
   as defense in depth (and hardens the filesystem-coordination path, which
   flushes from `load_vdb.main()`): it passes `timeout=` to
   `collection.flush()` (switching pymilvus's retry loop from a 75-attempt
   budget to a time budget), catches RateLimit rejections, waits out the
   limiter period (10 s + 0–5 s jitter) between attempts, and enforces a
   `max_wait_s` deadline. Non-rate-limit errors propagate immediately. It now
   returns the flush wall time.

## Summary / payload accounting

- Per-rank payloads: `insert_seconds` is now `insert_end - insert_start`
  (numerically equivalent to before); `flush_seconds` is kept at `0.0` for
  `rank_stats` schema stability.
- The load summary gains a top-level `collection_flush_seconds` (nullable —
  `null` if ranks failed before the flush).
- Grepped the full repo including `mlpstorage_py`: no other consumer reads the
  per-rank `flush_seconds` / `insert_seconds` fields, so reportgen and the
  submission checker are unaffected.

## Tests

New `tests/tests/test_issue_705_flush_rate_limit.py` (11 tests, following the
issue-numbered convention of #375/#463/#489, no live Milvus or pymilvus
required):

- rate-limit detection by error code and by message
- retry-then-succeed with limiter-period waits verified
- deadline enforcement with simulated time; bounded attempt count
- non-rate-limit errors propagate immediately (no sleep)
- `timeout=` forwarded to `collection.flush()`
- source-level guards: no `flush_collection` call between the insert loop and
  `comm.gather`; exactly one flush + `collection_flush_seconds` after it;
  `flush_seconds` retained in rank payloads

`tests/tests/test_load_vdb.py` shows the same 9 passed / 6 pre-existing
fixture errors before and after this change (verified via `git stash`).

## Multi-node validation

- [ ] 7 hosts × `--npernode 4` (28 ranks) datagen completes without RateLimit
      errors  <!-- fill in with your repro run -->
- [ ] post-flush `num_entities == num_vectors` on the loaded collection
- [ ] single-host MPI smoke test (`-n 4`, small vector count)

## Notes for reviewers

No Milvus server configuration change is required or made — the shipped stack
stays at stock defaults, which keeps the SUT config untouched for submission
comparability. A docs-only follow-up PR documents the limiter and optional
server-side overrides for users running external tooling against the same
collections.

## README updates
1. **README §12 Troubleshooting** — new entry titled with the literal error string (`rate limit exceeded[rate=0.1]` during datagen): symptom, the Milvus 2.4+ default responsible (`quotaAndLimits.flushRate.collection.max: 0.1`, one flush per 10 s per collection), why old benchmark versions failed at high `--npernode` while low counts passed, and how to proceed:
   - update to a version containing the #705 fix (identifiable by `collection_flush_seconds` in the load summary), or
   - apply a server-side override **only** if external tooling flushes the benchmark collections concurrently.

Ends with the comparability caveat: Milvus config is part of the SUT; keep defaults for official submissions and record any override in the system description.

2. **README §4.3 datagen Notes** — one cross-reference bullet pointing to the troubleshooting entry, since that's where a user whose datagen just failed will be looking.

3. **`stacks/milvus/user.yaml.example`** — fully commented Milvus override file for the MinIO stack (merged over built-in defaults when mounted at `/milvus/configs/user.yaml`), with the `quotaAndLimits.flushRate.collection.max: -1` knob left commented out and the same "the benchmark no longer needs this" framing.

4. **Compose files (commented lines only):**
   - MinIO stack: commented volume mount for `user.yaml`.
   - S3 stack: commented `QUOTAANDLIMITS_FLUSHRATE_COLLECTION_MAX: "-1"` environment variable, matching that file's env-only configuration style (same underscore-joined convention as the existing `COMMON_STORAGETYPE`).

Both compose files and the example YAML pass `yaml.safe_load`.

## Why no default override

The benchmark itself no longer needs any server-side change after #705 — datagen flushes each collection exactly once and retries rate-limited flushes. Shipping the stacks with stock Milvus quota defaults keeps submissions comparable; the overrides here are opt-in, commented out, and documented with the caveat.
