### PR TITLE
Mark disk_io as N/A for network-attached storage targets (fixes #591)

### DIFF
--- a/vdb_benchmark/README.md
+++ b/vdb_benchmark/README.md
@@ -1691,6 +1691,48 @@ write_iops
 
 In distributed mode, disk I/O is aggregated once per benchmark client host to avoid double-counting multiple MPI ranks on the same host.
 
+#### Scope and validity of `disk_io`
+
+`/proc/diskstats` only accounts for **local block devices** on the
+benchmark client node. The `disk_io` figures are therefore only valid
+when the storage under test is backed by a local block device on that
+node (e.g. local NVMe hosting the Milvus data directory).
+
+When the storage under test is a **network / remote filesystem** (NFS,
+CIFS/SMB, CephFS, GlusterFS, Lustre, GPFS, BeeGFS, PanFS, virtiofs,
+FUSE-based remote clients, etc.), no corresponding local block device
+exists, so diskstats deltas do not describe the storage under test. In
+that case the benchmark marks `disk_io` as **not applicable**:
+
+```json
+"disk_io": {
+  "applicable": false,
+  "status": "N/A",
+  "not_applicable_reason": "storage under test is a network/remote filesystem (nfs4 mounted at /mnt/vdb from filer:/export/vdb); /proc/diskstats only accounts for local block devices, so disk_io is not applicable.",
+  "storage_target": { "fstype": "nfs4", "mountpoint": "/mnt/vdb", "...": "..." },
+  "client_local_io": { "total_bytes_read": 0, "...": "..." }
+}
+```
+
+`client_local_io` preserves the raw client-local counters for
+debugging and audit, but must **not** be interpreted as I/O to the
+storage under test.
+
+Pass `--data-path <path>` (the mount point or directory backing the
+storage under test on the client node) for exact classification. If
+`--data-path` is omitted, classification is heuristic: `disk_io` is
+still reported, `storage_target.confidence` is set to `heuristic`, and
+any detected network mounts are listed so reviewers can judge scope.
+
+`disk_io` is informational only. The benchmark score (QPS, latency,
+recall) is never derived from `disk_io`, so `applicable: false` does
+not affect scoring or submission validity.
+
+In distributed mode, hosts reporting `applicable: false` are excluded
+from the aggregated totals and listed under
+`disk_io.hosts_not_applicable`; the aggregated `disk_io.applicable`
+flag is `false` when every sampled host was N/A.
+
 ---
 
 ## 11. Testing and Validation

--- a/vdb_benchmark/test_disk_stats.py
+++ b/vdb_benchmark/test_disk_stats.py
@@ -1,0 +1,83 @@
+"""Unit tests for vdbbench.disk_stats (issue #591)."""
+import sys
+sys.path.insert(0, ".")
+from vdbbench.disk_stats import (
+    build_disk_io_stats, classify_storage_target, find_mount_for_path,
+    is_network_fs, list_network_mounts,
+)
+
+MOUNTS_NFS = [
+    {"source": "/dev/nvme0n1p2", "mountpoint": "/", "fstype": "ext4"},
+    {"source": "tmpfs", "mountpoint": "/run", "fstype": "tmpfs"},
+    {"source": "filer:/export/vdb", "mountpoint": "/mnt/vdb", "fstype": "nfs4"},
+]
+MOUNTS_LOCAL = [
+    {"source": "/dev/nvme0n1p2", "mountpoint": "/", "fstype": "ext4"},
+    {"source": "/dev/nvme1n1", "mountpoint": "/var/lib/milvus", "fstype": "xfs"},
+]
+
+def fmt(b):
+    return f"{b} B"
+
+def test_is_network_fs():
+    assert is_network_fs("nfs4")
+    assert is_network_fs("cephfs")
+    assert is_network_fs("lustre")
+    assert is_network_fs("fuse.sshfs", "user@host:/data")
+    assert not is_network_fs("ext4", "/dev/nvme0n1p2")
+    assert not is_network_fs("xfs", "/dev/sda1")
+
+def test_longest_prefix_match():
+    m = find_mount_for_path("/mnt/vdb/milvus/data", MOUNTS_NFS)
+    assert m and m["fstype"] == "nfs4"
+    m = find_mount_for_path("/home/user", MOUNTS_NFS)
+    assert m and m["mountpoint"] == "/"
+
+def test_classify_nfs_target_not_applicable():
+    r = classify_storage_target("/mnt/vdb/milvus", mounts=MOUNTS_NFS)
+    assert r["applicable"] is False
+    assert r["confidence"] == "exact"
+    assert r["target_fstype"] == "nfs4"
+    assert "network" in r["reason"]
+
+def test_classify_local_target_applicable():
+    r = classify_storage_target("/var/lib/milvus/data", mounts=MOUNTS_LOCAL)
+    assert r["applicable"] is True
+    assert r["confidence"] == "exact"
+    assert r["target_fstype"] == "xfs"
+
+def test_classify_heuristic_no_data_path():
+    r = classify_storage_target(None, mounts=MOUNTS_NFS)
+    assert r["applicable"] is True          # numbers still reported...
+    assert r["confidence"] == "heuristic"   # ...but flagged as heuristic
+    assert len(r["network_mounts"]) == 1
+
+def test_payload_na_preserves_client_local_io():
+    diff = {"nvme0n1": {"bytes_read": 4096, "bytes_written": 8192}}
+    tgt = classify_storage_target("/mnt/vdb", mounts=MOUNTS_NFS)
+    p = build_disk_io_stats(diff, 10.0, tgt, fmt)
+    assert p["applicable"] is False and p["status"] == "N/A"
+    assert "total_bytes_read" not in p            # no top-level counters
+    assert p["client_local_io"]["total_bytes_read"] == 4096
+    assert p["not_applicable_reason"]
+
+def test_payload_applicable_keeps_legacy_fields():
+    diff = {"nvme1n1": {"bytes_read": 1024, "bytes_written": 2048}}
+    tgt = classify_storage_target("/var/lib/milvus", mounts=MOUNTS_LOCAL)
+    p = build_disk_io_stats(diff, 10.0, tgt, fmt)
+    assert p["applicable"] is True and p["status"] == "OK"
+    assert p["total_bytes_read"] == 1024          # backward compatible
+    assert p["total_bytes_read_per_sec"] == 102.4
+    assert "nvme1n1" in p["devices"]
+
+def test_payload_empty_diff():
+    tgt = classify_storage_target(None, mounts=MOUNTS_LOCAL)
+    p = build_disk_io_stats({}, 10.0, tgt, fmt)
+    assert p["applicable"] is False and "error" in p
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for f in fns:
+        f(); print(f"PASS {f.__name__}")
+    print(f"\n{len(fns)} tests passed")
+

--- a/vdb_benchmark/vdbbench/disk_stats.py
+++ b/vdb_benchmark/vdbbench/disk_stats.py
@@ -1,0 +1,357 @@
+"""
+Storage-target classification for disk_io reporting (issue #591).
+
+The disk_io figures in statistics.json are derived from /proc/diskstats,
+which only accounts for local block devices on the benchmark client node.
+When the storage under test is a network / remote filesystem (e.g. NFS,
+CephFS, Lustre, GPFS, PanFS), there is no corresponding local block device
+and the diskstats deltas do not describe the storage under test.
+
+This module implements option (b) from issue #591: detect network/remote
+mounts, classify the storage target, and let the benchmarks mark disk_io
+as N/A in statistics.json instead of emitting empty or misleading values.
+
+The QPS score is unaffected: this is purely a reporting-clarity change.
+"""
+
+from typing import Any, Dict, List, Optional
+
+MOUNTS_FILE = "/proc/self/mounts"
+
+# Filesystem types that indicate the mount is network / remote-attached.
+# /proc/diskstats has no local block device for these targets.
+NETWORK_FS_TYPES = {
+    "nfs",
+    "nfs4",
+    "cifs",
+    "smb3",
+    "smbfs",
+    "ceph",
+    "cephfs",
+    "glusterfs",
+    "lustre",
+    "gpfs",
+    "beegfs",
+    "panfs",
+    "ocfs2",
+    "afs",
+    "9p",
+    "virtiofs",
+    "davfs",
+    "fuse.sshfs",
+    "fuse.glusterfs",
+    "fuse.ceph",
+    "fuse.juicefs",
+    "fuse.s3fs",
+    "fuse.gcsfuse",
+    "fuse.weka",
+    "fuse.beeond",
+}
+
+# Pseudo / virtual filesystems that are neither local block storage nor
+# the storage under test; skipped during mount scans.
+PSEUDO_FS_TYPES = {
+    "proc", "sysfs", "devtmpfs", "devpts", "tmpfs", "cgroup", "cgroup2",
+    "securityfs", "pstore", "efivarfs", "bpf", "debugfs", "tracefs",
+    "configfs", "fusectl", "mqueue", "hugetlbfs", "autofs", "binfmt_misc",
+    "rpc_pipefs", "nsfs", "ramfs", "squashfs", "overlay",
+}
+
+
+def read_mounts(mounts_file: str = MOUNTS_FILE) -> List[Dict[str, str]]:
+    """Parse the mount table into a list of {source, mountpoint, fstype}."""
+    mounts: List[Dict[str, str]] = []
+
+    try:
+        with open(mounts_file, "r", encoding="utf-8") as file_obj:
+            for line in file_obj:
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+
+                mounts.append(
+                    {
+                        # Octal escapes (e.g. \040 for space) per fstab(5).
+                        "source": parts[0],
+                        "mountpoint": parts[1]
+                        .replace("\\040", " ")
+                        .replace("\\011", "\t"),
+                        "fstype": parts[2],
+                    }
+                )
+    except OSError:
+        return []
+
+    return mounts
+
+
+def is_network_fs(fstype: str, source: str = "") -> bool:
+    """Return True if a mount's fstype/source indicates remote storage."""
+    fstype_lower = (fstype or "").lower()
+
+    if fstype_lower in NETWORK_FS_TYPES:
+        return True
+
+    # Any fuse.* client whose source looks remote (host:/export, //server,
+    # or a URI scheme) is treated as network-attached.
+    if fstype_lower.startswith("fuse"):
+        if ":" in source or source.startswith("//") or "://" in source:
+            return True
+
+    return False
+
+
+def find_mount_for_path(
+    path: str,
+    mounts: Optional[List[Dict[str, str]]] = None,
+    resolve_symlinks: Optional[bool] = None,
+) -> Optional[Dict[str, str]]:
+    """Longest-prefix match of `path` against the mount table.
+
+    Symlinks should only be resolved against the same filesystem the
+    mount table came from. By default (resolve_symlinks=None), symlinks
+    are resolved iff the live mount table is read here (mounts is None);
+    callers holding a live-derived table can pass resolve_symlinks=True,
+    while synthetic tables (e.g. unit tests) must not trigger resolution
+    — macOS symlinks /var to /private/var, which would break matching
+    against injected fixtures.
+    """
+    import os
+
+    if resolve_symlinks is None:
+        resolve_symlinks = mounts is None
+
+    if mounts is None:
+        mounts = read_mounts()
+
+    if resolve_symlinks:
+        try:
+            real_path = os.path.realpath(path)
+        except OSError:
+            real_path = os.path.normpath(path)
+    else:
+        real_path = os.path.normpath(path)
+
+    best: Optional[Dict[str, str]] = None
+    best_len = -1
+
+    for mount in mounts:
+        mnt = mount["mountpoint"]
+        if real_path == mnt or real_path.startswith(mnt.rstrip("/") + "/") or mnt == "/":
+            if len(mnt) > best_len:
+                best = mount
+                best_len = len(mnt)
+
+    return best
+
+
+def list_network_mounts(
+    mounts: Optional[List[Dict[str, str]]] = None,
+) -> List[Dict[str, str]]:
+    """Return all network/remote mounts, excluding pseudo filesystems."""
+    if mounts is None:
+        mounts = read_mounts()
+
+    return [
+        mount
+        for mount in mounts
+        if mount["fstype"] not in PSEUDO_FS_TYPES
+        and is_network_fs(mount["fstype"], mount["source"])
+    ]
+
+
+def classify_storage_target(
+    data_path: Optional[str] = None,
+    mounts: Optional[List[Dict[str, str]]] = None,
+) -> Dict[str, Any]:
+    """
+    Classify the storage under test for disk_io applicability.
+
+    Args:
+        data_path: Optional path to the storage under test as mounted on
+            this node (e.g. the Milvus data directory or the NFS mount
+            backing it). When provided, classification is authoritative
+            for that path. When omitted, classification is best-effort
+            based on whether any network mounts are present on the node.
+
+    Returns:
+        {
+          "applicable":        bool  — diskstats describe the target,
+          "confidence":        "exact" | "heuristic",
+          "target_path":       str | None,
+          "target_fstype":     str | None,
+          "target_mountpoint": str | None,
+          "target_source":     str | None,
+          "network_mounts":    [ {source, mountpoint, fstype}, ... ],
+          "reason":            str,
+        }
+    """
+    live_mounts = mounts is None
+    if live_mounts:
+        mounts = read_mounts()
+
+    network_mounts = list_network_mounts(mounts)
+
+    result: Dict[str, Any] = {
+        "applicable": True,
+        "confidence": "heuristic",
+        "target_path": data_path,
+        "target_fstype": None,
+        "target_mountpoint": None,
+        "target_source": None,
+        "network_mounts": network_mounts,
+        "reason": "",
+    }
+
+    if data_path:
+        mount = find_mount_for_path(
+            data_path, mounts, resolve_symlinks=live_mounts
+        )
+
+        if mount is None:
+            result["applicable"] = False
+            result["confidence"] = "exact"
+            result["reason"] = (
+                f"--data-path {data_path!r} does not resolve to any mount "
+                "on this node; disk_io from /proc/diskstats cannot be "
+                "attributed to the storage under test."
+            )
+            return result
+
+        result["confidence"] = "exact"
+        result["target_fstype"] = mount["fstype"]
+        result["target_mountpoint"] = mount["mountpoint"]
+        result["target_source"] = mount["source"]
+
+        if is_network_fs(mount["fstype"], mount["source"]):
+            result["applicable"] = False
+            result["reason"] = (
+                f"storage under test is a network/remote filesystem "
+                f"({mount['fstype']} mounted at {mount['mountpoint']} "
+                f"from {mount['source']}); /proc/diskstats only accounts "
+                "for local block devices, so disk_io is not applicable."
+            )
+        else:
+            result["reason"] = (
+                f"storage under test resolves to a local mount "
+                f"({mount['fstype']} at {mount['mountpoint']}); "
+                "disk_io from /proc/diskstats is applicable."
+            )
+
+        return result
+
+    # No data path supplied: best-effort heuristic.
+    if network_mounts:
+        result["reason"] = (
+            "no --data-path was supplied and network/remote mounts are "
+            "present on this node; disk_io reflects client-local block "
+            "devices only and may not describe the storage under test. "
+            "Pass --data-path to classify the target exactly."
+        )
+    else:
+        result["reason"] = (
+            "no network/remote mounts detected on this node; disk_io "
+            "reflects client-local block devices."
+        )
+
+    return result
+
+
+def build_disk_io_stats(
+    disk_io_diff: Dict[str, Dict[str, int]],
+    duration_seconds: float,
+    storage_target: Dict[str, Any],
+    format_bytes_fn,
+) -> Dict[str, Any]:
+    """
+    Assemble the statistics.json `disk_io` payload with applicability
+    marking (issue #591, options a+b).
+
+    When the storage target is a network/remote filesystem the payload is
+    marked N/A; raw client-local counters are preserved under
+    `client_local_io` so they are still auditable but cannot be mistaken
+    for storage-under-test I/O.
+    """
+    applicable = bool(storage_target.get("applicable", True))
+
+    scope_note = (
+        "Derived from /proc/diskstats on the benchmark client node; "
+        "covers local block devices only. Not meaningful for "
+        "network-attached storage targets."
+    )
+
+    target_summary = {
+        "applicable": applicable,
+        "confidence": storage_target.get("confidence"),
+        "data_path": storage_target.get("target_path"),
+        "fstype": storage_target.get("target_fstype"),
+        "mountpoint": storage_target.get("target_mountpoint"),
+        "source": storage_target.get("target_source"),
+        "network_mounts_detected": [
+            f"{m['fstype']}:{m['mountpoint']}"
+            for m in storage_target.get("network_mounts", [])
+        ],
+        "reason": storage_target.get("reason", ""),
+    }
+
+    if not disk_io_diff:
+        return {
+            "applicable": False,
+            "status": "N/A",
+            "scope": scope_note,
+            "storage_target": target_summary,
+            "error": "Disk I/O statistics not available",
+        }
+
+    total_bytes_read = sum(d["bytes_read"] for d in disk_io_diff.values())
+    total_bytes_written = sum(d["bytes_written"] for d in disk_io_diff.values())
+
+    duration = duration_seconds if duration_seconds and duration_seconds > 0 else 0
+
+    devices: Dict[str, Any] = {}
+    for device, io_stats in disk_io_diff.items():
+        bytes_read = io_stats["bytes_read"]
+        bytes_written = io_stats["bytes_written"]
+
+        if bytes_read > 0 or bytes_written > 0:
+            devices[device] = {
+                "bytes_read": bytes_read,
+                "bytes_written": bytes_written,
+                "read_formatted": format_bytes_fn(bytes_read),
+                "write_formatted": format_bytes_fn(bytes_written),
+            }
+
+    counters = {
+        "total_bytes_read": total_bytes_read,
+        "total_bytes_read_per_sec": (
+            total_bytes_read / duration if duration > 0 else 0.0
+        ),
+        "total_bytes_written": total_bytes_written,
+        "total_bytes_written_per_sec": (
+            total_bytes_written / duration if duration > 0 else 0.0
+        ),
+        "total_read_formatted": format_bytes_fn(total_bytes_read),
+        "total_write_formatted": format_bytes_fn(total_bytes_written),
+        "devices": devices,
+    }
+
+    if applicable:
+        payload: Dict[str, Any] = {
+            "applicable": True,
+            "status": "OK",
+            "scope": scope_note,
+            "storage_target": target_summary,
+        }
+        payload.update(counters)
+        return payload
+
+    return {
+        "applicable": False,
+        "status": "N/A",
+        "not_applicable_reason": storage_target.get("reason", ""),
+        "scope": scope_note,
+        "storage_target": target_summary,
+        # Preserved for debugging/audit only; NOT storage-under-test I/O.
+        "client_local_io": counters,
+    }
+

--- a/vdb_benchmark/vdbbench/enhanced_bench.py
+++ b/vdb_benchmark/vdbbench/enhanced_bench.py
@@ -50,6 +50,8 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 
+from vdbbench.disk_stats import classify_storage_target
+
 try:
     from pymilvus import (
         Collection,
@@ -2484,6 +2486,15 @@ def main() -> None:
     # Enhanced path execution
     ap.add_argument("--k", type=int, default=10, help="Top-k for enhanced path.")
     ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument(
+        "--data-path",
+        default=None,
+        help=(
+            "Path to the storage under test as mounted on this node. "
+            "Used to classify whether disk_io from /proc/diskstats is "
+            "applicable; network/remote targets are marked N/A."
+        ),
+    )
     ap.add_argument("--normalize-cosine", action="store_true")
     ap.add_argument("--mode", choices=["single", "mp", "both"], default="both")
     ap.add_argument("--processes", type=int, default=8)
@@ -2822,6 +2833,15 @@ def main() -> None:
         print("Calculating benchmark statistics...")
         stats = calculate_statistics(output_dir, recall_stats=recall_stats)
 
+        # Issue #591: mark disk_io N/A when the storage under test is a
+        # network/remote filesystem (no local block device in diskstats).
+        storage_target = classify_storage_target(
+            data_path=getattr(args, "data_path", None)
+        )
+        disk_io_applicable = bool(storage_target["applicable"])
+        if not disk_io_applicable:
+            print(f"NOTE: disk_io marked N/A — {storage_target['reason']}")
+
         if disk_io_diff:
             total_bytes_read = sum(d["bytes_read"] for d in disk_io_diff.values())
             total_bytes_written = sum(d["bytes_written"] for d in disk_io_diff.values())
@@ -2853,7 +2873,7 @@ def main() -> None:
                         "write_iops": round(dev_write_iops, 1),
                     }
 
-            stats["disk_io"] = {
+            counters = {
                 "total_bytes_read": total_bytes_read,
                 "total_bytes_written": total_bytes_written,
                 "total_read_ios": total_read_ios,
@@ -2868,8 +2888,47 @@ def main() -> None:
                 "benchmark_duration_sec": round(total_time, 2),
                 "devices": dev_stats_out,
             }
+
+            target_summary = {
+                "applicable": disk_io_applicable,
+                "confidence": storage_target.get("confidence"),
+                "data_path": storage_target.get("target_path"),
+                "fstype": storage_target.get("target_fstype"),
+                "mountpoint": storage_target.get("target_mountpoint"),
+                "network_mounts_detected": [
+                    f"{m['fstype']}:{m['mountpoint']}"
+                    for m in storage_target.get("network_mounts", [])
+                ],
+                "reason": storage_target.get("reason", ""),
+            }
+
+            if disk_io_applicable:
+                stats["disk_io"] = {
+                    "applicable": True,
+                    "status": "OK",
+                    "storage_target": target_summary,
+                    **counters,
+                }
+            else:
+                stats["disk_io"] = {
+                    "applicable": False,
+                    "status": "N/A",
+                    "not_applicable_reason": storage_target.get("reason", ""),
+                    "storage_target": target_summary,
+                    # Client-local block-device counters, preserved for
+                    # debugging only; NOT storage-under-test I/O.
+                    "client_local_io": counters,
+                }
         else:
-            stats["disk_io"] = {"error": "Disk I/O statistics not available"}
+            stats["disk_io"] = {
+                "applicable": False,
+                "status": "N/A",
+                "storage_target": {
+                    "applicable": False,
+                    "reason": storage_target.get("reason", ""),
+                },
+                "error": "Disk I/O statistics not available",
+            }
 
         with open(os.path.join(output_dir, "statistics.json"), "w", encoding="utf-8") as f:
             json.dump(stats, f, indent=2)
@@ -2908,7 +2967,11 @@ def main() -> None:
 
             print("\nDISK I/O DURING BENCHMARK")
             print("-" * 60)
-            if disk_io_diff:
+            if not disk_io_applicable:
+                fstype = storage_target.get("target_fstype") or "network/remote"
+                print(f"N/A — storage under test is on a {fstype} filesystem;")
+                print("/proc/diskstats only covers local block devices.")
+            elif disk_io_diff:
                 di = stats.get("disk_io", {})
                 print(
                     f"Total Read: {di.get('total_read_formatted', 'N/A')} "

--- a/vdb_benchmark/vdbbench/mpi_aggregate.py
+++ b/vdb_benchmark/vdbbench/mpi_aggregate.py
@@ -255,6 +255,7 @@ def aggregate_disk_io(base_dir: Path, duration_seconds: float) -> dict[str, Any]
     total_read = 0.0
     total_write = 0.0
     hosts_seen: set[str] = set()
+    hosts_not_applicable: set[str] = set()
 
     for rank_dir in _rank_dirs(base_dir):
         meta = _json_load_if_exists(rank_dir / "rank_metadata.json")
@@ -268,12 +269,21 @@ def aggregate_disk_io(base_dir: Path, duration_seconds: float) -> dict[str, Any]
 
         stats = _json_load_if_exists(rank_dir / "statistics.json")
         disk = stats.get("disk_io") or {}
+
+        # Issue #591: hosts whose storage target is a network/remote
+        # filesystem report disk_io as N/A; exclude them from the sum.
+        if disk.get("applicable") is False:
+            hosts_not_applicable.add(hostname)
+            continue
+
         read_bytes, write_bytes = _extract_disk_totals(disk)
         total_read += read_bytes
         total_write += write_bytes
 
     return {
         "aggregation": "one_sample_per_hostname_local_rank_0",
+        "applicable": len(hosts_seen) > len(hosts_not_applicable),
+        "hosts_not_applicable": sorted(hosts_not_applicable),
         "host_count": len(hosts_seen),
         "duration_seconds": duration_seconds,
         "total_bytes_read": int(total_read),
@@ -752,6 +762,7 @@ def _aggregate_disk_io_from_rank_payloads(
     total_read = 0.0
     total_write = 0.0
     hosts_seen: set[str] = set()
+    hosts_not_applicable: set[str] = set()
 
     for payload in rank_payloads:
         if int(payload.get("local_rank", 0)) != 0:
@@ -764,12 +775,20 @@ def _aggregate_disk_io_from_rank_payloads(
 
         summary = payload.get("rank_summary") or {}
         disk = summary.get("disk_io") or {}
+
+        # Issue #591: skip N/A (network-target) hosts.
+        if disk.get("applicable") is False:
+            hosts_not_applicable.add(hostname)
+            continue
+
         read_bytes, write_bytes = _extract_disk_totals(disk)
         total_read += read_bytes
         total_write += write_bytes
 
     return {
         "aggregation": "mpi_gather_one_sample_per_hostname_local_rank_0",
+        "applicable": len(hosts_seen) > len(hosts_not_applicable),
+        "hosts_not_applicable": sorted(hosts_not_applicable),
         "host_count": len(hosts_seen),
         "duration_seconds": duration_seconds,
         "total_bytes_read": int(total_read),

--- a/vdb_benchmark/vdbbench/simple_bench.py
+++ b/vdb_benchmark/vdbbench/simple_bench.py
@@ -40,6 +40,7 @@ from tabulate import tabulate
 
 from vdbbench.config_loader import load_config, merge_config_with_args
 from vdbbench.connection import open_connection
+from vdbbench.disk_stats import build_disk_io_stats, classify_storage_target
 from vdbbench.list_collections import get_collection_info
 
 try:
@@ -1564,6 +1565,17 @@ def main():
         default=42,
         help="Random seed for deterministic query-vector generation",
     )
+    parser.add_argument(
+        "--data-path",
+        type=str,
+        default=None,
+        help=(
+            "Path to the storage under test as mounted on this node "
+            "(e.g. the Milvus data directory or its NFS mount). Used to "
+            "classify whether disk_io from /proc/diskstats is applicable; "
+            "network/remote targets are marked N/A in statistics.json."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1634,6 +1646,7 @@ def main():
         "num_query_vectors": args.num_query_vectors,
         "no_create_flat": args.no_create_flat,
         "seed": args.seed,
+        "data_path": args.data_path,
     }
 
     print(f"Results will be saved to: {output_dir}")
@@ -1998,44 +2011,22 @@ def main():
             json.dump(stats, f, indent=2)
         sys.exit(1)
 
-    if disk_io_diff:
-        total_bytes_read = sum(
-            dev_stats["bytes_read"] for dev_stats in disk_io_diff.values()
-        )
-        total_bytes_written = sum(
-            dev_stats["bytes_written"] for dev_stats in disk_io_diff.values()
-        )
+    # Issue #591: classify the storage target so disk_io is marked N/A
+    # for network/remote filesystems instead of reporting empty or
+    # client-local-only numbers as if they described the storage under test.
+    storage_target = classify_storage_target(data_path=args.data_path)
 
-        duration = stats.get("total_time_seconds", 0) or 0
+    if not storage_target["applicable"]:
+        print(f"NOTE: disk_io marked N/A — {storage_target['reason']}")
+    elif storage_target["confidence"] == "heuristic" and storage_target["network_mounts"]:
+        print(f"WARNING: {storage_target['reason']}")
 
-        stats["disk_io"] = {
-            "total_bytes_read": total_bytes_read,
-            "total_bytes_read_per_sec": (
-                total_bytes_read / duration if duration > 0 else 0.0
-            ),
-            "total_bytes_written": total_bytes_written,
-            "total_bytes_written_per_sec": (
-                total_bytes_written / duration if duration > 0 else 0.0
-            ),
-            "total_read_formatted": format_bytes(total_bytes_read),
-            "total_write_formatted": format_bytes(total_bytes_written),
-            "devices": {},
-        }
-
-        for device, io_stats in disk_io_diff.items():
-            bytes_read = io_stats["bytes_read"]
-            bytes_written = io_stats["bytes_written"]
-
-            if bytes_read > 0 or bytes_written > 0:
-                stats["disk_io"]["devices"][device] = {
-                    "bytes_read": bytes_read,
-                    "bytes_written": bytes_written,
-                    "read_formatted": format_bytes(bytes_read),
-                    "write_formatted": format_bytes(bytes_written),
-                }
-
-    else:
-        stats["disk_io"] = {"error": "Disk I/O statistics not available"}
+    stats["disk_io"] = build_disk_io_stats(
+        disk_io_diff=disk_io_diff,
+        duration_seconds=stats.get("total_time_seconds", 0) or 0,
+        storage_target=storage_target,
+        format_bytes_fn=format_bytes,
+    )
 
     stats_output_file = os.path.join(output_dir, "statistics.json")
     with open(stats_output_file, "w", encoding="utf-8") as f:
@@ -2097,7 +2088,15 @@ def main():
         print("\nDISK I/O DURING BENCHMARK")
         print("-" * 50)
 
-        if disk_io_diff:
+        if not storage_target["applicable"]:
+            fstype = storage_target.get("target_fstype") or "network/remote"
+            print(f"N/A — storage under test is on a {fstype} filesystem;")
+            print("/proc/diskstats only covers local block devices.")
+            print(
+                "(Client-local counters preserved under "
+                "disk_io.client_local_io in statistics.json.)"
+            )
+        elif disk_io_diff:
             total_bytes_read = sum(
                 dev_stats["bytes_read"] for dev_stats in disk_io_diff.values()
             )


### PR DESCRIPTION
Fixes #591.

## Problem

`disk_io` in `statistics.json` is computed from `/proc/diskstats` deltas on the benchmark client node. `/proc/diskstats` only covers **local block devices**, so when the storage under test is a network/remote filesystem (NFS, CIFS/SMB, CephFS, GlusterFS, Lustre, GPFS, BeeGFS, PanFS, virtiofs, remote FUSE clients, …) the reported figures are empty or misleading, with nothing telling the reader they don't describe the storage under test.

Per the discussion in #591 (comment from @FileSystemGuy), this implements **option (b)** — detect network/remote mounts and mark `disk_io` N/A — with **option (a)** (documentation of scope/validity) folded in. Option (c) is not attempted: per-protocol client-side accounting isn't tractable across the varied and proprietary network filesystems. The QPS score is never derived from `disk_io`, so this is purely a reporting-clarity change.

## Changes

**New: `vdbbench/disk_stats.py`** — shared classification/annotation logic (used by both benches, mirroring the centralized-helper approach from #572):
- `read_mounts()` parses `/proc/self/mounts` (handles octal escapes, returns `[]` gracefully where procfs is absent).
- `find_mount_for_path()` — longest-prefix mount match. Symlinks are resolved only against the *live* mount table, never against injected fixtures, so unit tests are portable (macOS symlinks `/var` → `/private/var`).
- `classify_storage_target(data_path)` — exact classification when `--data-path` is given; best-effort heuristic (with detected network mounts listed and `confidence: "heuristic"`) when it is not.
- `build_disk_io_stats()` — assembles the annotated payload.

**`simple_bench.py` / `enhanced_bench.py`**
- New optional `--data-path` flag: path backing the storage under test as mounted on the client node (e.g. the Milvus data dir or its NFS mount).
- Network target → payload marked N/A; raw client-local counters preserved under `client_local_io`, clearly labeled as *not* storage-under-test I/O:

```json
  "disk_io": {
    "applicable": false,
    "status": "N/A",
    "not_applicable_reason": "storage under test is a network/remote filesystem (nfs4 mounted at /mnt/vdb from filer:/export/vdb); /proc/diskstats only accounts for local block devices, so disk_io is not applicable.",
    "storage_target": { "confidence": "exact", "fstype": "nfs4", "mountpoint": "/mnt/vdb", "network_mounts_detected": ["nfs4:/mnt/vdb"] },
    "client_local_io": { "total_bytes_read": "...", "devices": { } }
  }
```

- Local target → `"applicable": true, "status": "OK"` plus **all existing top-level fields unchanged** (`total_bytes_read`, `devices`, IOPS/MB/s in enhanced_bench), so downstream parsers are unaffected.
- Console summary prints `N/A — storage under test is on a nfs4 filesystem; /proc/diskstats only covers local block devices.` instead of zeros.

**`mpi_aggregate.py`**
- Both aggregation paths (`aggregate_disk_io`, `_aggregate_disk_io_from_rank_payloads`) skip `applicable: false` hosts
  instead of summing their client-local counters, list them under `hosts_not_applicable`, and set an aggregated `applicable` flag (false when every sampled host was N/A).

**`README.md`** (option a)
- New "Scope and validity of `disk_io`" subsection under Disk I/O Metrics: local-block-device-only scope, N/A schema, `--data-path` usage, distributed-mode semantics, and an explicit note that scoring and submission validity are unaffected.

## Backward compatibility

- Without `--data-path`, single-host behavior is unchanged apart from additive annotation fields (`applicable`, `status`, `scope`, `storage_target`).
- `applicable: true` payloads retain every legacy field;  `_extract_disk_totals()` continues to work for both old and new payloads (N/A payloads carry no top-level counters, so legacy aggregators sum 0 rather than bogus values).

## Testing

- [x] Unit tests (8): fstype classification, longest-prefix matching, NFS → N/A (exact), local XFS → applicable (exact), heuristic mode without `--data-path`, N/A payload shape + `client_local_io` preservation, legacy-field backward compatibility, empty-diff handling. Pass on Linux and macOS.
- [x] MPI aggregation regression: mixed applicable/N-A hosts — N/A host excluded from totals and reported in `hosts_not_applicable`.
- [x] `python3 -m py_compile` on all touched files; live `classify_storage_target()` smoke against a real mount table.
- [ ] End-to-end on Linux clients: NFS-backed Milvus run with `--data-path` → `"status": "N/A"`; local-NVMe control run → `"status": "OK"` with legacy fields; multi-node run via `mpi_wrapper` with one NFS host → correct `hosts_not_applicable.