### PR TITLE
fix(#717): skip D-26/D-27 and D-20/D-24 gates for non-run commands

### DIFF
--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -1382,7 +1382,18 @@ class ReportGenerator:
                 # is a simulation, not a submission; INVALID semantics
                 # don't apply.
                 invalid_messages: List[str] = []
-                if category_str != 'whatif':
+                # Issue #717: the D-26/D-27 (training) and D-20/D-24
+                # (checkpointing) rules-strict gates encode Rules.md
+                # invariants that apply to the ``run`` command only —
+                # ``datagen`` legitimately produces a single invocation
+                # and carries no metric lists. The workload grouping
+                # key does not include ``command`` (D-05), and datagen
+                # runs typically land in their own group anyway because
+                # they carry ``accelerator=None`` while ``run`` groups
+                # carry e.g. ``h100``. Skip these gates for any group
+                # whose command is not ``run`` — otherwise a datagen
+                # group gets a spurious "found 1" INVALID.
+                if category_str != 'whatif' and runs[0].command == 'run':
                     bt = runs[0].benchmark_type
                     if bt == BENCHMARK_TYPES.training:
                         # D-27: training must be exactly 6 invocations

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -920,6 +920,101 @@ class TestInvalidRulesStrict:
         assert "expected 10 checkpoint operations per Rules.md" not in text
         assert "cannot aggregate" not in text
 
+    def test_training_datagen_group_skips_rules_strict_gates(self, tmp_path):
+        """Issue #717: training ``datagen`` group must NOT trip the D-27 count gate.
+
+        Rules.md §2.1.17's 1-warmup-plus-5-real invariant applies to the
+        ``run`` command only. ``datagen`` legitimately produces a single
+        invocation; the D-27 gate at ``_process_workload_groups`` was
+        firing on it because it filtered only by ``benchmark_type``, not
+        by command. Since the workload grouping key includes
+        ``accelerator`` (``None`` for datagen vs e.g. ``h100`` for run),
+        datagen runs land in their own group and hit the gate.
+
+        This test constructs a single training datagen ``BenchmarkRun``
+        under a ``.../training/unet3d/datagen/<ts>/`` path (matching the
+        production layout at ``rules/utils.py:285-300``) and asserts the
+        emitted result is NOT categorized ``INVALID`` with the D-27
+        template.
+        """
+        gen = _make_bare_generator(tmp_path)
+        run_root = tmp_path / "closed" / "acme" / "results" / "sys-a" / "training" / "unet3d" / "datagen"
+        ts = "20260708_114640"
+        run_dir = run_root / ts
+        run_dir.mkdir(parents=True)
+        datagen_run = _make_run(
+            benchmark_type=BENCHMARK_TYPES.training,
+            model="unet3d",
+            result_dir=str(run_dir),
+            metrics={},
+            accelerator=None,
+            run_datetime=ts,
+            command="datagen",
+        )
+
+        _run_process_workload_groups(gen, [datagen_run])
+
+        assert len(gen.workload_results) == 1
+        result = next(iter(gen.workload_results.values()))
+        text = self._row_issue_text(result)
+        # Primary contract: the D-27 template MUST NOT appear.
+        assert "expected 6 training invocations per Rules.md" not in text, (
+            f"Issue #717 regression: D-27 template fired on datagen group; got: {text!r}"
+        )
+        assert _INVALID_MSG_TRAINING_COUNT.format(n=1) not in text
+        # And the result must not be flagged INVALID by the rules-strict
+        # gates (the upstream verifier is stubbed to CLOSED in this test).
+        assert result.category != PARAM_VALIDATION.INVALID, (
+            f"Issue #717 regression: datagen group downgraded to INVALID; "
+            f"category={result.category!r}, issues={text!r}"
+        )
+
+    def test_checkpointing_non_run_group_skips_rules_strict_gates(self, tmp_path):
+        """Guard for #717-shape latent bug in the checkpointing branch.
+
+        The D-20/D-24 gate at ``_process_workload_groups`` iterates
+        ``run.metrics`` looking for list values of length != 10. Like
+        the training D-27 gate, it filters only by ``benchmark_type``,
+        not by command. Checkpointing does not currently accept
+        ``datagen`` / ``validate`` at the CLI, so this cannot fire in
+        production today — but the same-shape defense keeps the gate
+        honest if either command is added later.
+
+        Synthesizes a checkpointing ``BenchmarkRun`` with
+        ``command != 'run'`` and a metric list of length 7 (would trip
+        D-24 template c under the current gate). Asserts the
+        checkpoint-count template does NOT appear.
+        """
+        gen = _make_bare_generator(tmp_path)
+        run_root = tmp_path / "closed" / "acme" / "results" / "sys-a" / "checkpointing" / "llama3-8b"
+        ts = "20260708_120000"
+        run_dir = run_root / ts
+        run_dir.mkdir(parents=True)
+        non_run = _make_run(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            model="llama3-8b",
+            result_dir=str(run_dir),
+            # 7 entries — under the current gate this would be INVALID.
+            metrics={"checkpoint_read_throughput_GB_per_second": [1.0] * 7},
+            accelerator=None,
+            run_datetime=ts,
+            command="datagen",
+        )
+
+        _run_process_workload_groups(gen, [non_run])
+
+        assert len(gen.workload_results) == 1
+        result = next(iter(gen.workload_results.values()))
+        text = self._row_issue_text(result)
+        assert "expected 10 checkpoint operations per Rules.md" not in text, (
+            f"Latent #717-shape bug fired on non-run checkpointing group; got: {text!r}"
+        )
+        assert _INVALID_MSG_CHECKPOINT_COUNT.format(n=7) not in text
+        assert result.category != PARAM_VALIDATION.INVALID, (
+            f"Non-run checkpointing group downgraded to INVALID; "
+            f"category={result.category!r}, issues={text!r}"
+        )
+
     def test_statistics_error_not_swallowed(self, tmp_path):
         """D-23 loud-failure: helper propagates ``StatisticsError`` on empty metric list.
 


### PR DESCRIPTION
Closes #717.

## Summary
- `mlpstorage reports reportgen` was flagging `training datagen` workload groups as INVALID with `expected 6 training invocations per Rules.md §2.1.17 (1 warmup + 5 real); found 1`.
- Root cause: the rules-strict gates in `_process_workload_groups` filtered only by `benchmark_type`, not by `command`. Datagen legitimately produces a single invocation but hit the D-27 6-count check because the workload grouping key does not include `command` (D-05), and datagen runs land in their own group (accelerator=`None` vs `h100` for `run`).
- Fix: add `runs[0].command == 'run'` to the gate condition. Applied to both the training (D-26/D-27) and checkpointing (D-20/D-24) branches — the same bug shape is latent in checkpointing (its CLI doesn't currently accept datagen/validate, but the guard preempts the misfire if either is added).

## Test plan
- [x] RED: two new tests in `TestInvalidRulesStrict` fail with the exact `_INVALID_MSG_TRAINING_COUNT` / `_INVALID_MSG_CHECKPOINT_COUNT` templates before the fix.
- [x] GREEN: both pass after the guard is added.
- [x] Full CI parity locally:
  - `uv run pytest tests` — 2744 passed, 1 skipped
  - `uv run pytest mlpstorage_py/tests` — 834 passed
  - `uv run pytest vdb_benchmark/tests` — 174 passed
  - `uv run pytest kv_cache_benchmark/tests` — 238 passed

## Notes
- No changelog entry added — recent fixes (#696, #712, #716) landed on `main` without touching `BugsFixedInVersions.md`; the maintainer bundles docs updates on version bump.
- Related follow-up (not in this PR): datagen writes `results.json` / `summary.json` to `<results-dir>/.../training/<model>/datagen/<ts>/` but there is no run-checker or submission-checker validating that hierarchy exists / is well-formed. A malformed datagen contribution is currently silent. Planned as a separate small phase.