### PR TITLE
fix(#718): accept capture-prewritten pointer-only leaf in reserve_run_directory

### DIFF
--- a/mlpstorage_py/run_directory.py
+++ b/mlpstorage_py/run_directory.py
@@ -20,11 +20,50 @@ from typing import Callable
 RUN_DATETIME_FORMAT = "%Y%m%d_%H%M%S"
 DEFAULT_COLLISION_BUMP_BUDGET = 10
 
+# Hardcoded (rather than imported from submission_checker/tools/code_image) to
+# avoid pulling that module's heavy transitive imports into the reserve path.
+# The single source of truth for the filename lives at
+# submission_checker/tools/code_image.py::_POINTER_FILENAME; keep them in sync.
+_CODE_IMAGE_POINTER_FILENAME = ".mlps-code-image"
+
 
 def bump_datetime_one_second(run_datetime: str) -> str:
     """Return ``run_datetime`` advanced by one second, preserving format."""
     parsed = _datetime.datetime.strptime(run_datetime, RUN_DATETIME_FORMAT)
     return (parsed + _datetime.timedelta(seconds=1)).strftime(RUN_DATETIME_FORMAT)
+
+
+def _is_prewritten_pointer_only_leaf(candidate: str) -> bool:
+    """True when ``candidate`` exists and holds nothing but a code-image pointer.
+
+    ``capture_or_verify_code_image`` runs BEFORE ``Benchmark`` instantiation
+    (main.py invokes it prior to constructing the benchmark class) and
+    ``mkdir(parents=True, exist_ok=True)`` the run leaf so it can drop the
+    ``.mlps-code-image`` pointer inside. When ``_reserve_run_directory``
+    then races to ``os.mkdir`` the same path, the naive ``FileExistsError``
+    handler bumps the timestamp one second forward and splits the run
+    across two directories — one with only the pointer, one with all
+    outputs but no pointer. Both fail submission-checker gates (#718).
+
+    Recognising a pointer-only leaf as our own reserved slot resolves the
+    split without loosening collision protection: a leaf that also contains
+    anything else (prior run outputs, foreign files) still triggers the
+    bump, because those files are not ours to overwrite.
+    """
+    try:
+        entries = os.listdir(candidate)
+    except OSError:
+        return False
+    if not entries:
+        return False
+    tmp_prefix = f".{_CODE_IMAGE_POINTER_FILENAME}.tmp."
+    for name in entries:
+        if name == _CODE_IMAGE_POINTER_FILENAME:
+            continue
+        if name.startswith(tmp_prefix):
+            continue
+        return False
+    return True
 
 
 def reserve_run_directory(
@@ -60,6 +99,12 @@ def reserve_run_directory(
         try:
             os.mkdir(candidate)
         except FileExistsError:
+            # #718: the leaf may have been pre-created by
+            # capture_or_verify_code_image (which runs BEFORE Benchmark
+            # instantiation) purely to house the .mlps-code-image pointer.
+            # Treat that as our own reserved slot rather than bumping past it.
+            if _is_prewritten_pointer_only_leaf(candidate):
+                return candidate, run_datetime
             run_datetime = bump_datetime_one_second(run_datetime)
             continue
         return candidate, run_datetime

--- a/tests/unit/test_accumulation.py
+++ b/tests/unit/test_accumulation.py
@@ -823,7 +823,10 @@ class TestReserveRunDirectory:
         leaf = tmp_path / "20260708_120804"
         leaf.mkdir()
         (leaf / ".mlps-code-image").write_text("md5-tree-v2:" + "a" * 32)
-        (leaf / f".mlps-code-image.tmp.{os.getpid()}").write_text("partial")
+        # _write_pointer_atomic names its tmp sibling ".<pointer>.tmp.<pid>"
+        # which, since _POINTER_FILENAME already starts with a dot, becomes
+        # "..mlps-code-image.tmp.<pid>" on disk.
+        (leaf / f"..mlps-code-image.tmp.{os.getpid()}").write_text("partial")
 
         reserved, final_dt = reserve_run_directory(
             "20260708_120804", _flat_path_for(tmp_path)

--- a/tests/unit/test_accumulation.py
+++ b/tests/unit/test_accumulation.py
@@ -16,6 +16,7 @@ covers single-run discovery. This file covers the multi-run accumulation gap.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -786,3 +787,65 @@ class TestReserveRunDirectory:
             "20250111_140000", _flat_path_for(tmp_path), budget=3
         )
         assert final_dt == "20250111_140002"
+
+    def test_accepts_leaf_prewritten_with_code_image_pointer_only(self, tmp_path):
+        """Issue #718: capture_or_verify_code_image runs BEFORE Benchmark
+        instantiation and creates the run leaf with mkdir(exist_ok=True) to
+        drop a .mlps-code-image pointer. Reserve must not treat that leaf as
+        a collision — otherwise it bumps the timestamp by one second, the
+        benchmark's outputs land in leaf T+1s (with no pointer, failing
+        CHECK-01), and leaf T is left holding only the pointer (failing all
+        result-file presence checks). Accept a leaf whose only content is
+        the pre-written pointer as our own reserved slot.
+        """
+        leaf = tmp_path / "20260708_120804"
+        leaf.mkdir()
+        (leaf / ".mlps-code-image").write_text("md5-tree-v2:" + "a" * 32)
+
+        reserved, final_dt = reserve_run_directory(
+            "20260708_120804", _flat_path_for(tmp_path)
+        )
+
+        assert final_dt == "20260708_120804", (
+            "Reserve must not bump the timestamp when the pre-existing "
+            "leaf holds only the code-image pointer written by capture."
+        )
+        assert reserved == str(leaf)
+        # Pointer must survive so downstream CHECK-01 sees it.
+        assert (leaf / ".mlps-code-image").exists()
+
+    def test_accepts_leaf_prewritten_with_pointer_and_tmp_sibling(self, tmp_path):
+        """Same as above, but the pointer's atomic-write tmp sibling is
+        still present (write failed mid-flight or a rank crashed before the
+        rename). Reserve must still accept the leaf — the tmp file is our
+        own artifact, not a foreign occupant.
+        """
+        leaf = tmp_path / "20260708_120804"
+        leaf.mkdir()
+        (leaf / ".mlps-code-image").write_text("md5-tree-v2:" + "a" * 32)
+        (leaf / f".mlps-code-image.tmp.{os.getpid()}").write_text("partial")
+
+        reserved, final_dt = reserve_run_directory(
+            "20260708_120804", _flat_path_for(tmp_path)
+        )
+
+        assert final_dt == "20260708_120804"
+        assert reserved == str(leaf)
+
+    def test_still_bumps_when_prewritten_leaf_has_other_files(self, tmp_path):
+        """Regression guard for the #718 fix: if the pre-existing leaf holds
+        anything OTHER than the code-image pointer (e.g., a completed prior
+        run's summary.json), it's a genuine same-second collision and must
+        still bump forward — otherwise a rerun would overwrite results.
+        """
+        collided = tmp_path / "20250111_140000"
+        collided.mkdir()
+        (collided / ".mlps-code-image").write_text("md5-tree-v2:" + "a" * 32)
+        (collided / "summary.json").write_text("{}")
+
+        reserved, final_dt = reserve_run_directory(
+            "20250111_140000", _flat_path_for(tmp_path)
+        )
+
+        assert final_dt == "20250111_140001"
+        assert reserved == str(tmp_path / "20250111_140001")


### PR DESCRIPTION
## Summary

Fixes #718.

- `capture_or_verify_code_image` runs *before* `Benchmark` instantiation and `mkdir(parents=True, exist_ok=True)` the run leaf so it can drop the `.mlps-code-image` pointer inside. `Benchmark._reserve_run_directory` then race-lost `os.mkdir` on the same path with `FileExistsError`, bumped the timestamp one second forward, and split the run across two leaves — `T` holding only the pointer (fails required-file checks) and `T+1s` holding outputs but no pointer (fails `CHECK-01 poolPointerResolution`). A typical submission-mode training run produced ~40–50 spurious `[ERROR]` lines per `validate` invocation.
- Teach `reserve_run_directory` to recognise a leaf whose only content is the pre-written pointer (with or without its atomic-write `..mlps-code-image.tmp.<pid>` sibling) as our own reserved slot: return it without bumping. Any other content still triggers the bump, preserving genuine same-second collision protection.
- TDD: commit 1 is RED (three tests, two failing without the fix), commit 2 is GREEN (production fix + a small correction to the tmp-sibling test's filename — `_write_pointer_atomic` produces a double-dot name because `_POINTER_FILENAME` already starts with a dot).

## Test plan

- [x] `uv run pytest tests/` — 2745 passed, 1 skipped, 13 deselected
- [x] `uv run pytest mlpstorage_py/tests/` — 834 passed
- [x] `uv run pytest vdb_benchmark/tests/` — 174 passed
- [x] `uv run pytest kv_cache_benchmark/tests/` — 238 passed, 2 deselected
- [x] RED tests fail before the `run_directory.py` change; all three pass after
- [ ] Verify against a real `mlpstorage closed training run ...` invocation that the submission tree contains exactly one leaf per DLIO invocation, each carrying `.mlps-code-image` alongside `summary.json`/`dlio.log`/etc.