### PR TITLE
fix(#719, #720, #722): earliest-timestamp warmup fallback for v3.0 flow

### DIFF
--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -39,10 +39,6 @@ from mlpstorage_py.reporting import (
 _INVALID_MSG_TRAINING_COUNT = (
     "expected 6 training invocations per Rules.md §2.1.17 (1 warmup + 5 real); found {n}"
 )
-_INVALID_MSG_WARMUP_UNDETECTED = (
-    "expected exactly 1 warmup invocation to be detected; found 0 in a 6-invocation set. "
-    "Cannot compute Rules.md §2.1.17 5-run mean."
-)
 _INVALID_MSG_CHECKPOINT_COUNT = (
     "expected 10 checkpoint operations per Rules.md §2.1.23; found {n}"
 )
@@ -769,16 +765,29 @@ class ReportGenerator:
         should be aggregated into results.{csv,json}. Checkpointing has
         1 disk dir = 1 run (write-then-read self-warms), no warmup.
 
-        DLIO writes the warmup's ``summary.start`` value to match the FIRST
-        real run's start time (not the warmup's own directory timestamp), so
-        the two runs produce equal ``run_id`` values and collide in
-        ``self.run_results``. Detection here: on collision, the run whose
-        ``result_dir`` basename is lex-earlier is the warmup — its basename
-        is recorded in ``self.warmup_result_dirs`` and the later run wins
-        the dict slot (matching prior dict-overwrite semantics, which are
-        preserved so aggregate counts are unchanged). The workload printer
-        looks up ``warmup_result_dirs`` to render the warmup with a
-        ``[WARMUP, not aggregated]`` label instead of a category badge.
+        Warmup detection is two-tier:
+
+        Tier 1 (collision) — retained for backward compatibility with the
+        retired ``--loops`` orchestrator. DLIO writes the warmup's
+        ``summary.start`` value to match the FIRST real run's start time
+        (not the warmup's own directory timestamp), so the two runs produce
+        equal ``run_id`` values and collide in ``self.run_results``.
+        Detection here: on collision, the run whose ``result_dir`` basename
+        is lex-earlier is the warmup — its basename is recorded in
+        ``self.warmup_result_dirs`` and the later run wins the dict slot
+        (matching prior dict-overwrite semantics, which are preserved so
+        aggregate counts are unchanged).
+
+        Tier 2 (earliest-timestamp fallback per Rules.md §2.1.17) — applied
+        in ``_process_workload_groups`` for 6-invocation training groups
+        when Tier 1 finds nothing. The v3.0 flow prescribed by #502 uses
+        6 independent ``run`` invocations, each with its own
+        ``summary.start`` → no Tier-1 collision. Fallback picks the
+        lex-earliest ``basename(result_dir)`` in the group as the warmup.
+
+        The workload printer looks up ``warmup_result_dirs`` to render the
+        warmup with a ``[WARMUP, not aggregated]`` label instead of a
+        category badge.
 
         Args:
             benchmark_run: The benchmark run to process.
@@ -1403,16 +1412,38 @@ class ReportGenerator:
                                 _INVALID_MSG_TRAINING_COUNT.format(n=len(runs))
                             )
                         else:
-                            # D-26: warmup MUST have been detected for a
-                            # 6-invocation set. No lex-first-timestamp
-                            # fallback — loud INVALID over silent guess.
+                            # Issue #719: when the ``summary.start`` collision
+                            # path (retired ``--loops`` orchestrator) does not
+                            # fire — the v3.0 flow of 6 independent ``run``
+                            # invocations produces no collision — fall back
+                            # to the Rules.md §2.1.17 positional rule: "the
+                            # 1st of those 6 is the warm up run". Pick the
+                            # lex-earliest ``basename(result_dir)`` (dir
+                            # names are ISO-8601-ish so lex == chronological;
+                            # tiebreak on abspath is defensive, atomic
+                            # datetime allocation prevents same-second
+                            # collisions in practice). Retain the collision
+                            # path for backward compat with ``--loops``-era
+                            # trees.
                             warmup_present = any(
                                 os.path.abspath(r.result_dir or "") in self.warmup_result_dirs
                                 for r in runs
                             )
                             if not warmup_present:
-                                invalid_messages.append(
-                                    _INVALID_MSG_WARMUP_UNDETECTED
+                                earliest = min(
+                                    runs,
+                                    key=lambda r: (
+                                        os.path.basename(r.result_dir or ""),
+                                        os.path.abspath(r.result_dir or ""),
+                                    ),
+                                )
+                                earliest_abs = os.path.abspath(earliest.result_dir or "")
+                                self.warmup_result_dirs.add(earliest_abs)
+                                self.logger.debug(
+                                    f"Detected warmup run (earliest-timestamp "
+                                    f"fallback per Rules.md §2.1.17): "
+                                    f"{os.path.basename(earliest_abs)} "
+                                    "(excluded from aggregate)"
                                 )
                     elif bt == BENCHMARK_TYPES.checkpointing:
                         # D-20/D-24: each invocation's metric lists MUST

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -77,7 +77,6 @@ from mlpstorage_py.report_generator import (
     _INVALID_MSG_CHECKPOINT_COUNT,
     _INVALID_MSG_EMPTY_METRIC,
     _INVALID_MSG_TRAINING_COUNT,
-    _INVALID_MSG_WARMUP_UNDETECTED,
 )
 from mlpstorage_py.config import BENCHMARK_TYPES, PARAM_VALIDATION
 from mlpstorage_py.rules.models import BenchmarkRun, BenchmarkRunData
@@ -773,32 +772,93 @@ class TestInvalidRulesStrict:
         assert "1 warmup + 5 real" in text
         assert "found 3" in text
 
-    def test_warmup_undetected_on_6run_training_downgrades_to_invalid(self, tmp_path):
-        """D-26: 6-invocation training with empty ``warmup_result_dirs`` → INVALID.
+    def test_warmup_undetected_on_6run_training_falls_back_to_earliest(self, tmp_path):
+        """Issue #719: 6-invocation training with empty ``warmup_result_dirs``
+        falls back to the Rules.md §2.1.17 positional rule.
 
-        Uses the 6-run unet3d fixture but leaves
-        ``gen.warmup_result_dirs`` empty (as if the DLIO id-collision
-        detection failed to fire). The D-26 gate refuses to
-        aggregate and emits the second verbatim D-24 template.
+        Uses the 6-run unet3d fixture and leaves ``gen.warmup_result_dirs``
+        empty (as under the v3.0 flow of 6 independent ``run`` invocations,
+        which produce no ``summary.start`` collision). The workload-group
+        loop must pick the lex-earliest directory (``20260701_100000`` —
+        the warmup slot) as the warmup and aggregate the mean over the
+        remaining 5 real runs. The result must match what an explicit
+        collision-based warmup population produces.
         """
         gen = _make_bare_generator(tmp_path)
         runs_root = tmp_path / "closed" / "acme" / "results" / "sys-a" / "training" / "unet3d" / "run"
         runs_root.mkdir(parents=True)
         runs = _training_runs_from_unet3d_fixture(runs_root)
-        # Intentionally empty — the invariant D-26 protects.
+        # Intentionally empty — mimics the v3.0 independent-invocation flow.
         gen.warmup_result_dirs = set()
 
         _run_process_workload_groups(gen, runs)
 
         assert len(gen.workload_results) == 1
         result = next(iter(gen.workload_results.values()))
-        assert result.category == PARAM_VALIDATION.INVALID
-        text = self._row_issue_text(result)
-        # Structured pin.
-        assert _INVALID_MSG_WARMUP_UNDETECTED in text
-        # Verbatim substring pin — the exact D-24 template literal.
-        assert "expected exactly 1 warmup invocation to be detected" in text
-        assert "found 0 in a 6-invocation set" in text
+        # Fallback must PROMOTE the row from INVALID to a valid category.
+        assert result.category != PARAM_VALIDATION.INVALID, (
+            f"expected fallback to produce a valid aggregation; got {result.category!r} "
+            f"with issues={result.issues!r}"
+        )
+
+        # Earliest fixture ts is the warmup; it must now be in warmup_result_dirs.
+        expected_warmup_abs = os.path.abspath(str(runs_root / "20260701_100000"))
+        assert expected_warmup_abs in gen.warmup_result_dirs, (
+            f"earliest-timestamp fallback did not populate warmup_result_dirs; "
+            f"got {gen.warmup_result_dirs!r}"
+        )
+
+        # The aggregated mean must match the 5-run mean (warmup excluded).
+        real_run_ts = [
+            "20260701_101500",
+            "20260701_103000",
+            "20260701_104500",
+            "20260701_110000",
+            "20260701_111500",
+        ]
+        real_per_run_means = []
+        for ts in real_run_ts:
+            m = _load_summary(runs_root / ts / "summary.json")["metric"]
+            real_per_run_means.append(statistics.fmean(m["train_au_percentage"]))
+        expected_5run_mean = statistics.fmean(real_per_run_means)
+
+        actual = result.metrics.get("train_mean_of_au_percentage")
+        assert actual is not None, (
+            f"expected 'train_mean_of_au_percentage' in aggregated result; "
+            f"got keys: {list(result.metrics)}"
+        )
+        assert math.isclose(actual, expected_5run_mean, rel_tol=1e-9), (
+            f"train_mean_of_au_percentage = {actual}, "
+            f"expected 5-run mean = {expected_5run_mean} (warmup excluded)"
+        )
+
+    def test_collision_populated_warmup_is_preserved_over_fallback(self, tmp_path):
+        """Issue #719: collision path (Tier 1) is preserved.
+
+        When ``warmup_result_dirs`` is already populated by the
+        ``--loops``-era collision detection, the earliest-timestamp
+        fallback (Tier 2) must not fire — the pre-existing entry wins
+        and no additional entries are added.
+        """
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "closed" / "acme" / "results" / "sys-a" / "training" / "unet3d" / "run"
+        runs_root.mkdir(parents=True)
+        runs = _training_runs_from_unet3d_fixture(runs_root)
+        # Populate with a NON-earliest run to prove Tier 1 wins Tier 2.
+        preset_warmup = os.path.abspath(str(runs_root / "20260701_103000"))
+        gen.warmup_result_dirs = {preset_warmup}
+
+        _run_process_workload_groups(gen, runs)
+
+        result = next(iter(gen.workload_results.values()))
+        assert result.category != PARAM_VALIDATION.INVALID
+        # No fallback promotion happened — earliest is NOT in the set.
+        earliest_abs = os.path.abspath(str(runs_root / "20260701_100000"))
+        assert earliest_abs not in gen.warmup_result_dirs, (
+            "earliest-timestamp fallback fired when Tier-1 collision path had already "
+            "populated warmup_result_dirs — Tier 1 must win"
+        )
+        assert preset_warmup in gen.warmup_result_dirs
 
     def test_checkpointing_op_count_mismatch_downgrades_to_invalid(self, tmp_path):
         """D-24 template c: checkpointing metric list len != 10 → INVALID.


### PR DESCRIPTION
## Summary
Closes #719, #720, #722 (three reports of the same root cause).

reportgen detected the training warmup only via a `summary.start` collision between the warmup and the first real run — a property of the retired `--loops` orchestrator. The v3.0 flow prescribed by #502 uses 6 independent `run` invocations, each with its own `summary.start`, so no collision fires. The D-26 gate then flagged the group `INVALID` with `expected exactly 1 warmup invocation to be detected; found 0` and skipped the Rules.md §2.1.17 5-run mean — leaving every documented-flow submission with an empty aggregated AU in `results.json`.

## Fix

Two-tier warmup detection in `_process_workload_groups`:

- **Tier 1 (collision, preserved)** — retained for backward compat with `--loops`-era trees.
- **Tier 2 (positional fallback, new)** — when Tier 1 finds nothing on an exactly-6-invocation training group, pick the lex-earliest `basename(result_dir)` as the warmup. This is exactly what Rules.md §2.1.17 documents (*"the 1st of those 6 is the warm up run"*) and is #720's proposed "Option B" verbatim.

Result-dir basenames are ISO-8601-ish so lex order == chronological order. Same-second collisions are prevented by the atomic-datetime allocation in `reserve_run_directory` (bumps the seconds field on collision), but the fallback's sort tiebreaks on abspath as belt-and-suspenders.

The retired `_INVALID_MSG_WARMUP_UNDETECTED` constant is deleted; its test is rewritten to assert the new fallback behavior.

## What is *not* changed

- The `len(runs) == 6` gate remains — 12+ subdirs in a single `run/` leaf (e.g. two attempts, or #679's per-accelerator collision) still get the existing `_INVALID_MSG_TRAINING_COUNT` message. Multi-attempt directory layout is a separate concern for a future PR/issue.
- Tier 1 collision detection is untouched — legacy `--loops`-era trees keep working.

## Test plan

- [x] Rewrote `test_warmup_undetected_on_6run_training_downgrades_to_invalid` → `test_warmup_undetected_on_6run_training_falls_back_to_earliest`: asserts fallback promotes the row from INVALID to valid, populates `warmup_result_dirs` with the earliest fixture ts, and produces a `train_mean_of_au_percentage` that matches the explicit 5-run mean (excludes the ~10% warmup value).
- [x] Added `test_collision_populated_warmup_is_preserved_over_fallback`: pre-populates `warmup_result_dirs` with a NON-earliest run and asserts the fallback does *not* fire — Tier 1 wins Tier 2 when both would apply.
- [x] Full CI matrix (`tests`, `mlpstorage_py/tests`, `vdb_benchmark/tests`, `kv_cache_benchmark/tests`) → **3994 passed**, 0 failed.