### PR TITLE
fix(#712): forward MLPS_/MLPSTORAGE_ env vars via mpirun -x

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -599,11 +599,20 @@ class DLIOBenchmark(Benchmark, abc.ABC):
                                                  mpi_btl=getattr(self.args, 'mpi_btl', 'auto'))
             # Forward env vars to ranks — OpenMPI does not propagate arbitrary
             # env vars to remote hosts by default; -x VAR opts each one in.
+            # (HPE Cray PALS mpiexec propagates env by default and takes the
+            # PALS-native branch in generate_mpi_prefix_cmd, so it doesn't
+            # need this list.)
             if 'DLIO_DROP_CACHES_TIMEOUT' in os.environ:
                 mpi_prefix += " -x DLIO_DROP_CACHES_TIMEOUT"
             # S3/object-storage vars required for multi-host runs (storage #592).
+            # MLPS_/MLPSTORAGE_ vars required for multi-host checkpointing —
+            # notably MLPSTORAGE_CHECKPOINT_URI_SCHEME (storage #712 / #583),
+            # without which remote-rank object-store writes fail with
+            # "Unsupported URI scheme" once the model-parallel shards land off
+            # the head node.
             for _v in sorted(os.environ):
                 if (_v.startswith('AWS_') or _v.startswith('S3DLIO_')
+                        or _v.startswith('MLPS_') or _v.startswith('MLPSTORAGE_')
                         or _v in ('STORAGE_LIBRARY', 'BUCKET')):
                     mpi_prefix += f" -x {_v}"
             cmd = f"{mpi_prefix} {cmd}"

--- a/tests/unit/test_mpi_s3_env_forwarding.py
+++ b/tests/unit/test_mpi_s3_env_forwarding.py
@@ -125,6 +125,46 @@ class TestS3EnvForwardingMissing:
 
 
 # ---------------------------------------------------------------------------
+# BUG #712: MLPS_/MLPSTORAGE_ vars not forwarded to remote ranks
+# ---------------------------------------------------------------------------
+
+class TestMlpsEnvForwardingMissing:
+    """MLPS_/MLPSTORAGE_-prefixed env vars must reach remote MPI ranks.
+
+    Concrete trigger (issue #712): `MLPSTORAGE_CHECKPOINT_URI_SCHEME` is set
+    by `CheckpointingBenchmark.add_checkpoint_params` (see #583) so the
+    writer/reader factories can put the object-store scheme back on the
+    URI. Without `-x` forwarding, remote ranks never see it and the
+    `S3DLIOStorageWriter` fails with "Unsupported URI scheme" on every
+    mp_rank that landed on a non-head host.
+
+    `MLPS_CHECKPOINT_MP_START_METHOD` is the same class of latent bug for
+    the streaming-checkpoint subprocess start method.
+    """
+
+    @patch(_MPI_PREFIX_PATCH, return_value=_FIXED_MPI_PREFIX)
+    def test_mlpstorage_checkpoint_uri_scheme_forwarded(self, _mock, monkeypatch):
+        """#712: MLPSTORAGE_CHECKPOINT_URI_SCHEME must reach remote ranks."""
+        monkeypatch.setenv("MLPSTORAGE_CHECKPOINT_URI_SCHEME", "s3")
+        monkeypatch.delenv("DLIO_DROP_CACHES_TIMEOUT", raising=False)
+        cmd = _make_dlio_for_cmd().generate_dlio_command()
+        assert "-x MLPSTORAGE_CHECKPOINT_URI_SCHEME" in cmd, (
+            "BUG #712: MLPSTORAGE_CHECKPOINT_URI_SCHEME not forwarded; "
+            "remote-rank object-store writes fail with 'Unsupported URI scheme'"
+        )
+
+    @patch(_MPI_PREFIX_PATCH, return_value=_FIXED_MPI_PREFIX)
+    def test_mlps_checkpoint_mp_start_method_forwarded(self, _mock, monkeypatch):
+        """#712 sibling: MLPS_CHECKPOINT_MP_START_METHOD must reach remote ranks."""
+        monkeypatch.setenv("MLPS_CHECKPOINT_MP_START_METHOD", "forkserver")
+        monkeypatch.delenv("DLIO_DROP_CACHES_TIMEOUT", raising=False)
+        cmd = _make_dlio_for_cmd().generate_dlio_command()
+        assert "-x MLPS_CHECKPOINT_MP_START_METHOD" in cmd, (
+            "BUG #712: MLPS_CHECKPOINT_MP_START_METHOD not forwarded"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Invariant: absent vars must NOT produce -x flags (no spurious forwarding)
 # ---------------------------------------------------------------------------
 
@@ -144,6 +184,20 @@ class TestAbsentVarsNotForwarded:
         monkeypatch.delenv("DLIO_DROP_CACHES_TIMEOUT", raising=False)
         cmd = _make_dlio_for_cmd().generate_dlio_command()
         assert "-x S3DLIO_CONNECT_TIMEOUT_SECS" not in cmd
+
+    @patch(_MPI_PREFIX_PATCH, return_value=_FIXED_MPI_PREFIX)
+    def test_absent_mlpstorage_var_not_forwarded(self, _mock, monkeypatch):
+        monkeypatch.delenv("MLPSTORAGE_CHECKPOINT_URI_SCHEME", raising=False)
+        monkeypatch.delenv("DLIO_DROP_CACHES_TIMEOUT", raising=False)
+        cmd = _make_dlio_for_cmd().generate_dlio_command()
+        assert "-x MLPSTORAGE_CHECKPOINT_URI_SCHEME" not in cmd
+
+    @patch(_MPI_PREFIX_PATCH, return_value=_FIXED_MPI_PREFIX)
+    def test_absent_mlps_var_not_forwarded(self, _mock, monkeypatch):
+        monkeypatch.delenv("MLPS_CHECKPOINT_MP_START_METHOD", raising=False)
+        monkeypatch.delenv("DLIO_DROP_CACHES_TIMEOUT", raising=False)
+        cmd = _make_dlio_for_cmd().generate_dlio_command()
+        assert "-x MLPS_CHECKPOINT_MP_START_METHOD" not in cmd
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #712 — object-store checkpoint writes drop the `s3://` scheme for every model-parallel shard that lands on a remote host.

## Root cause

`CheckpointingBenchmark.add_checkpoint_params` (`mlpstorage_py/benchmarks/dlio.py:963-988`) strips the URI scheme from `checkpoint.checkpoint_folder` to sidestep DLIO's `ObjStoreLibStorage._preflight` double-prepend (fix from #583) and stashes the scheme in `os.environ['MLPSTORAGE_CHECKPOINT_URI_SCHEME']`. `StorageWriterFactory` and `StorageReaderFactory` reconstruct the URI at dispatch time via `_normalize_checkpoint_uri`, which reads that env var.

OpenMPI does not propagate arbitrary env vars to remote ranks by default. `generate_dlio_command`'s existing `-x` allowlist covered `AWS_*` / `S3DLIO_*` / `STORAGE_LIBRARY` / `BUCKET` (#592) but not `MLPSTORAGE_*`. Under multi-host runs with `--map-by node` (the default in `generate_mpi_prefix_cmd` for multi-host) and llama3-70b at 64 procs (TP=8, PP=1):

- head-node ranks inherit env directly → scheme reconstruction works
- remote-node ranks never see `MLPSTORAGE_CHECKPOINT_URI_SCHEME` → `_normalize_checkpoint_uri` no-ops → `S3DLIOStorageWriter` raises `Unsupported URI scheme`

Under `--map-by node`, `mp_rank = my_rank % 8` lines up with node index, so mp_rank_0 = my_rank ∈ {0, 8, 16, …} all live on the head node and succeed, while mp_rank_1..7 all live on remote nodes and fail. Matches the reporter's observation exactly. Single-node subset runs (8 procs, one host) are unaffected because env is inherited without `-x`.

## Change

Extend the `-x` allowlist to also match `MLPS_` and `MLPSTORAGE_` prefixes. Covers the concrete #712 trigger (`MLPSTORAGE_CHECKPOINT_URI_SCHEME`) plus the latent sibling `MLPS_CHECKPOINT_MP_START_METHOD` (`streaming_checkpoint.py:88`) that would fail the same way if a user overrode it on the driver shell.

The HPE Cray PALS `mpiexec` branch (`utils.py:580-601`) propagates env by default and doesn't touch this allowlist, so no PALS-side change is needed.

## Symmetric coverage — read + write

Reads and writes both run inside the **same** DLIO invocation under one `mpirun`, so one `-x` addition covers both. `_normalize_checkpoint_uri` is symmetrically wired into `StorageReaderFactory` (fix from #641 / #649). This PR closes the multi-host read-path latent bug at the same time as the write-path reported one.

## Test plan

RED-first, following the convention from #641:

- [x] Commit 1 (`test(#712): RED`) — 2 forwarding assertions + 2 absent-case invariants in `tests/unit/test_mpi_s3_env_forwarding.py`. Verified failing against `origin/main`.
- [x] Commit 2 (`fix(#712)`) — 4-line allowlist extension in `mlpstorage_py/benchmarks/dlio.py`. Verified GREEN.
- [x] Full CI matrix locally on `fix/712`:
  - `tests` — 2740 passed, 1 skipped, 13 deselected
  - `mlpstorage_py/tests` — 828 passed
  - `vdb_benchmark/tests` — 174 passed
  - `kv_cache_benchmark/tests` — 238 passed, 2 deselected
  - **Total: 3980 passed, 0 failed**