### PR TITLE
fix(#716): auto-write .mlps-image-pool sentinel; heal fresh & pre-fix trees

### DIFF
--- a/mlpstorage_py/submission_checker/tools/code_image.py
+++ b/mlpstorage_py/submission_checker/tools/code_image.py
@@ -1057,6 +1057,18 @@ def capture_or_verify_code_image(args, env, log):
         pool_dir = _capture_new_pool_image(org_root, source_root, live_hash, log)
         log.status(f"captured new pool image at {pool_dir}")
 
+    # Issue #716: ensure the .mlps-image-pool sentinel exists whenever a pool
+    # image does. CHECK-04 D-91 hard-fails validation when pool dirs exist
+    # without the sentinel. Deferred import breaks the code_image ↔
+    # legacy_migration cycle (legacy_migration imports _scan_legacy_layout
+    # from this module).
+    from mlpstorage_py.submission_checker.tools.legacy_migration import (
+        _SENTINEL_FILENAME,
+        _write_sentinel_atomic,
+    )
+    if not (org_root / _SENTINEL_FILENAME).exists():
+        _write_sentinel_atomic(org_root, log)
+
     # 6d. Compute the run leaf via the canonical Rules.md §2.1 shape and
     # write the pointer file (PTR-01, D-65). We construct a lightweight
     # shim rather than a real Benchmark instance because

--- a/mlpstorage_py/submission_checker/tools/legacy_migration.py
+++ b/mlpstorage_py/submission_checker/tools/legacy_migration.py
@@ -335,12 +335,20 @@ def _check_and_migrate_legacy_layout(args, env, log) -> None:
     if not results_dir.exists():
         return
 
-    sentinel = results_dir / orgname / _SENTINEL_FILENAME
+    org_root = results_dir / orgname
+    sentinel = org_root / _SENTINEL_FILENAME
     if sentinel.exists():
         return
 
     offenders = _scan_legacy_layout(results_dir, orgname)
     if not offenders:
+        # Sentinel absent + no legacy code/ dirs. If pool images already exist
+        # (capture_or_verify_code_image ran first on a fresh tree), we must
+        # still write the sentinel — otherwise CHECK-04 D-91 will flag the
+        # tree as a partial migration forever. migrate_legacy_layout handles
+        # the N=0 case by just writing the sentinel atomically.
+        if org_root.is_dir() and any(org_root.glob("code-*")):
+            migrate_legacy_layout(results_dir, orgname, log)
         return
 
     migrate_legacy_layout(results_dir, orgname, log)

--- a/mlpstorage_py/tests/test_capture_or_verify_pool.py
+++ b/mlpstorage_py/tests/test_capture_or_verify_pool.py
@@ -550,3 +550,76 @@ class TestCaptureOrVerifyPool:
         )
         with pytest.raises(ConfigurationError):
             capture_or_verify_code_image(args, {}, log)
+
+
+class TestSentinelSelfHeal:
+    """Issue #716: capture_or_verify_code_image must leave a .mlps-image-pool
+    sentinel whenever it leaves a pool image. Otherwise CHECK-04 D-91 flags
+    the tree as a partial migration forever.
+    """
+
+    def test_first_run_on_fresh_tree_writes_sentinel(
+        self, tmp_path, fake_source_root, log
+    ):
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        args = _make_args(
+            mode="closed", command="run", results_dir=results_dir, orgname="Acme",
+        )
+        capture_or_verify_code_image(args, {}, log)
+
+        sentinel = results_dir / "Acme" / ".mlps-image-pool"
+        assert sentinel.is_file(), (
+            "capture on a fresh tree must write the sentinel; "
+            "otherwise CHECK-04 D-91 flags the tree as partial-migration"
+        )
+        # Sentinel content shape (D-72): two key=value lines.
+        text = sentinel.read_text()
+        assert "mlpstorage_version=" in text
+        assert "migration_completed_at=" in text
+
+    def test_match_branch_writes_sentinel_when_absent(
+        self, tmp_path, fake_source_root, log
+    ):
+        """Sentinel-heal fires on the reuse path too — covers legacy trees
+        that had pool images before the fix landed."""
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        args = _make_args(
+            mode="closed", command="run", results_dir=results_dir, orgname="Acme",
+        )
+        # First capture writes both pool and sentinel.
+        capture_or_verify_code_image(args, {}, log)
+        sentinel = results_dir / "Acme" / ".mlps-image-pool"
+        assert sentinel.is_file()
+
+        # Simulate a pre-fix tree: pool dir on disk, sentinel deleted.
+        sentinel.unlink()
+        assert not sentinel.exists()
+
+        # Second call goes through the match branch and must re-heal the sentinel.
+        capture_or_verify_code_image(args, {}, log)
+        assert sentinel.is_file(), (
+            "reuse path must also self-heal the sentinel — this covers "
+            "trees created before the #716 fix landed"
+        )
+
+    def test_existing_sentinel_is_not_rewritten(
+        self, tmp_path, fake_source_root, log
+    ):
+        """If the sentinel already exists, don't clobber it — preserves
+        migration_completed_at timestamps from prior legitimate migrations."""
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        args = _make_args(
+            mode="closed", command="run", results_dir=results_dir, orgname="Acme",
+        )
+        capture_or_verify_code_image(args, {}, log)
+        sentinel = results_dir / "Acme" / ".mlps-image-pool"
+        first_content = sentinel.read_text()
+        first_mtime = sentinel.stat().st_mtime_ns
+
+        # Second call must not rewrite the sentinel.
+        capture_or_verify_code_image(args, {}, log)
+        assert sentinel.read_text() == first_content
+        assert sentinel.stat().st_mtime_ns == first_mtime

--- a/tests/unit/test_legacy_migration.py
+++ b/tests/unit/test_legacy_migration.py
@@ -207,6 +207,65 @@ class TestPreCheckHelper:
         _check_and_migrate_legacy_layout(args, {}, _make_log())
         assert scan_spy.call_count == 0, "sentinel present: _scan_legacy_layout must NOT be called"
 
+    def test_pool_dirs_present_but_no_sentinel_triggers_migration(self, tmp_path, monkeypatch):
+        """Issue #716: sentinel-absent + pool-present + no-legacy must migrate.
+
+        Fresh-tree flow: capture_or_verify_code_image creates
+        ``<org>/code-<hash8>/`` pool dirs but never writes the sentinel. If a
+        subsequent submission-mode invocation still finds no sentinel and no
+        legacy ``code/`` dirs, the pre-check must call migrate_legacy_layout
+        so it can write the sentinel via its N=0 recovery branch — otherwise
+        CHECK-04 D-91 flags the tree as partial-migration forever.
+        """
+        results_dir = tmp_path / "results"
+        org_root = results_dir / "Acme"
+        org_root.mkdir(parents=True)
+        # Pool dir exists (capture_or_verify_code_image ran on a prior invocation).
+        (org_root / "code-deadbeef").mkdir()
+        # Sentinel does NOT exist.
+        assert not (org_root / ".mlps-image-pool").exists()
+
+        # No legacy code/ dirs.
+        monkeypatch.setattr(lm, "_scan_legacy_layout", lambda rd, org: [])
+
+        migrate_spy = MagicMock()
+        monkeypatch.setattr(lm, "migrate_legacy_layout", migrate_spy)
+
+        args = Namespace(
+            mode="closed", command="run", results_dir=str(results_dir),
+            orgname="Acme", systemname=None,
+        )
+        _check_and_migrate_legacy_layout(args, {}, _make_log())
+
+        assert migrate_spy.call_count == 1, (
+            "pool dirs present + sentinel absent + no legacy: "
+            "migrate_legacy_layout must be called so N=0 branch writes the sentinel"
+        )
+
+    def test_no_pool_dirs_and_no_legacy_does_not_migrate(self, tmp_path, monkeypatch):
+        """Fresh-tree pre-capture path stays a no-op.
+
+        Genuine fresh tree (no sentinel, no legacy, no pool dirs) must not
+        trigger migration — that path predates capture_or_verify_code_image
+        and there is nothing to seal a sentinel over.
+        """
+        results_dir = tmp_path / "results"
+        (results_dir / "Acme").mkdir(parents=True)
+
+        monkeypatch.setattr(lm, "_scan_legacy_layout", lambda rd, org: [])
+        migrate_spy = MagicMock()
+        monkeypatch.setattr(lm, "migrate_legacy_layout", migrate_spy)
+
+        args = Namespace(
+            mode="closed", command="run", results_dir=str(results_dir),
+            orgname="Acme", systemname=None,
+        )
+        _check_and_migrate_legacy_layout(args, {}, _make_log())
+
+        assert migrate_spy.call_count == 0, (
+            "fresh tree with no pool dirs: migrate_legacy_layout must NOT be called"
+        )
+
     def test_non_submission_mode_no_ops(self, tmp_path, monkeypatch):
         """_check_and_migrate_legacy_layout is a no-op for non-submission modes.
 


### PR DESCRIPTION
## Summary
Fixes #716. Two coordinated writers guarantee the `.mlps-image-pool` sentinel exists whenever `code-*` pool images do, so `CHECK-04 D-91` (`poolLegacyCheck`) stops flagging fresh trees as "partial migration."

- **First-run heal** — `capture_or_verify_code_image` (`code_image.py:1060-1069`): after `pool_dir` is established (match or capture branch), write the sentinel via `_write_sentinel_atomic` if absent. The very first submission-mode invocation now leaves a validate-clean tree.
- **Retro heal** — `_check_and_migrate_legacy_layout` (`legacy_migration.py:338-354`): when the sentinel is absent, no legacy `code/` offenders are found, but `code-*` pool dirs exist, drive `migrate_legacy_layout` so its N=0 branch writes the sentinel. Covers trees created before this fix.
- Neither writer clobbers an existing sentinel — `migration_completed_at` timestamps from legitimate migrations survive.
- Deferred import from `code_image` → `legacy_migration` avoids the circular top-level dependency (`legacy_migration` imports `_scan_legacy_layout` from `code_image`).

## Test plan
- [x] New unit tests in `tests/unit/test_legacy_migration.py`:
  - `test_pool_dirs_present_but_no_sentinel_triggers_migration` — retro-heal path.
  - `test_no_pool_dirs_and_no_legacy_does_not_migrate` — fresh-tree pre-capture stays a no-op.
- [x] New unit tests in `mlpstorage_py/tests/test_capture_or_verify_pool.py::TestSentinelSelfHeal`:
  - `test_first_run_on_fresh_tree_writes_sentinel` — first-run heal.
  - `test_match_branch_writes_sentinel_when_absent` — reuse-branch heal covers pre-fix trees.
  - `test_existing_sentinel_is_not_rewritten` — content + mtime preserved.
- [x] Full suite: `uv run pytest tests/unit mlpstorage_py/tests` → **3433 passed, 1 skipped**.