### PR TITLE
feat(#731): validate training datagen hierarchy and emit self-describing manifest

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -16,7 +16,9 @@ from mlpstorage_py.errors import ConfigurationError, ErrorCode
 from mlpstorage_py.rules import calculate_training_data_size, HostInfo, HostMemoryInfo, HostCPUInfo, ClusterInformation
 from mlpstorage_py.rules.datagen_hierarchy import (
     assert_data_dir_hierarchy_absent,
+    validate_datagen_leaf,
     validate_supported_model,
+    write_datagen_manifest,
 )
 from mlpstorage_py.utils import (read_config_from_file, create_nested_dict, update_nested_dict, generate_mpi_prefix_cmd)
 from mlpstorage_py.storage_config import resolve_object_storage_config
@@ -957,7 +959,49 @@ class TrainingBenchmark(DLIOBenchmark):
         except Exception as e:
             self.logger.error(f'Error occurred while executing command: {str(e)}')
             return EXIT_CODE.FAILURE
+        # Post-datagen actions: leaf WARN + self-describing manifest
+        # write. Runs only after DLIO's datagen command returned
+        # success and only outside whatif (whatif is simulation and
+        # skips per D-29 policy).
+        if self.args.command == "datagen" and self.args.mode != "whatif":
+            try:
+                self._post_datagen_actions()
+            except ConfigurationError as e:
+                # A workload YAML that lacks the three DLIO fields is
+                # a real bug — surface loudly rather than write a
+                # silently-broken manifest.
+                self.logger.error(
+                    f'Post-datagen validation failed: {e}'
+                )
+                return EXIT_CODE.FAILURE
         return EXIT_CODE.SUCCESS
+
+    def _post_datagen_actions(self):
+        """WARN for missing leaf files, then write the datagen manifest.
+
+        Leaf-presence check runs unconditionally — any missing file
+        surfaces as a WARN but does not flip the exit code. Manifest
+        write is local-storage-only (S3 presence semantics are a
+        separate API and the future run-vs-datagen size check would
+        need a different discovery path for object storage).
+        """
+        missing = validate_datagen_leaf(self.run_result_output)
+        for item in missing:
+            self.logger.warning(
+                f'Datagen output leaf incomplete: {item}'
+            )
+
+        storage_type = self.params_dict.get("storage.storage_type", "local")
+        if storage_type != "local":
+            return
+        dataset_params = (self.combined_params or {}).get("dataset", {})
+        manifest_path = write_datagen_manifest(
+            data_dir=self.args.data_dir,
+            model=self.args.model,
+            dataset_params=dataset_params,
+            source_datagen_result_dir=self.run_result_output,
+        )
+        self.logger.info(f'Datagen manifest written: {manifest_path}')
 
 
 class CheckpointingBenchmark(DLIOBenchmark):

--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -677,18 +677,14 @@ class TrainingBenchmark(DLIOBenchmark):
             # directories are created if we abort. Whatif skips both
             # guards (matches D-29 reportgen policy and the "no
             # significant validation" direction for whatif).
+            # The refuse-to-overwrite helper detects object-storage
+            # URIs via scheme and dispatches to s3dlio internally, so
+            # no storage_type gate is needed here.
             if self.args.command == "datagen" and self.args.mode != "whatif":
                 validate_supported_model(self.args.model, self.args.mode)
-                storage_type = self.params_dict.get(
-                    "storage.storage_type", "local"
+                assert_data_dir_hierarchy_absent(
+                    self.args.data_dir, self.args.model
                 )
-                if storage_type == "local":
-                    # Object-storage (S3) presence checks are a
-                    # different API and are out of scope for the
-                    # local-filesystem refuse-to-overwrite guard.
-                    assert_data_dir_hierarchy_absent(
-                        self.args.data_dir, self.args.model
-                    )
             # The datasize command uses --data-dir and needs to generate a command that also calls --data-dir
             # The add_datadir_param would convert --data-dir to --dataset.data_folder which is invalid to
             # mlpstorage.
@@ -979,11 +975,11 @@ class TrainingBenchmark(DLIOBenchmark):
     def _post_datagen_actions(self):
         """WARN for missing leaf files, then write the datagen manifest.
 
-        Leaf-presence check runs unconditionally — any missing file
-        surfaces as a WARN but does not flip the exit code. Manifest
-        write is local-storage-only (S3 presence semantics are a
-        separate API and the future run-vs-datagen size check would
-        need a different discovery path for object storage).
+        Leaf-presence check runs unconditionally on the local
+        ``run_result_output`` — any missing file surfaces as a WARN
+        but does not flip the exit code. The manifest writer detects
+        object-storage URIs via ``--data-dir``'s scheme and dispatches
+        to s3dlio internally, so this method is backend-agnostic.
         """
         missing = validate_datagen_leaf(self.run_result_output)
         for item in missing:
@@ -991,9 +987,6 @@ class TrainingBenchmark(DLIOBenchmark):
                 f'Datagen output leaf incomplete: {item}'
             )
 
-        storage_type = self.params_dict.get("storage.storage_type", "local")
-        if storage_type != "local":
-            return
         dataset_params = (self.combined_params or {}).get("dataset", {})
         manifest_path = write_datagen_manifest(
             data_dir=self.args.data_dir,

--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -14,6 +14,10 @@ from mlpstorage_py.config import (CONFIGS_ROOT_DIR, BENCHMARK_TYPES, EXEC_TYPE, 
 from mlpstorage_py.dependency_check import validate_benchmark_dependencies
 from mlpstorage_py.errors import ConfigurationError, ErrorCode
 from mlpstorage_py.rules import calculate_training_data_size, HostInfo, HostMemoryInfo, HostCPUInfo, ClusterInformation
+from mlpstorage_py.rules.datagen_hierarchy import (
+    assert_data_dir_hierarchy_absent,
+    validate_supported_model,
+)
 from mlpstorage_py.utils import (read_config_from_file, create_nested_dict, update_nested_dict, generate_mpi_prefix_cmd)
 from mlpstorage_py.storage_config import resolve_object_storage_config
 
@@ -667,6 +671,22 @@ class TrainingBenchmark(DLIOBenchmark):
             self.verify_benchmark()
 
         if self.args.command != "datasize" and self.args.data_dir:
+            # Pre-datagen guards: fire BEFORE add_datadir_param so no
+            # directories are created if we abort. Whatif skips both
+            # guards (matches D-29 reportgen policy and the "no
+            # significant validation" direction for whatif).
+            if self.args.command == "datagen" and self.args.mode != "whatif":
+                validate_supported_model(self.args.model, self.args.mode)
+                storage_type = self.params_dict.get(
+                    "storage.storage_type", "local"
+                )
+                if storage_type == "local":
+                    # Object-storage (S3) presence checks are a
+                    # different API and are out of scope for the
+                    # local-filesystem refuse-to-overwrite guard.
+                    assert_data_dir_hierarchy_absent(
+                        self.args.data_dir, self.args.model
+                    )
             # The datasize command uses --data-dir and needs to generate a command that also calls --data-dir
             # The add_datadir_param would convert --data-dir to --dataset.data_folder which is invalid to
             # mlpstorage.

--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -22,6 +22,11 @@ from typing import List, Dict, Any, Optional, Set
 from mlpstorage_py.mlps_logging import setup_logging, apply_logging_options
 from mlpstorage_py.config import MLPS_DEBUG, BENCHMARK_TYPES, EXIT_CODE, PARAM_VALIDATION, LLM_MODELS, MODELS, ACCELERATORS
 from mlpstorage_py.rules import get_runs_files, BenchmarkVerifier, BenchmarkRun, Issue, RunID
+from mlpstorage_py.rules.datagen_hierarchy import (
+    validate_datagen_leaf,
+    validate_supported_model,
+)
+from mlpstorage_py.errors import ConfigurationError
 from mlpstorage_py.utils import flatten_nested_dict, remove_nan_values
 from mlpstorage_py.reporting import (
     ResultsDirectoryValidator,
@@ -1432,6 +1437,42 @@ class ReportGenerator:
                     # the D-22 pass-through boundary — their INVALID
                     # category (if any) is set by the upstream
                     # BenchmarkVerifier, not by Phase 6.
+
+                # ----------------------------------------------------------
+                # Datagen-side reportgen checks (training datagen only):
+                #   - Supported-model gate: reject models not in the
+                #     current mode's allowlist. INVALID.
+                #   - Leaf presence: WARN for any missing required file
+                #     under the datagen leaf. Does NOT invalidate — a
+                #     malformed datagen contribution is worth surfacing
+                #     but does not by itself void the submission.
+                # Whatif skips both, matching the D-29 policy the #717
+                # fix already established.
+                # ----------------------------------------------------------
+                if (
+                    category_str != 'whatif'
+                    and runs[0].command == 'datagen'
+                    and runs[0].benchmark_type == BENCHMARK_TYPES.training
+                ):
+                    try:
+                        validate_supported_model(
+                            runs[0].model or "", category_str or ""
+                        )
+                    except ConfigurationError as e:
+                        invalid_messages.append(str(e))
+                    for run in runs:
+                        result_dir = run.result_dir or ""
+                        missing = validate_datagen_leaf(result_dir)
+                        for item in missing:
+                            leaf_name = os.path.basename(result_dir) or "?"
+                            issues.append(
+                                Issue(
+                                    PARAM_VALIDATION.CLOSED,
+                                    f"[WARN] datagen leaf incomplete "
+                                    f"({leaf_name}): {item}",
+                                    severity="warning",
+                                )
+                            )
 
                 # ----------------------------------------------------------
                 # Aggregation dispatch — inner try/except for

--- a/mlpstorage_py/rules/datagen_hierarchy.py
+++ b/mlpstorage_py/rules/datagen_hierarchy.py
@@ -41,6 +41,9 @@ import json
 import os
 import re
 from typing import Any, Dict, List, Mapping, Optional
+from urllib.parse import urlparse
+
+import s3dlio
 
 from mlpstorage_py import __version__ as _MLPSTORAGE_VERSION
 from mlpstorage_py.config import (
@@ -122,6 +125,40 @@ def validate_supported_model(model: str, mode: str) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# URI helpers — local vs object storage dispatch                              #
+# --------------------------------------------------------------------------- #
+
+# Object-storage URI schemes that s3dlio abstracts uniformly. The
+# ``direct://`` scheme is s3dlio's zero-copy file-backed backend; from
+# our perspective it's just another URI-based backend so it lives in
+# the same branch as s3/gs/az.
+_OBJECT_STORAGE_SCHEMES = frozenset({"s3", "gs", "az", "direct"})
+
+
+def _is_object_uri(path: str) -> bool:
+    """Return True if ``path`` is an object-storage URI s3dlio understands.
+
+    An empty scheme (bare ``/local/path``) and ``file://`` are both
+    treated as local filesystem — the local branch uses ``os.path``
+    and ``open()`` directly.
+    """
+    scheme = urlparse(path).scheme
+    return scheme in _OBJECT_STORAGE_SCHEMES
+
+
+def _join_model_location(data_dir: str, model: str) -> str:
+    """Join ``data_dir`` and ``model`` into a per-model location string.
+
+    For local paths uses ``os.path.join``. For object-storage URIs
+    normalizes any trailing slash and appends ``/<model>``. The
+    caller may further append ``/<filename>`` for a manifest URI.
+    """
+    if _is_object_uri(data_dir):
+        return data_dir.rstrip("/") + "/" + model
+    return os.path.join(data_dir, model)
+
+
+# --------------------------------------------------------------------------- #
 # assert_data_dir_hierarchy_absent                                            #
 # --------------------------------------------------------------------------- #
 
@@ -136,56 +173,111 @@ def assert_data_dir_hierarchy_absent(data_dir: str, model: str) -> None:
     detect that, we refuse and force the operator to ``rm -rf`` or
     supply a different ``--data-dir``.
 
+    Dispatches on ``data_dir``'s URI scheme:
+
+    - Local filesystem (empty scheme or ``file://``): stat-based
+      check with ``os.scandir``.
+    - Object storage (``s3://``, ``gs://``, ``az://``, ``direct://``):
+      bounded LIST via ``s3dlio.list(uri, recursive=False)``. The
+      ``recursive=False`` flag yields a delimiter-based listing that
+      returns only direct children — bounded regardless of how many
+      objects sit under a prior datagen's prefix. Any s3dlio
+      exception during the LIST fails safe (aborts) per the design
+      decision: a transient object-store error must NOT be silently
+      treated as "assume empty, proceed".
+
     Accepted states (no raise):
         - ``<data-dir>/<model>`` does not exist.
-        - ``<data-dir>/<model>`` exists as an empty directory (the
-          operator pre-created the mount point).
+        - ``<data-dir>/<model>`` exists as an empty directory (local
+          case only — the operator pre-created the mount point).
 
     Rejected states (raise ``ConfigurationError``):
-        - ``<data-dir>/<model>`` exists as a non-empty directory.
-        - ``<data-dir>/<model>`` exists as a file, symlink to a file,
-          or other non-directory node.
+        - ``<data-dir>/<model>`` contains any file/object.
+        - ``<data-dir>/<model>`` exists as a non-directory node
+          (local case only).
+        - Object-storage LIST raises for any reason.
     """
-    model_dir = os.path.join(data_dir, model)
+    model_location = _join_model_location(data_dir, model)
 
-    if not os.path.lexists(model_dir):
+    if _is_object_uri(data_dir):
+        _assert_object_hierarchy_absent(model_location, model)
         return
 
-    if not os.path.isdir(model_dir):
+    if not os.path.lexists(model_location):
+        return
+
+    if not os.path.isdir(model_location):
         raise ConfigurationError(
-            f"{model_dir!r} exists and is not a directory — refusing to "
+            f"{model_location!r} exists and is not a directory — refusing to "
             f"proceed with datagen.",
             parameter="data_dir",
-            actual=model_dir,
+            actual=model_location,
             suggestion=(
-                f"Remove {model_dir!r} manually or pass a different "
+                f"Remove {model_location!r} manually or pass a different "
                 "--data-dir."
             ),
             code=ErrorCode.CONFIG_INVALID_VALUE,
         )
 
     try:
-        has_entries = any(True for _ in os.scandir(model_dir))
+        has_entries = any(True for _ in os.scandir(model_location))
     except OSError as e:
         raise ConfigurationError(
-            f"Cannot inspect {model_dir!r}: {e}.",
+            f"Cannot inspect {model_location!r}: {e}.",
             parameter="data_dir",
-            actual=model_dir,
+            actual=model_location,
             code=ErrorCode.CONFIG_INVALID_VALUE,
         ) from e
 
     if has_entries:
         raise ConfigurationError(
-            f"{model_dir!r} already exists and is not empty — refusing to "
+            f"{model_location!r} already exists and is not empty — refusing to "
             f"overwrite an existing {model!r} dataset. A re-datagen with "
             f"different parameters (e.g. num_samples_per_file) may only "
             f"partially overwrite files on filename collision, silently "
             f"corrupting the dataset.",
             parameter="data_dir",
-            actual=model_dir,
+            actual=model_location,
             suggestion=(
-                f"Remove {model_dir!r} (e.g. rm -rf) or pass a different "
+                f"Remove {model_location!r} (e.g. rm -rf) or pass a different "
                 "--data-dir."
+            ),
+            code=ErrorCode.CONFIG_INVALID_VALUE,
+        )
+
+
+def _assert_object_hierarchy_absent(model_uri: str, model: str) -> None:
+    """Object-storage half of :func:`assert_data_dir_hierarchy_absent`.
+
+    See parent docstring for semantics. Any s3dlio exception during
+    the LIST is wrapped as a ``ConfigurationError`` and the original
+    is chained via ``__cause__`` so the operator can diagnose the
+    underlying object-store failure.
+    """
+    try:
+        entries = s3dlio.list(model_uri, recursive=False)
+    except Exception as e:
+        raise ConfigurationError(
+            f"Cannot inspect {model_uri!r} for prior {model!r} datagen "
+            f"output: {e}. Refusing to proceed rather than silently "
+            f"assume the prefix is empty.",
+            parameter="data_dir",
+            actual=model_uri,
+            code=ErrorCode.CONFIG_INVALID_VALUE,
+        ) from e
+
+    if entries:
+        raise ConfigurationError(
+            f"{model_uri!r} already contains objects — refusing to "
+            f"overwrite an existing {model!r} dataset. A re-datagen with "
+            f"different parameters (e.g. num_samples_per_file) may only "
+            f"partially overwrite objects on key collision, silently "
+            f"corrupting the dataset.",
+            parameter="data_dir",
+            actual=model_uri,
+            suggestion=(
+                f"Remove the existing objects under {model_uri!r} or pass a "
+                "different --data-dir."
             ),
             code=ErrorCode.CONFIG_INVALID_VALUE,
         )
@@ -328,12 +420,33 @@ def write_datagen_manifest(
         "mlpstorage_version": _MLPSTORAGE_VERSION,
         "source_datagen_result_dir": source_datagen_result_dir,
     }
+    payload = json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
+
+    if _is_object_uri(data_dir):
+        manifest_uri = (
+            _join_model_location(data_dir, model)
+            + "/"
+            + DATAGEN_MANIFEST_FILENAME
+        )
+        try:
+            s3dlio.put_bytes(manifest_uri, payload)
+        except Exception as e:
+            # Loud failure over silent skip — a manifest that fails
+            # to land leaves the dataset without provenance and
+            # breaks the future run-vs-datagen size check.
+            raise ConfigurationError(
+                f"Failed to write datagen manifest to {manifest_uri!r}: {e}.",
+                parameter="data_dir",
+                actual=manifest_uri,
+                code=ErrorCode.CONFIG_INVALID_VALUE,
+            ) from e
+        return manifest_uri
 
     model_dir = os.path.join(data_dir, model)
     os.makedirs(model_dir, exist_ok=True)
     manifest_path = os.path.abspath(
         os.path.join(model_dir, DATAGEN_MANIFEST_FILENAME)
     )
-    with open(manifest_path, "w") as f:
-        json.dump(manifest, f, indent=2, sort_keys=True)
+    with open(manifest_path, "wb") as f:
+        f.write(payload)
     return manifest_path

--- a/mlpstorage_py/rules/datagen_hierarchy.py
+++ b/mlpstorage_py/rules/datagen_hierarchy.py
@@ -1,0 +1,339 @@
+"""Training datagen hierarchy validation and self-describing manifest.
+
+This module packages the four helpers used by:
+
+- the training benchmark's datagen path in ``mlpstorage_py/benchmarks/``
+  (pre-run guard + post-run manifest write + leaf WARN)
+- the report_generator's datagen group handling in
+  ``mlpstorage_py/report_generator.py``
+  (supported-model INVALID gate + leaf WARN)
+
+Design notes
+------------
+
+The DLIO datagen leaf under ``<results-dir>/.../training/<model>/datagen/<ts>/``
+carries the files listed in
+``mlpstorage_py/submission_checker/constants.py``
+(DATAGEN_REQUIRED_FILES / DATAGEN_REQUIRED_FOLDERS). We reuse those constants
+so the same file-set contract is enforced from three call sites (submission
+checker, run-checker, reportgen) without drift.
+
+The manifest at ``<data-dir>/<model>/.mlps-datagen-manifest.json`` is the
+self-describing record a future ``training run`` command will read to compare
+its requested workload size against the dataset the operator generated. The
+schema is intentionally minimal — only the three DLIO knobs that determine
+whether a run's request fits the dataset, plus provenance fields for audit.
+
+Whatif exemption
+----------------
+
+Per the D-29 policy already in place in the report_generator, ``whatif`` is
+a simulation modality that skips submission-strict validation. The
+``validate_supported_model`` helper preserves that policy so unsupported
+research models pass through when the operator is exploring configurations
+before committing to a closed/open submission.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import re
+from typing import Any, Dict, List, Mapping, Optional
+
+from mlpstorage_py import __version__ as _MLPSTORAGE_VERSION
+from mlpstorage_py.config import (
+    MODELS,
+    MODELS_CLOSED,
+    MODELS_OPEN,
+)
+from mlpstorage_py.errors import ConfigurationError, ErrorCode
+from mlpstorage_py.submission_checker.constants import (
+    DATAGEN_REQUIRED_FILES,
+    DATAGEN_REQUIRED_FOLDERS,
+)
+
+
+DATAGEN_MANIFEST_FILENAME = ".mlps-datagen-manifest.json"
+DATAGEN_MANIFEST_SCHEMA_VERSION = 1
+
+# Files required inside dlio_config/ per submission_checker rule §2.1.15
+# (see checks/directory_checks.py:129-130). Kept local because §2.1.15
+# defines them inline in the check rather than exporting a constant.
+_DLIO_CONFIG_REQUIRED_FILES = ("config.yaml", "hydra.yaml", "overrides.yaml")
+
+_MODEL_ALLOWLIST: Dict[str, List[str]] = {
+    "closed": MODELS_CLOSED,
+    "open": MODELS_OPEN,
+    # Whatif carries no submission-strict model check; the reportgen
+    # D-29 policy already skips whatif for INVALID gates, and this
+    # helper mirrors that so a whatif operator can iterate on any
+    # known model without fighting the validator.
+    "whatif": MODELS,
+}
+
+
+# --------------------------------------------------------------------------- #
+# validate_supported_model                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def validate_supported_model(model: str, mode: str) -> None:
+    """Raise ``ConfigurationError`` if ``model`` is not in the allowlist for ``mode``.
+
+    Args:
+        model: The training model name (e.g. ``"unet3d"``).
+        mode: One of ``"closed"``, ``"open"``, ``"whatif"``.
+
+    The CLI already restricts model choices per mode at parse time
+    (see ``mlpstorage_py/cli/training_args.py``); this helper is the
+    runtime defense that catches call sites which construct
+    benchmark runs from persisted state (e.g. reportgen scanning a
+    submission tree from a prior version).
+    """
+    if mode == "whatif":
+        return
+
+    allowed = _MODEL_ALLOWLIST.get(mode)
+    if allowed is None:
+        raise ConfigurationError(
+            f"Unsupported submission mode {mode!r} — expected one of "
+            f"{sorted(_MODEL_ALLOWLIST)}.",
+            parameter="mode",
+            expected=sorted(_MODEL_ALLOWLIST),
+            actual=mode,
+            code=ErrorCode.CONFIG_INVALID_VALUE,
+        )
+
+    if model not in allowed:
+        raise ConfigurationError(
+            f"Model {model!r} is not permitted for {mode!r} submissions "
+            f"per Rules.md v3.0 — allowed models: {sorted(allowed)}.",
+            parameter="model",
+            expected=sorted(allowed),
+            actual=model,
+            suggestion=(
+                f"Use one of {sorted(allowed)} for {mode!r}, or run in "
+                "whatif mode for exploratory work with other models."
+            ),
+            code=ErrorCode.CONFIG_INVALID_VALUE,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# assert_data_dir_hierarchy_absent                                            #
+# --------------------------------------------------------------------------- #
+
+
+def assert_data_dir_hierarchy_absent(data_dir: str, model: str) -> None:
+    """Refuse to overwrite an existing ``<data-dir>/<model>`` tree.
+
+    Rationale: a re-datagen with different ``num_samples_per_file``
+    (or any other per-file byte-size knob) would leave the old and
+    new files interleaved on filename collision, silently corrupting
+    the dataset for a subsequent run. Rather than teach DLIO to
+    detect that, we refuse and force the operator to ``rm -rf`` or
+    supply a different ``--data-dir``.
+
+    Accepted states (no raise):
+        - ``<data-dir>/<model>`` does not exist.
+        - ``<data-dir>/<model>`` exists as an empty directory (the
+          operator pre-created the mount point).
+
+    Rejected states (raise ``ConfigurationError``):
+        - ``<data-dir>/<model>`` exists as a non-empty directory.
+        - ``<data-dir>/<model>`` exists as a file, symlink to a file,
+          or other non-directory node.
+    """
+    model_dir = os.path.join(data_dir, model)
+
+    if not os.path.lexists(model_dir):
+        return
+
+    if not os.path.isdir(model_dir):
+        raise ConfigurationError(
+            f"{model_dir!r} exists and is not a directory — refusing to "
+            f"proceed with datagen.",
+            parameter="data_dir",
+            actual=model_dir,
+            suggestion=(
+                f"Remove {model_dir!r} manually or pass a different "
+                "--data-dir."
+            ),
+            code=ErrorCode.CONFIG_INVALID_VALUE,
+        )
+
+    try:
+        has_entries = any(True for _ in os.scandir(model_dir))
+    except OSError as e:
+        raise ConfigurationError(
+            f"Cannot inspect {model_dir!r}: {e}.",
+            parameter="data_dir",
+            actual=model_dir,
+            code=ErrorCode.CONFIG_INVALID_VALUE,
+        ) from e
+
+    if has_entries:
+        raise ConfigurationError(
+            f"{model_dir!r} already exists and is not empty — refusing to "
+            f"overwrite an existing {model!r} dataset. A re-datagen with "
+            f"different parameters (e.g. num_samples_per_file) may only "
+            f"partially overwrite files on filename collision, silently "
+            f"corrupting the dataset.",
+            parameter="data_dir",
+            actual=model_dir,
+            suggestion=(
+                f"Remove {model_dir!r} (e.g. rm -rf) or pass a different "
+                "--data-dir."
+            ),
+            code=ErrorCode.CONFIG_INVALID_VALUE,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# validate_datagen_leaf                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _select_regex_set(mapping: Dict[str, List[str]]) -> List[str]:
+    """Prefer v3.0 patterns; fall back to ``default`` if absent."""
+    return mapping.get("v3.0") or mapping.get("default") or []
+
+
+def validate_datagen_leaf(leaf_path: str) -> List[str]:
+    """Return a list of missing-item descriptions for a datagen leaf.
+
+    The check is stat-only: presence of the four datagen-required
+    files (regex-matched against the DATAGEN_REQUIRED_FILES set) and
+    the dlio_config/ folder with its three inner YAMLs. Contents are
+    not inspected — the caller is expected to fail fast on
+    presence, then let downstream tooling (submission_checker, DLIO)
+    speak to content correctness.
+
+    Returns:
+        A list of human-readable missing-item strings. Empty list
+        means the leaf is complete. Never raises.
+    """
+    if not os.path.isdir(leaf_path):
+        return [f"datagen leaf directory not found: {leaf_path}"]
+
+    missing: List[str] = []
+    entries = os.listdir(leaf_path)
+
+    for pattern in _select_regex_set(DATAGEN_REQUIRED_FILES):
+        if not any(re.search(pattern, name) for name in entries):
+            missing.append(_pretty_file_pattern(pattern))
+
+    for folder in _select_regex_set(DATAGEN_REQUIRED_FOLDERS):
+        folder_path = os.path.join(leaf_path, folder)
+        if not os.path.isdir(folder_path):
+            missing.append(f"required folder missing: {folder}/")
+            # No point drilling into the folder's expected inner files
+            # if the folder itself is absent — one message is clearer.
+            continue
+        inner_entries = set(os.listdir(folder_path))
+        for inner_name in _DLIO_CONFIG_REQUIRED_FILES:
+            if inner_name not in inner_entries:
+                missing.append(f"{folder}/{inner_name}")
+
+    return missing
+
+
+def _pretty_file_pattern(pattern: str) -> str:
+    """Convert a DATAGEN_REQUIRED_FILES regex to a human-readable name.
+
+    The submission_checker patterns are anchored regexes like
+    ``r"training_datagen\\.stdout\\.log$"``. Strip the trailing ``$``
+    and un-escape dots so the missing-item message reads like a
+    filename rather than a regex.
+    """
+    name = pattern.rstrip("$")
+    name = name.replace(r"\.", ".")
+    # Metadata pattern uses ``.*`` for the timestamp segment — leave
+    # it in place; the operator will recognize the shape.
+    return name
+
+
+# --------------------------------------------------------------------------- #
+# write_datagen_manifest                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def write_datagen_manifest(
+    data_dir: str,
+    model: str,
+    dataset_params: Mapping[str, Any],
+    source_datagen_result_dir: str,
+    now: Optional[datetime.datetime] = None,
+) -> str:
+    """Write the self-describing manifest for a completed datagen run.
+
+    Emits ``<data-dir>/<model>/.mlps-datagen-manifest.json`` with the
+    schema documented in this module's docstring. A future
+    ``training run`` command will read this file to compare its
+    requested workload size against what the dataset actually
+    supports.
+
+    Args:
+        data_dir: The ``--data-dir`` path the operator passed to
+            datagen. The manifest lands at ``data_dir/model/FILENAME``.
+        model: The training model name (drives the per-model subdir).
+        dataset_params: A dict with (at minimum) the three keys
+            ``num_files_train``, ``num_samples_per_file``, and
+            ``record_length_bytes``. Extra keys are ignored — the
+            manifest schema is intentionally tight.
+        source_datagen_result_dir: Absolute path to the datagen leaf
+            under ``--results-dir``. Written as-is for provenance.
+        now: Injectable clock for tests. Defaults to
+            ``datetime.datetime.now(timezone.utc)``.
+
+    Returns:
+        Absolute path to the written manifest file.
+
+    Raises:
+        ConfigurationError: If any of the three required
+        ``dataset_params`` keys is absent. Loud rather than defaulted
+        to zero — a missing field means the caller passed a broken
+        merged config, and silently writing ``0`` would corrupt the
+        future run-vs-datagen comparison.
+    """
+    required = ("num_files_train", "num_samples_per_file", "record_length_bytes")
+    missing = [k for k in required if k not in dataset_params]
+    if missing:
+        raise ConfigurationError(
+            f"Datagen manifest cannot be written — dataset_params is "
+            f"missing required key(s): {missing}. All three of "
+            f"{list(required)} must be present in the merged DLIO "
+            f"config.",
+            parameter="dataset_params",
+            expected=list(required),
+            actual=sorted(dataset_params.keys()),
+            code=ErrorCode.CONFIG_MISSING_REQUIRED,
+        )
+
+    if now is None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+    # ISO 8601 UTC with Z suffix — the tests pin the Z suffix and this
+    # format is unambiguous across parsers.
+    created_at = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    manifest = {
+        "schema_version": DATAGEN_MANIFEST_SCHEMA_VERSION,
+        "model": model,
+        "num_files_train": dataset_params["num_files_train"],
+        "num_samples_per_file": dataset_params["num_samples_per_file"],
+        "record_length_bytes": dataset_params["record_length_bytes"],
+        "created_at": created_at,
+        "mlpstorage_version": _MLPSTORAGE_VERSION,
+        "source_datagen_result_dir": source_datagen_result_dir,
+    }
+
+    model_dir = os.path.join(data_dir, model)
+    os.makedirs(model_dir, exist_ok=True)
+    manifest_path = os.path.abspath(
+        os.path.join(model_dir, DATAGEN_MANIFEST_FILENAME)
+    )
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+    return manifest_path

--- a/tests/integration/test_datagen_hierarchy_wiring.py
+++ b/tests/integration/test_datagen_hierarchy_wiring.py
@@ -143,8 +143,9 @@ class TestRefuseToOverwriteWiring:
 
         args = _training_datagen_args(tmp_path)
         args.command = "run"
-        # verify_benchmark runs for `run` — it will likely raise, but
-        # the refuse-guard invocation is what we assert on.
+        # verify_benchmark runs for `run` and may raise (or call
+        # sys.exit) — either is fine; the refuse-guard invocation is
+        # what we assert on.
         from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
 
         with patch(
@@ -152,7 +153,7 @@ class TestRefuseToOverwriteWiring:
         ) as mock_guard:
             try:
                 TrainingBenchmark(args, logger=MagicMock())
-            except Exception:
+            except (Exception, SystemExit):
                 pass
             mock_guard.assert_not_called()
 
@@ -191,7 +192,7 @@ class TestSupportedModelWiring:
         ) as mock_validate:
             try:
                 TrainingBenchmark(args, logger=MagicMock())
-            except Exception:
+            except (Exception, SystemExit):
                 pass
             # Guard is not invoked in whatif — helper handles it, but
             # the caller short-circuits earlier for symmetry with the

--- a/tests/integration/test_datagen_hierarchy_wiring.py
+++ b/tests/integration/test_datagen_hierarchy_wiring.py
@@ -388,3 +388,150 @@ class TestPostRunLeafWarn:
         assert warn_msgs == [], (
             f"Unexpected leaf-incomplete warnings on healthy leaf: {warn_msgs}"
         )
+
+
+# --------------------------------------------------------------------------- #
+# Object-storage parity — TrainingBenchmark invokes the S3 branches           #
+# --------------------------------------------------------------------------- #
+
+
+def _apply_object_storage_stub(self):
+    """Stub for ``_apply_object_storage_params``: set the s3 params directly.
+
+    In production the real method reads ``BUCKET`` / ``STORAGE_LIBRARY``
+    from the environment (via ``.env`` loading) and mutates
+    ``params_dict``. Under test we bypass the .env dance and just
+    inject the two keys the downstream storage-scheme-consistency
+    check compares — that matches the production shape without
+    needing real credentials.
+    """
+    self.params_dict['storage.storage_type'] = 's3'
+
+
+@pytest.fixture
+def _object_storage_env_stubs():
+    """Stub the .env-driven object-storage wiring so tests can pass an s3:// URI.
+
+    Two things need bypassing:
+
+    - ``_apply_object_storage_params`` reads env vars → replace with a
+      stub that just injects ``storage.storage_type='s3'``.
+    - ``_check_storage_scheme_consistency`` verifies s3 storage_type
+      pairs with an s3:// dataset URI; the real check would pass here
+      but pulls in production plumbing we don't need in the test.
+    """
+    with patch(
+        "mlpstorage_py.benchmarks.dlio.DLIOBenchmark._apply_object_storage_params",
+        _apply_object_storage_stub,
+    ), patch(
+        "mlpstorage_py.benchmarks.dlio.DLIOBenchmark._check_storage_scheme_consistency",
+        lambda self: None,
+    ):
+        yield
+
+
+class TestTrainingBenchmarkObjectStorageWiring:
+    """The datagen wiring must fire the guards for object-storage --data-dir too.
+
+    Prior to this test class, both the pre-run refuse guard and the
+    post-run manifest write were gated on ``storage_type == 'local'``
+    which made them silent no-ops on S3. This class pins the parity:
+    an ``s3://`` --data-dir must:
+
+    - Invoke ``assert_data_dir_hierarchy_absent`` (which internally
+      dispatches to ``s3dlio.list``, mocked here) BEFORE add_datadir_param.
+    - Invoke ``write_datagen_manifest`` (which internally dispatches
+      to ``s3dlio.put_bytes``, mocked here) AFTER DLIO returns success.
+    """
+
+    def test_s3_datagen_invokes_refuse_and_manifest_write(
+        self, tmp_path, _object_storage_env_stubs
+    ):
+        # Point --data-dir at an s3 URI. --results-dir stays local
+        # because submission artifacts always land locally.
+        args = _training_datagen_args(tmp_path)
+        args.data_dir = "s3://mybucket/mytraining"
+
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        # Patch s3dlio at the module boundary
+        # (mlpstorage_py.rules.datagen_hierarchy.s3dlio). Empty LIST
+        # → refuse-guard passes; put_bytes mock captures the manifest
+        # PUT arguments for verification.
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            mock_s3dlio.list.return_value = []
+
+            benchmark = TrainingBenchmark(args, logger=MagicMock())
+            # LIST fired during __init__ pre-run guard.
+            assert mock_s3dlio.list.call_count == 1
+            (list_uri,), list_kwargs = mock_s3dlio.list.call_args
+            assert list_uri.startswith("s3://mybucket/mytraining")
+            assert "unet3d" in list_uri
+            assert list_kwargs.get("recursive") is False
+
+            # Replace DLIO invocation with a no-op so _run reports
+            # SUCCESS without shelling out.
+            benchmark.command_method_map["datagen"] = MagicMock(
+                return_value=None
+            )
+
+            result = benchmark._run()
+
+        assert result == EXIT_CODE.SUCCESS
+        # PUT fired during post-run manifest write.
+        mock_s3dlio.put_bytes.assert_called_once()
+        (put_uri, payload), _ = mock_s3dlio.put_bytes.call_args
+        assert put_uri == (
+            "s3://mybucket/mytraining/unet3d/"
+            ".mlps-datagen-manifest.json"
+        )
+        assert isinstance(payload, (bytes, bytearray))
+
+    def test_s3_datagen_refuses_when_prefix_non_empty(
+        self, tmp_path, _object_storage_env_stubs
+    ):
+        args = _training_datagen_args(tmp_path)
+        args.data_dir = "s3://mybucket/mytraining"
+
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            # LIST returns a non-empty result → refuse-guard raises.
+            mock_s3dlio.list.return_value = [
+                "s3://mybucket/mytraining/unet3d/train/shard_000.npz"
+            ]
+            with pytest.raises(ConfigurationError) as excinfo:
+                TrainingBenchmark(args, logger=MagicMock())
+
+        text = str(excinfo.value)
+        assert "unet3d" in text
+        assert "s3://mybucket/mytraining" in text
+        # And put_bytes MUST NOT have been called — refuse fires
+        # before any write path.
+        mock_s3dlio.put_bytes.assert_not_called()
+
+    def test_s3_datagen_whatif_skips_both_s3_calls(
+        self, tmp_path, _object_storage_env_stubs
+    ):
+        args = _training_datagen_args(tmp_path, mode="whatif")
+        args.data_dir = "s3://mybucket/mytraining"
+
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            benchmark = TrainingBenchmark(args, logger=MagicMock())
+            benchmark.command_method_map["datagen"] = MagicMock(
+                return_value=None
+            )
+            benchmark._run()
+
+        # Whatif skips both the pre-run guard and the post-run
+        # manifest write per the D-29 policy.
+        mock_s3dlio.list.assert_not_called()
+        mock_s3dlio.put_bytes.assert_not_called()

--- a/tests/integration/test_datagen_hierarchy_wiring.py
+++ b/tests/integration/test_datagen_hierarchy_wiring.py
@@ -3,22 +3,31 @@
 The unit tests in ``tests/unit/test_datagen_hierarchy.py`` prove the four
 helpers in ``mlpstorage_py.rules.datagen_hierarchy`` behave correctly in
 isolation. This file proves that the training benchmark's
-``__init__`` actually calls them at the right points and only for the
-right command/mode combinations:
+``__init__`` and ``_run`` actually call them at the right points and only
+for the right command/mode combinations:
 
     - Pre-run guards fire for ``command == "datagen"``.
+    - Post-run manifest write + leaf WARN fire after datagen succeeds
+      (before ``_run`` returns SUCCESS).
     - Whatif mode skips all guards (matches D-29 reportgen policy and
       the user's "no significant validation checking" direction).
+    - Object storage skips the local manifest write (S3 presence
+      semantics are a different API).
     - Non-datagen commands (``run``, ``configview``, ``datasize``) do
       not invoke datagen-specific guards — a populated ``--data-dir``
       is expected input for ``run``, not a refuse-to-overwrite signal.
 """
 from __future__ import annotations
 
+import json
+import os
+
 import pytest
 from unittest.mock import MagicMock, patch
 
+from mlpstorage_py.config import EXIT_CODE
 from mlpstorage_py.errors import ConfigurationError
+from mlpstorage_py.rules.datagen_hierarchy import DATAGEN_MANIFEST_FILENAME
 from tests.fixtures.sample_data import create_sample_benchmark_args
 
 
@@ -212,6 +221,170 @@ class TestSupportedModelWiring:
             ) as mock_validate:
                 try:
                     TrainingBenchmark(args, logger=MagicMock())
-                except Exception:
+                except (Exception, SystemExit):
                     pass
                 mock_validate.assert_called_once_with(model, "closed")
+
+
+# --------------------------------------------------------------------------- #
+# Post-run — manifest write + leaf WARN                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _instantiate_datagen_benchmark(tmp_path, *, model="unet3d", mode="closed"):
+    """Instantiate a datagen TrainingBenchmark with cluster-info mocked out.
+
+    Callers own creating ``tmp_path/data`` — for post-run tests we want
+    an empty data-dir so the refuse-to-overwrite pre-run guard passes.
+    """
+    args = _training_datagen_args(tmp_path, model=model, mode=mode)
+    from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+    logger = MagicMock()
+    benchmark = TrainingBenchmark(args, logger=logger)
+    # Patch the DLIO invocation path so _run does not actually shell out.
+    # The command_method_map for 'datagen' points at execute_command;
+    # substitute a no-op so _run reports success without invoking DLIO.
+    benchmark.command_method_map["datagen"] = MagicMock(return_value=None)
+    return benchmark, logger
+
+
+class TestPostRunManifestWrite:
+    """Manifest is written under ``<data-dir>/<model>/`` after datagen succeeds."""
+
+    def test_datagen_success_writes_manifest_with_dlio_fields(self, tmp_path):
+        (tmp_path / "data").mkdir()
+        benchmark, _logger = _instantiate_datagen_benchmark(tmp_path)
+
+        result = benchmark._run()
+
+        assert result == EXIT_CODE.SUCCESS
+        manifest_path = os.path.join(
+            benchmark.args.data_dir, "unet3d", DATAGEN_MANIFEST_FILENAME
+        )
+        assert os.path.isfile(manifest_path), (
+            f"Expected manifest at {manifest_path}; not found."
+        )
+        with open(manifest_path) as f:
+            data = json.load(f)
+        # The three fields the future run-vs-datagen check will consume,
+        # pulled from configs/dlio/workload/unet3d_datagen.yaml.
+        assert data["model"] == "unet3d"
+        assert data["num_files_train"] == 168
+        assert data["num_samples_per_file"] == 1
+        assert data["record_length_bytes"] == 146600628
+
+    def test_datagen_whatif_skips_manifest_write(self, tmp_path):
+        (tmp_path / "data").mkdir()
+        benchmark, _logger = _instantiate_datagen_benchmark(
+            tmp_path, mode="whatif"
+        )
+
+        result = benchmark._run()
+
+        assert result == EXIT_CODE.SUCCESS
+        # Whatif is simulation — no manifest should land.
+        manifest_path = os.path.join(
+            benchmark.args.data_dir, "unet3d", DATAGEN_MANIFEST_FILENAME
+        )
+        assert not os.path.exists(manifest_path)
+
+    def test_datagen_object_storage_skips_local_manifest_write(self, tmp_path):
+        (tmp_path / "data").mkdir()
+        benchmark, _logger = _instantiate_datagen_benchmark(tmp_path)
+        # Simulate the object-storage branch: params_dict was
+        # written by _apply_object_storage_params in production.
+        benchmark.params_dict["storage.storage_type"] = "s3"
+
+        result = benchmark._run()
+
+        assert result == EXIT_CODE.SUCCESS
+        # No local manifest for object storage — the file path we
+        # would have written to must not exist.
+        manifest_path = os.path.join(
+            benchmark.args.data_dir, "unet3d", DATAGEN_MANIFEST_FILENAME
+        )
+        assert not os.path.exists(manifest_path)
+
+    def test_datagen_missing_dlio_field_returns_failure(self, tmp_path):
+        (tmp_path / "data").mkdir()
+        benchmark, logger = _instantiate_datagen_benchmark(tmp_path)
+        # Simulate a broken workload YAML: strip record_length_bytes
+        # from combined_params so write_datagen_manifest raises.
+        del benchmark.combined_params["dataset"]["record_length_bytes"]
+
+        result = benchmark._run()
+
+        assert result == EXIT_CODE.FAILURE
+        # An error message must surface the missing key — silent
+        # failure would be worse than the original bug.
+        error_msgs = [
+            call.args[0]
+            for call in logger.error.call_args_list
+            if call.args
+        ]
+        assert any(
+            "record_length_bytes" in m for m in error_msgs
+        ), f"Expected 'record_length_bytes' in error logs; got {error_msgs!r}"
+
+
+class TestPostRunLeafWarn:
+    """Missing leaf files produce WARN log entries, not FAILURE."""
+
+    def test_missing_leaf_files_emit_warnings(self, tmp_path):
+        (tmp_path / "data").mkdir()
+        benchmark, logger = _instantiate_datagen_benchmark(tmp_path)
+        # The result_dir was reserved during __init__ (empty dir —
+        # DLIO would populate it, but our mocked command_method_map
+        # never runs). validate_datagen_leaf should report every
+        # required file/folder as missing.
+
+        result = benchmark._run()
+
+        assert result == EXIT_CODE.SUCCESS
+        warn_msgs = [
+            call.args[0]
+            for call in logger.warning.call_args_list
+            if call.args
+        ]
+        # Sanity: at least the four required files + dlio_config folder
+        # should surface as WARN. Assert on a couple of representative
+        # anchors rather than the full list to avoid over-pinning.
+        joined = "\n".join(warn_msgs)
+        assert "stdout" in joined, joined
+        assert "dlio.log" in joined, joined
+        assert "dlio_config" in joined, joined
+
+    def test_healthy_leaf_produces_no_warn(self, tmp_path):
+        (tmp_path / "data").mkdir()
+        benchmark, logger = _instantiate_datagen_benchmark(tmp_path)
+        # Simulate DLIO's on-disk output: populate the reserved
+        # result_dir with all required files.
+        leaf = benchmark.run_result_output
+        for name in (
+            "training_datagen.stdout.log",
+            "training_datagen.stderr.log",
+            "dlio.log",
+        ):
+            open(os.path.join(leaf, name), "w").close()
+        # The mlpstorage-injected metadata name is timestamped;
+        # os.path.basename(leaf) is the datetime segment used in
+        # the metadata filename in production.
+        ts = os.path.basename(leaf)
+        open(os.path.join(leaf, f"training_{ts}_metadata.json"), "w").close()
+        dlio_cfg = os.path.join(leaf, "dlio_config")
+        os.makedirs(dlio_cfg)
+        for name in ("config.yaml", "hydra.yaml", "overrides.yaml"):
+            open(os.path.join(dlio_cfg, name), "w").close()
+
+        result = benchmark._run()
+
+        assert result == EXIT_CODE.SUCCESS
+        warn_msgs = [
+            call.args[0]
+            for call in logger.warning.call_args_list
+            if call.args and "Datagen output leaf" in call.args[0]
+        ]
+        assert warn_msgs == [], (
+            f"Unexpected leaf-incomplete warnings on healthy leaf: {warn_msgs}"
+        )

--- a/tests/integration/test_datagen_hierarchy_wiring.py
+++ b/tests/integration/test_datagen_hierarchy_wiring.py
@@ -289,23 +289,6 @@ class TestPostRunManifestWrite:
         )
         assert not os.path.exists(manifest_path)
 
-    def test_datagen_object_storage_skips_local_manifest_write(self, tmp_path):
-        (tmp_path / "data").mkdir()
-        benchmark, _logger = _instantiate_datagen_benchmark(tmp_path)
-        # Simulate the object-storage branch: params_dict was
-        # written by _apply_object_storage_params in production.
-        benchmark.params_dict["storage.storage_type"] = "s3"
-
-        result = benchmark._run()
-
-        assert result == EXIT_CODE.SUCCESS
-        # No local manifest for object storage — the file path we
-        # would have written to must not exist.
-        manifest_path = os.path.join(
-            benchmark.args.data_dir, "unet3d", DATAGEN_MANIFEST_FILENAME
-        )
-        assert not os.path.exists(manifest_path)
-
     def test_datagen_missing_dlio_field_returns_failure(self, tmp_path):
         (tmp_path / "data").mkdir()
         benchmark, logger = _instantiate_datagen_benchmark(tmp_path)

--- a/tests/integration/test_datagen_hierarchy_wiring.py
+++ b/tests/integration/test_datagen_hierarchy_wiring.py
@@ -1,0 +1,216 @@
+"""Integration tests: datagen_hierarchy guards wired into TrainingBenchmark.
+
+The unit tests in ``tests/unit/test_datagen_hierarchy.py`` prove the four
+helpers in ``mlpstorage_py.rules.datagen_hierarchy`` behave correctly in
+isolation. This file proves that the training benchmark's
+``__init__`` actually calls them at the right points and only for the
+right command/mode combinations:
+
+    - Pre-run guards fire for ``command == "datagen"``.
+    - Whatif mode skips all guards (matches D-29 reportgen policy and
+      the user's "no significant validation checking" direction).
+    - Non-datagen commands (``run``, ``configview``, ``datasize``) do
+      not invoke datagen-specific guards — a populated ``--data-dir``
+      is expected input for ``run``, not a refuse-to-overwrite signal.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from mlpstorage_py.errors import ConfigurationError
+from tests.fixtures.sample_data import create_sample_benchmark_args
+
+
+@pytest.fixture(autouse=True)
+def _bypass_capacity_gate():
+    """Skip the pre-execution CAP gate for these instantiation tests."""
+    with patch(
+        "mlpstorage_py.benchmarks.base.Benchmark._pre_execution_gate",
+        return_value=None,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _mock_cluster_information():
+    """Skip the real ClusterInformation collection."""
+    with patch("mlpstorage_py.benchmarks.base.ClusterInformation") as mock_ci:
+        mock_ci.return_value = MagicMock()
+        mock_ci.return_value.total_memory_bytes = 256 * 1024**3
+        mock_ci.return_value.host_info_list = []
+        yield mock_ci
+
+
+def _training_datagen_args(tmp_path, model="unet3d", mode="closed"):
+    """Build a training-datagen args Namespace with results/data dirs under tmp_path."""
+    args = create_sample_benchmark_args(
+        benchmark_type="training",
+        command="datagen",
+        model=model,
+        accelerator_type="h100",
+        num_accelerators=8,
+        client_host_memory_in_gb=256,
+        hosts=["127.0.0.1"],
+        data_dir=str(tmp_path / "data"),
+    )
+    args.mode = mode
+    args.results_dir = str(tmp_path / "results")
+    args.dry_run = True
+    args.what_if = mode == "whatif"
+    return args
+
+
+# --------------------------------------------------------------------------- #
+# Pre-run guard — refuse-to-overwrite an existing <data-dir>/<model>          #
+# --------------------------------------------------------------------------- #
+
+
+class TestRefuseToOverwriteWiring:
+    """<data-dir>/<model> already exists → ``TrainingBenchmark.__init__`` raises."""
+
+    def test_datagen_closed_refuses_populated_data_dir(self, tmp_path):
+        # Pre-populate <data-dir>/unet3d/ with a stray file to simulate a
+        # prior datagen (or a hand-crafted tree).
+        (tmp_path / "data" / "unet3d").mkdir(parents=True)
+        (tmp_path / "data" / "unet3d" / "prior_shard.npz").write_bytes(b"x")
+
+        args = _training_datagen_args(tmp_path)
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        with pytest.raises(ConfigurationError) as excinfo:
+            TrainingBenchmark(args, logger=MagicMock())
+
+        text = str(excinfo.value)
+        # The guard's language, not some downstream reason.
+        assert "unet3d" in text
+        assert (
+            "refusing to overwrite" in text
+            or "already exists" in text
+        ), f"unexpected error text: {text!r}"
+
+    def test_datagen_closed_accepts_empty_data_dir(self, tmp_path):
+        # <data-dir> exists but <data-dir>/unet3d does not — the fresh case.
+        (tmp_path / "data").mkdir(parents=True)
+
+        args = _training_datagen_args(tmp_path)
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        # Patch the guard so we can prove it was called AND allowed to
+        # pass. Downstream init may raise for other reasons — we care
+        # only that the refuse-guard did not.
+        with patch(
+            "mlpstorage_py.benchmarks.dlio.assert_data_dir_hierarchy_absent"
+        ) as mock_guard:
+            try:
+                TrainingBenchmark(args, logger=MagicMock())
+            except ConfigurationError:
+                # Some other config check may fire — allowed. What we
+                # care about is the refuse-guard invocation.
+                pass
+
+            mock_guard.assert_called_once()
+            # Guard receives (data_dir, model).
+            called_args, _ = mock_guard.call_args
+            assert called_args[0] == args.data_dir
+            assert called_args[1] == "unet3d"
+
+    def test_datagen_whatif_skips_refuse_guard(self, tmp_path):
+        # Whatif is simulation; the refuse-to-overwrite guard must NOT fire.
+        (tmp_path / "data" / "unet3d").mkdir(parents=True)
+        (tmp_path / "data" / "unet3d" / "prior_shard.npz").write_bytes(b"x")
+
+        args = _training_datagen_args(tmp_path, mode="whatif")
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        with patch(
+            "mlpstorage_py.benchmarks.dlio.assert_data_dir_hierarchy_absent"
+        ) as mock_guard:
+            try:
+                TrainingBenchmark(args, logger=MagicMock())
+            except Exception:
+                # Any downstream error is fine — we only assert the
+                # whatif exemption for the refuse-guard.
+                pass
+
+            mock_guard.assert_not_called()
+
+    def test_run_command_does_not_invoke_datagen_refuse_guard(self, tmp_path):
+        # A populated data-dir is required INPUT for `run` — the datagen
+        # refuse-to-overwrite guard must not fire on the run path.
+        (tmp_path / "data" / "unet3d").mkdir(parents=True)
+        (tmp_path / "data" / "unet3d" / "shard.npz").write_bytes(b"x")
+
+        args = _training_datagen_args(tmp_path)
+        args.command = "run"
+        # verify_benchmark runs for `run` — it will likely raise, but
+        # the refuse-guard invocation is what we assert on.
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        with patch(
+            "mlpstorage_py.benchmarks.dlio.assert_data_dir_hierarchy_absent"
+        ) as mock_guard:
+            try:
+                TrainingBenchmark(args, logger=MagicMock())
+            except Exception:
+                pass
+            mock_guard.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Pre-run guard — supported-model check                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestSupportedModelWiring:
+    """Datagen's ``__init__`` must reject unsupported models per mode."""
+
+    def test_datagen_closed_rejects_cosmoflow(self, tmp_path):
+        # cosmoflow was a v2.0 model — no longer in MODELS_CLOSED for v3.0.
+        (tmp_path / "data").mkdir(parents=True)
+
+        args = _training_datagen_args(tmp_path, model="cosmoflow")
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        with pytest.raises(ConfigurationError) as excinfo:
+            TrainingBenchmark(args, logger=MagicMock())
+
+        text = str(excinfo.value)
+        assert "cosmoflow" in text
+        assert "closed" in text
+
+    def test_datagen_whatif_accepts_cosmoflow(self, tmp_path):
+        # Whatif skips the model allowlist — matches the D-29 policy.
+        (tmp_path / "data").mkdir(parents=True)
+
+        args = _training_datagen_args(tmp_path, model="cosmoflow", mode="whatif")
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        with patch(
+            "mlpstorage_py.benchmarks.dlio.validate_supported_model"
+        ) as mock_validate:
+            try:
+                TrainingBenchmark(args, logger=MagicMock())
+            except Exception:
+                pass
+            # Guard is not invoked in whatif — helper handles it, but
+            # the caller short-circuits earlier for symmetry with the
+            # refuse-guard.
+            mock_validate.assert_not_called()
+
+    def test_datagen_closed_retinanet_and_unet3d_accepted(self, tmp_path):
+        # Sanity: both v3.0 supported models pass the guard.
+        for model in ("unet3d", "retinanet"):
+            data_dir = tmp_path / model / "data"
+            data_dir.mkdir(parents=True)
+            args = _training_datagen_args(tmp_path / model, model=model)
+            from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+            with patch(
+                "mlpstorage_py.benchmarks.dlio.validate_supported_model"
+            ) as mock_validate:
+                try:
+                    TrainingBenchmark(args, logger=MagicMock())
+                except Exception:
+                    pass
+                mock_validate.assert_called_once_with(model, "closed")

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -1035,6 +1035,149 @@ class TestInvalidRulesStrict:
 
 
 # --------------------------------------------------------------------------- #
+# TestDatagenReportgenValidation — post-#717 datagen-side checks              #
+# --------------------------------------------------------------------------- #
+
+
+def _make_datagen_run(dest_root: pathlib.Path, *, model: str, ts: str,
+                     populate_leaf: bool = True) -> BenchmarkRun:
+    """Build a training datagen ``BenchmarkRun`` and optionally populate its leaf.
+
+    Path shape mirrors production (``rules/utils.py:285-300``):
+        ``<dest_root>/<ts>/`` with either the four required files +
+        dlio_config folder (populate_leaf=True) or an empty dir
+        (populate_leaf=False).
+    """
+    leaf = dest_root / ts
+    leaf.mkdir(parents=True, exist_ok=True)
+    if populate_leaf:
+        for name in (
+            "training_datagen.stdout.log",
+            "training_datagen.stderr.log",
+            "dlio.log",
+            f"training_{ts}_metadata.json",
+        ):
+            (leaf / name).write_text("")
+        dlio_cfg = leaf / "dlio_config"
+        dlio_cfg.mkdir()
+        for name in ("config.yaml", "hydra.yaml", "overrides.yaml"):
+            (dlio_cfg / name).write_text("")
+    return _make_run(
+        benchmark_type=BENCHMARK_TYPES.training,
+        model=model,
+        result_dir=str(leaf),
+        metrics={},
+        accelerator=None,
+        run_datetime=ts,
+        command="datagen",
+    )
+
+
+class TestDatagenReportgenValidation:
+    """Datagen-side reportgen checks — supported-model INVALID + leaf WARN.
+
+    Fires only on training datagen groups (``runs[0].command == 'datagen'``
+    and ``runs[0].benchmark_type == training``). Whatif rows skip both
+    checks per the D-29 policy the #717 fix already established.
+    """
+
+    def _row_issue_text(self, result) -> str:
+        return "; ".join(
+            getattr(issue, "message", "") or str(issue)
+            for issue in (result.issues or [])
+        )
+
+    def test_unsupported_model_datagen_group_marked_invalid(self, tmp_path):
+        """Datagen leaf whose model is not in MODELS_CLOSED → row is INVALID.
+
+        Uses ``cosmoflow`` — a v2.0 model no longer in the v3.0 allowlist.
+        Full leaf files are present so any INVALID must come from the
+        model check, not from a leaf-presence path.
+        """
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "closed" / "acme" / "results" / "sys-a" / "training" / "cosmoflow" / "datagen"
+        run = _make_datagen_run(runs_root, model="cosmoflow", ts="20260708_120000")
+
+        _run_process_workload_groups(gen, [run])
+
+        assert len(gen.workload_results) == 1
+        result = next(iter(gen.workload_results.values()))
+        assert result.category == PARAM_VALIDATION.INVALID
+        text = self._row_issue_text(result)
+        assert "cosmoflow" in text
+        assert "closed" in text
+
+    def test_supported_model_datagen_group_not_invalid(self, tmp_path):
+        """Datagen leaf with unet3d + populated files → NOT INVALID."""
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "closed" / "acme" / "results" / "sys-a" / "training" / "unet3d" / "datagen"
+        run = _make_datagen_run(runs_root, model="unet3d", ts="20260708_130000")
+
+        _run_process_workload_groups(gen, [run])
+
+        result = next(iter(gen.workload_results.values()))
+        assert result.category != PARAM_VALIDATION.INVALID, (
+            f"Expected non-INVALID for healthy unet3d datagen; got "
+            f"category={result.category!r}, issues={self._row_issue_text(result)!r}"
+        )
+
+    def test_whatif_unsupported_model_datagen_group_not_invalid(self, tmp_path):
+        """Whatif skips the supported-model gate per D-29."""
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "whatif" / "training" / "cosmoflow" / "datagen"
+        run = _make_datagen_run(runs_root, model="cosmoflow", ts="20260708_140000")
+
+        _run_process_workload_groups(gen, [run])
+
+        result = next(iter(gen.workload_results.values()))
+        assert result.category != PARAM_VALIDATION.INVALID
+        # And no unsupported-model text should have leaked through.
+        text = self._row_issue_text(result)
+        assert "not permitted" not in text
+        assert "cosmoflow" not in text or "Model 'cosmoflow'" not in text
+
+    def test_missing_leaf_files_datagen_warn_not_invalid(self, tmp_path):
+        """Datagen leaf missing files → row carries WARN messages, category NOT INVALID.
+
+        A malformed datagen contribution to a submission is worth
+        surfacing (so the operator can regenerate) but does not by
+        itself invalidate the submission.
+        """
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "closed" / "acme" / "results" / "sys-a" / "training" / "unet3d" / "datagen"
+        run = _make_datagen_run(
+            runs_root, model="unet3d", ts="20260708_150000", populate_leaf=False
+        )
+
+        _run_process_workload_groups(gen, [run])
+
+        result = next(iter(gen.workload_results.values()))
+        assert result.category != PARAM_VALIDATION.INVALID, (
+            f"Missing leaf files should WARN, not INVALID; got category={result.category!r}"
+        )
+        text = self._row_issue_text(result)
+        # WARN messages surface with a distinguishable prefix so the
+        # CSV column stays parseable.
+        assert "[WARN]" in text, f"Expected [WARN] prefix in issues text; got: {text!r}"
+        assert "dlio.log" in text or "stdout" in text or "metadata" in text, text
+
+    def test_healthy_leaf_datagen_no_warn_no_invalid(self, tmp_path):
+        """Fully-populated datagen leaf produces no datagen-side WARN and no INVALID."""
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "closed" / "acme" / "results" / "sys-a" / "training" / "unet3d" / "datagen"
+        run = _make_datagen_run(runs_root, model="unet3d", ts="20260708_160000")
+
+        _run_process_workload_groups(gen, [run])
+
+        result = next(iter(gen.workload_results.values()))
+        assert result.category != PARAM_VALIDATION.INVALID
+        text = self._row_issue_text(result)
+        assert "[WARN]" not in text, (
+            f"No [WARN] should be emitted for a healthy leaf; got: {text!r}"
+        )
+
+
+# --------------------------------------------------------------------------- #
 # TestColumnOrdering — D-14 / D-18                                            #
 # --------------------------------------------------------------------------- #
 

--- a/tests/unit/test_datagen_hierarchy.py
+++ b/tests/unit/test_datagen_hierarchy.py
@@ -1,0 +1,348 @@
+"""Unit tests for mlpstorage_py.rules.datagen_hierarchy.
+
+Covers the four helpers introduced for training datagen validation:
+
+    * ``validate_supported_model(model, mode)`` — hard-fail on unsupported
+      model for the given submission mode. Whatif skips (matches the D-29
+      whatif-exemption policy in Phase 6 reportgen).
+
+    * ``assert_data_dir_hierarchy_absent(data_dir, model)`` — refuse to
+      overwrite an existing ``<data-dir>/<model>`` tree. Rationale: a
+      re-datagen with different ``num_samples_per_file`` (or any other
+      parameter that changes per-file byte size) would leave the old
+      and new files interleaved on filename collision, silently
+      corrupting the dataset.
+
+    * ``validate_datagen_leaf(leaf_path)`` — stat-only presence check
+      of the four datagen-required files plus ``dlio_config/`` and its
+      three inner files. Returns a list of human-readable missing-item
+      strings (empty list means the leaf is complete). Does NOT walk
+      into file contents.
+
+    * ``write_datagen_manifest(...)`` — extract
+      ``num_files_train`` / ``num_samples_per_file`` /
+      ``record_length_bytes`` from a nested ``dataset`` param dict,
+      write ``<data-dir>/<model>/.mlps-datagen-manifest.json`` with the
+      documented schema, and return the manifest path. Loud failure if
+      any of the three fields is absent from the input dict.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+
+import pytest
+
+from mlpstorage_py.errors import ConfigurationError
+from mlpstorage_py.rules.datagen_hierarchy import (
+    DATAGEN_MANIFEST_FILENAME,
+    DATAGEN_MANIFEST_SCHEMA_VERSION,
+    assert_data_dir_hierarchy_absent,
+    validate_datagen_leaf,
+    validate_supported_model,
+    write_datagen_manifest,
+)
+
+
+# --------------------------------------------------------------------------- #
+# validate_supported_model                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestValidateSupportedModel:
+    """Mode-aware model allowlist enforcement.
+
+    Rules.md v3.0 restricts CLOSED and OPEN to {unet3d, retinanet}.
+    Whatif is simulation and skips all validation per the D-29
+    reportgen policy — the helper mirrors that policy so unsupported
+    models pass through in whatif.
+    """
+
+    @pytest.mark.parametrize("mode", ["closed", "open"])
+    @pytest.mark.parametrize("model", ["unet3d", "retinanet"])
+    def test_supported_models_accepted_in_closed_and_open(self, mode, model):
+        # Must not raise.
+        validate_supported_model(model, mode)
+
+    @pytest.mark.parametrize("mode", ["closed", "open"])
+    @pytest.mark.parametrize(
+        "model", ["cosmoflow", "resnet50", "dlrm", "flux", "gpt2", ""]
+    )
+    def test_unsupported_models_rejected_in_closed_and_open(self, mode, model):
+        with pytest.raises(ConfigurationError) as excinfo:
+            validate_supported_model(model, mode)
+        # Message should surface both the model and the mode so the
+        # operator can see immediately which allowlist rejected them.
+        text = str(excinfo.value)
+        assert model in text or "model" in text.lower()
+        assert mode in text
+
+    @pytest.mark.parametrize(
+        "model", ["unet3d", "retinanet", "cosmoflow", "resnet50", "dlrm", "flux"]
+    )
+    def test_whatif_accepts_any_known_model(self, model):
+        # Whatif is simulation — the D-29 pattern skips validation.
+        validate_supported_model(model, "whatif")
+
+    def test_unknown_mode_rejected(self):
+        # Defensive: a mode outside {closed, open, whatif} means a
+        # caller wiring bug — loud failure over silent accept.
+        with pytest.raises(ConfigurationError):
+            validate_supported_model("unet3d", "bogus")
+
+
+# --------------------------------------------------------------------------- #
+# assert_data_dir_hierarchy_absent                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestAssertDataDirHierarchyAbsent:
+    """Refuse-to-overwrite guard for ``<data-dir>/<model>``.
+
+    Rationale: if the operator re-runs datagen against the same
+    ``--data-dir`` with a different ``num_samples_per_file`` (or any
+    other per-file size knob), filename collisions may only
+    partially overwrite the prior tree. Rather than teach the
+    generator to detect that, we refuse and force ``rm -rf`` or a
+    different ``--data-dir``.
+    """
+
+    def test_absent_hierarchy_returns_cleanly(self, tmp_path):
+        # <data-dir>/<model> does not exist — nothing to refuse.
+        assert_data_dir_hierarchy_absent(str(tmp_path), "unet3d")
+
+    def test_empty_model_dir_returns_cleanly(self, tmp_path):
+        # A pre-created but empty directory is allowed — e.g. the
+        # operator ran ``mkdir -p`` in advance. The invariant we
+        # protect is "no partially-overwritten files", so an empty
+        # dir is fine.
+        (tmp_path / "unet3d").mkdir()
+        assert_data_dir_hierarchy_absent(str(tmp_path), "unet3d")
+
+    def test_non_empty_model_dir_raises_configuration_error(self, tmp_path):
+        model_dir = tmp_path / "unet3d"
+        model_dir.mkdir()
+        (model_dir / "some_shard.npz").write_bytes(b"prior data")
+        with pytest.raises(ConfigurationError) as excinfo:
+            assert_data_dir_hierarchy_absent(str(tmp_path), "unet3d")
+        text = str(excinfo.value)
+        # Operator needs to see the offending path and be told how to
+        # recover (rm -rf or a different --data-dir).
+        assert str(model_dir) in text
+        assert "unet3d" in text
+
+    def test_model_dir_is_a_file_raises(self, tmp_path):
+        # An operator laying down a file at <data-dir>/<model> is a
+        # pathological state; refuse rather than silently proceed.
+        (tmp_path / "unet3d").write_text("stray")
+        with pytest.raises(ConfigurationError):
+            assert_data_dir_hierarchy_absent(str(tmp_path), "unet3d")
+
+    def test_sibling_model_dir_does_not_block(self, tmp_path):
+        # A populated retinanet tree must not block a fresh unet3d
+        # datagen — one --data-dir is allowed to hold multiple
+        # datasets, as long as the per-model subdirs don't collide.
+        (tmp_path / "retinanet").mkdir()
+        (tmp_path / "retinanet" / "shard.jpeg").write_bytes(b"x")
+        assert_data_dir_hierarchy_absent(str(tmp_path), "unet3d")
+
+
+# --------------------------------------------------------------------------- #
+# validate_datagen_leaf                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _make_healthy_leaf(root: pathlib.Path, ts: str = "20260708_120000") -> pathlib.Path:
+    """Create a healthy datagen leaf directory: all required files + dlio_config."""
+    leaf = root / ts
+    leaf.mkdir(parents=True)
+    (leaf / "training_datagen.stdout.log").write_text("")
+    (leaf / "training_datagen.stderr.log").write_text("")
+    (leaf / "dlio.log").write_text("")
+    (leaf / f"training_{ts}_metadata.json").write_text("{}")
+    dlio_cfg = leaf / "dlio_config"
+    dlio_cfg.mkdir()
+    (dlio_cfg / "config.yaml").write_text("")
+    (dlio_cfg / "hydra.yaml").write_text("")
+    (dlio_cfg / "overrides.yaml").write_text("")
+    return leaf
+
+
+class TestValidateDatagenLeaf:
+    """Stat-only completeness check of the ``datagen/<ts>/`` leaf.
+
+    Mirrors the file/folder list already enforced by
+    ``submission_checker`` rule §2.1.14 / §2.1.15 (see
+    ``mlpstorage_py/submission_checker/constants.py:67-81``) but is
+    reachable both from a post-datagen run-checker hook and from
+    ``reports reportgen`` — the submission_checker itself is a
+    separate tool the operator may never invoke.
+
+    Contract: return a list of human-readable missing-item strings.
+    Empty list means the leaf is complete. Never raises for a
+    stat-only check.
+    """
+
+    def test_healthy_leaf_returns_empty_list(self, tmp_path):
+        leaf = _make_healthy_leaf(tmp_path)
+        assert validate_datagen_leaf(str(leaf)) == []
+
+    def test_missing_stdout_log_reported(self, tmp_path):
+        leaf = _make_healthy_leaf(tmp_path)
+        (leaf / "training_datagen.stdout.log").unlink()
+        missing = validate_datagen_leaf(str(leaf))
+        assert any("stdout" in m for m in missing), missing
+
+    def test_missing_metadata_reported(self, tmp_path):
+        leaf = _make_healthy_leaf(tmp_path, ts="20260708_130000")
+        (leaf / "training_20260708_130000_metadata.json").unlink()
+        missing = validate_datagen_leaf(str(leaf))
+        assert any("metadata" in m for m in missing), missing
+
+    def test_missing_dlio_log_reported(self, tmp_path):
+        leaf = _make_healthy_leaf(tmp_path)
+        (leaf / "dlio.log").unlink()
+        missing = validate_datagen_leaf(str(leaf))
+        assert any("dlio.log" in m for m in missing), missing
+
+    def test_missing_dlio_config_folder_reported(self, tmp_path):
+        leaf = _make_healthy_leaf(tmp_path)
+        # Remove the whole folder — expects folder-level missing message,
+        # not per-file complaints.
+        for entry in (leaf / "dlio_config").iterdir():
+            entry.unlink()
+        (leaf / "dlio_config").rmdir()
+        missing = validate_datagen_leaf(str(leaf))
+        assert any("dlio_config" in m for m in missing), missing
+
+    def test_missing_config_yaml_inside_dlio_config_reported(self, tmp_path):
+        leaf = _make_healthy_leaf(tmp_path)
+        (leaf / "dlio_config" / "config.yaml").unlink()
+        missing = validate_datagen_leaf(str(leaf))
+        assert any("config.yaml" in m for m in missing), missing
+
+    def test_leaf_does_not_exist_reports_leaf_missing(self, tmp_path):
+        # If the leaf itself does not exist, the helper reports that
+        # as a single top-level miss rather than N per-file misses.
+        missing = validate_datagen_leaf(str(tmp_path / "does_not_exist"))
+        assert len(missing) == 1
+        assert "does_not_exist" in missing[0]
+
+
+# --------------------------------------------------------------------------- #
+# write_datagen_manifest                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _valid_dataset_params():
+    """Realistic dataset param block matching configs/dlio/workload/unet3d_datagen.yaml."""
+    return {
+        "num_files_train": 168,
+        "num_samples_per_file": 1,
+        "record_length_bytes": 146600628,
+    }
+
+
+class TestWriteDatagenManifest:
+    """Manifest emission at ``<data-dir>/<model>/.mlps-datagen-manifest.json``.
+
+    Fields recorded (per user direction — only what the future
+    run-vs-datagen size check needs plus provenance):
+
+        schema_version         — integer, bumps if layout changes
+        model                  — e.g. "unet3d"
+        num_files_train        — from merged DLIO config
+        num_samples_per_file   — from merged DLIO config
+        record_length_bytes    — from merged DLIO config
+        created_at             — ISO 8601 UTC (Z-suffixed)
+        mlpstorage_version     — from mlpstorage_py.__version__
+        source_datagen_result_dir — absolute path to the --results-dir leaf
+
+    Loud failure if any of the three DLIO fields is absent from the
+    input dict — the extraction is authoritative, and a config that
+    lacks any of them is a workload-YAML bug (both unet3d_datagen.yaml
+    and retinanet_datagen.yaml expose all three).
+    """
+
+    def test_writes_manifest_with_all_expected_fields(self, tmp_path):
+        source_dir = "/tmp/whatever/training/unet3d/datagen/20260708_120000"
+        manifest_path = write_datagen_manifest(
+            data_dir=str(tmp_path),
+            model="unet3d",
+            dataset_params=_valid_dataset_params(),
+            source_datagen_result_dir=source_dir,
+        )
+        # Return value: absolute path we wrote.
+        assert manifest_path.endswith(
+            os.path.join("unet3d", DATAGEN_MANIFEST_FILENAME)
+        )
+        assert os.path.isabs(manifest_path)
+        assert os.path.isfile(manifest_path)
+
+        with open(manifest_path) as f:
+            data = json.load(f)
+
+        assert data["schema_version"] == DATAGEN_MANIFEST_SCHEMA_VERSION
+        assert data["model"] == "unet3d"
+        assert data["num_files_train"] == 168
+        assert data["num_samples_per_file"] == 1
+        assert data["record_length_bytes"] == 146600628
+        assert data["source_datagen_result_dir"] == source_dir
+        # ISO 8601 UTC — the exact format string is trivial to verify,
+        # but the important invariant is "parseable + Z-suffixed".
+        assert isinstance(data["created_at"], str)
+        assert data["created_at"].endswith("Z")
+        # mlpstorage_version is captured — value not pinned here so
+        # the test doesn't break on every version bump.
+        assert isinstance(data["mlpstorage_version"], str)
+        assert data["mlpstorage_version"]
+
+    def test_writes_into_model_subdir(self, tmp_path):
+        # Manifest lives at <data-dir>/<model>/.mlps-datagen-manifest.json —
+        # NOT at the data-dir root. Per-model nesting lets one
+        # --data-dir hold multiple datasets.
+        write_datagen_manifest(
+            data_dir=str(tmp_path),
+            model="retinanet",
+            dataset_params={
+                "num_files_train": 1170301,
+                "num_samples_per_file": 1,
+                "record_length_bytes": 322957,
+            },
+            source_datagen_result_dir="/some/leaf",
+        )
+        assert (tmp_path / "retinanet" / DATAGEN_MANIFEST_FILENAME).is_file()
+        # And NOT at the top level.
+        assert not (tmp_path / DATAGEN_MANIFEST_FILENAME).exists()
+
+    def test_creates_model_subdir_if_missing(self, tmp_path):
+        # The refuse-to-overwrite guard fires BEFORE this helper —
+        # by the time we get here, <data-dir>/<model> may not exist
+        # yet (datagen itself hasn't populated it). The manifest
+        # writer must create the directory as needed.
+        write_datagen_manifest(
+            data_dir=str(tmp_path),
+            model="unet3d",
+            dataset_params=_valid_dataset_params(),
+            source_datagen_result_dir="/some/leaf",
+        )
+        assert (tmp_path / "unet3d").is_dir()
+
+    @pytest.mark.parametrize(
+        "missing_key",
+        ["num_files_train", "num_samples_per_file", "record_length_bytes"],
+    )
+    def test_missing_required_field_raises_loudly(self, tmp_path, missing_key):
+        params = _valid_dataset_params()
+        del params[missing_key]
+        with pytest.raises(ConfigurationError) as excinfo:
+            write_datagen_manifest(
+                data_dir=str(tmp_path),
+                model="unet3d",
+                dataset_params=params,
+                source_datagen_result_dir="/some/leaf",
+            )
+        # Error must name the missing key so operators can see which
+        # workload YAML is broken.
+        assert missing_key in str(excinfo.value)

--- a/tests/unit/test_datagen_hierarchy.py
+++ b/tests/unit/test_datagen_hierarchy.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -346,3 +347,207 @@ class TestWriteDatagenManifest:
         # Error must name the missing key so operators can see which
         # workload YAML is broken.
         assert missing_key in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------- #
+# Object-storage parity — refuse-to-overwrite + manifest PUT via s3dlio       #
+# --------------------------------------------------------------------------- #
+
+# All s3dlio interaction goes through the ``s3dlio`` module attribute
+# on ``mlpstorage_py.rules.datagen_hierarchy``. Patching that attribute
+# is how we simulate LIST / PUT behavior in these unit tests — no real
+# object-storage endpoint is required. The maintainer confirmed
+# depending on s3dlio's upstream unit tests for wire-level correctness
+# is acceptable given (1) s3dlio is already exercised by the
+# checkpointing benchmark's actual production I/O, and (2) our sentinel
+# operations are a ~1 KB PUT and a bounded LIST — orders of magnitude
+# simpler than what s3dlio already carries in this codebase.
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "s3://bucket/prefix",
+        "s3://bucket/prefix/",
+        "gs://bucket/prefix",
+        "az://container/prefix",
+        "direct://bucket/prefix",
+    ],
+)
+class TestAssertDataDirHierarchyAbsentObjectStorage:
+    """Refuse-to-overwrite parity for every URI scheme s3dlio abstracts.
+
+    Semantic contract must match the local case:
+        - No object under <data-dir>/<model>/ → clean return.
+        - Any object present → ``ConfigurationError`` with the offending
+          URI in the message.
+        - Any s3dlio exception during LIST → ``ConfigurationError``
+          (fail-safe abort per the design decision — a transient
+          object-store error must not silently be treated as
+          "assume empty, proceed").
+    """
+
+    def test_empty_prefix_returns_cleanly(self, uri):
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            mock_s3dlio.list.return_value = []
+            # Must not raise.
+            assert_data_dir_hierarchy_absent(uri, "unet3d")
+
+            # LIST must be scoped to <data-dir>/<model>/ (with model
+            # segment appended), NOT to the raw data-dir prefix —
+            # otherwise a data-dir that hosts sibling datasets
+            # (retinanet, etc.) would be misdetected as populated.
+            (called_uri,), _ = mock_s3dlio.list.call_args
+            assert "unet3d" in called_uri
+            assert called_uri.startswith(uri.rstrip("/"))
+
+    def test_bounded_list_uses_non_recursive(self, uri):
+        # s3dlio.list has no MaxKeys=1 knob. To keep the check
+        # bounded regardless of dataset size we pass
+        # recursive=False — a delimiter-based listing that returns
+        # only the small set of direct children (train/, valid/,
+        # test/ + manifest). Documented in the design conversation
+        # and PR discussion.
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            mock_s3dlio.list.return_value = []
+            assert_data_dir_hierarchy_absent(uri, "unet3d")
+            _, kwargs = mock_s3dlio.list.call_args
+            assert kwargs.get("recursive") is False, (
+                f"Expected recursive=False for bounded LIST; got kwargs={kwargs!r}"
+            )
+
+    def test_non_empty_prefix_raises_with_uri_in_message(self, uri):
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            mock_s3dlio.list.return_value = [
+                f"{uri.rstrip('/')}/unet3d/train/shard_000.npz"
+            ]
+            with pytest.raises(ConfigurationError) as excinfo:
+                assert_data_dir_hierarchy_absent(uri, "unet3d")
+            text = str(excinfo.value)
+            # Must name the offending model URI so the operator can
+            # act (rm-rf equivalent or a different --data-dir).
+            assert "unet3d" in text
+            assert "s3://" in text or "gs://" in text or "az://" in text or "direct://" in text
+
+    def test_s3dlio_exception_fails_safe_abort(self, uri):
+        # Per the design decision: a transient LIST failure must NOT
+        # be treated as "assume empty". Any s3dlio exception during
+        # the refuse-to-overwrite check is a ConfigurationError.
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            mock_s3dlio.list.side_effect = RuntimeError(
+                "network failure or credentials missing"
+            )
+            with pytest.raises(ConfigurationError) as excinfo:
+                assert_data_dir_hierarchy_absent(uri, "unet3d")
+            # The underlying error must surface (chained or in the
+            # message) so the operator can diagnose.
+            text = str(excinfo.value)
+            assert "unet3d" in text
+            # Chained exception should preserve the original.
+            assert excinfo.value.__cause__ is not None
+
+
+class TestWriteDatagenManifestObjectStorage:
+    """Manifest PUT via s3dlio.put_bytes for object-storage --data-dir.
+
+    Feature parity with the local ``open(..., 'w')`` path: the JSON
+    body is byte-identical (schema_version, three DLIO knobs,
+    provenance fields) — only the write mechanism differs.
+    """
+
+    def test_writes_manifest_via_put_bytes_at_expected_uri(self):
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            returned_uri = write_datagen_manifest(
+                data_dir="s3://mybucket/mytraining",
+                model="unet3d",
+                dataset_params=_valid_dataset_params(),
+                source_datagen_result_dir="/results/leaf",
+            )
+
+            # The manifest lands under <data-dir>/<model>/<filename>
+            # (matches local per-model nesting so one bucket can hold
+            # multiple model datasets).
+            expected_uri = (
+                f"s3://mybucket/mytraining/unet3d/{DATAGEN_MANIFEST_FILENAME}"
+            )
+            assert returned_uri == expected_uri
+            mock_s3dlio.put_bytes.assert_called_once()
+            (called_uri, payload), _ = mock_s3dlio.put_bytes.call_args
+            assert called_uri == expected_uri
+            # Payload must be bytes-typed — s3dlio.put_bytes contract.
+            assert isinstance(payload, (bytes, bytearray))
+
+    def test_manifest_body_matches_local_schema(self):
+        # The wire body must be byte-identical to what the local
+        # branch would write — the future run-side reader is the
+        # same code path across storage backends.
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            write_datagen_manifest(
+                data_dir="s3://mybucket/mytraining",
+                model="unet3d",
+                dataset_params=_valid_dataset_params(),
+                source_datagen_result_dir="/results/leaf",
+            )
+            (_, payload), _ = mock_s3dlio.put_bytes.call_args
+            data = json.loads(payload.decode("utf-8"))
+            assert data["schema_version"] == DATAGEN_MANIFEST_SCHEMA_VERSION
+            assert data["model"] == "unet3d"
+            assert data["num_files_train"] == 168
+            assert data["num_samples_per_file"] == 1
+            assert data["record_length_bytes"] == 146600628
+            assert data["source_datagen_result_dir"] == "/results/leaf"
+            assert data["created_at"].endswith("Z")
+            assert data["mlpstorage_version"]
+
+    @pytest.mark.parametrize(
+        "missing_key",
+        ["num_files_train", "num_samples_per_file", "record_length_bytes"],
+    )
+    def test_missing_field_raises_before_put(self, missing_key):
+        # The loud-failure contract applies to object storage too.
+        # No PUT must fire if extraction fails — otherwise a
+        # zero-valued placeholder could pollute the object store.
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            params = _valid_dataset_params()
+            del params[missing_key]
+            with pytest.raises(ConfigurationError):
+                write_datagen_manifest(
+                    data_dir="s3://mybucket/mytraining",
+                    model="unet3d",
+                    dataset_params=params,
+                    source_datagen_result_dir="/results/leaf",
+                )
+            mock_s3dlio.put_bytes.assert_not_called()
+
+    def test_put_bytes_exception_propagates_configuration_error(self):
+        # s3dlio raises on PUT (auth failure, network hiccup, etc.).
+        # Wrap into ConfigurationError so main.py's uniform error
+        # rendering surfaces it — silent PUT failure would leave the
+        # dataset without its manifest and break the future
+        # run-vs-datagen check.
+        with patch(
+            "mlpstorage_py.rules.datagen_hierarchy.s3dlio"
+        ) as mock_s3dlio:
+            mock_s3dlio.put_bytes.side_effect = RuntimeError("PUT failed")
+            with pytest.raises(ConfigurationError) as excinfo:
+                write_datagen_manifest(
+                    data_dir="s3://mybucket/mytraining",
+                    model="unet3d",
+                    dataset_params=_valid_dataset_params(),
+                    source_datagen_result_dir="/results/leaf",
+                )
+            assert excinfo.value.__cause__ is not None


### PR DESCRIPTION
Closes #731.

## Summary
- Adds `mlpstorage_py/rules/datagen_hierarchy.py` with four helpers: mode-aware supported-model check, refuse-to-overwrite guard on `<data-dir>/<model>`, stat-only leaf-presence check, and manifest writer.
- Wires pre-run guards into `TrainingBenchmark.__init__` (fire before any directory is created) and post-run leaf WARN + manifest write into `TrainingBenchmark._run` (fire after DLIO succeeds).
- Wires supported-model INVALID gate + leaf-presence WARN into `report_generator._process_workload_groups` for training datagen groups. Whatif skips all new checks (matches D-29 policy from #728).
- No `--data-dir` tree walk anywhere. `--data-dir` may be extremely large; validation trusts DLIO's own file-count invariants.
- Manifest at `<data-dir>/<model>/.mlps-datagen-manifest.json`: schema_version, model, num_files_train, num_samples_per_file, record_length_bytes, created_at (ISO 8601 UTC), mlpstorage_version, source_datagen_result_dir. Future PR will read this from `mlpstorage training run` to verify the requested workload fits the dataset.

## Test plan

**RED-first TDD across four pairs of commits:**

- [x] `test_datagen_hierarchy.py` (41 unit tests) — pure helper behavior: allowlist per mode, refuse-to-overwrite states, leaf-presence returns, manifest fields + missing-field loud-failure.
- [x] `test_datagen_hierarchy_wiring.py` (13 integration tests) — TrainingBenchmark pre-run guards fire only for datagen non-whatif; post-run manifest write, leaf WARN, and object-storage/whatif skips.
- [x] `TestDatagenReportgenValidation` in `test_aggregation.py` (5 tests) — reportgen INVALID on unsupported model, WARN on missing leaf files, whatif exemption, and healthy-leaf baseline.

**Full CI parity locally (matrix from `.github/workflows/test.yml`):**

- [x] `uv run pytest tests` — 2806 passed, 1 skipped, 13 deselected
- [x] `uv run pytest mlpstorage_py/tests` — 834 passed
- [x] `uv run pytest vdb_benchmark/tests` — 174 passed
- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed

## Notes

- No changelog entry added — recent fixes (#728, #729) landed on `main` without touching `BugsFixedInVersions.md`; the maintainer bundles docs updates on version bump.
- Not in scope, called out in issue #731 for future work: `mlpstorage training run` reading the manifest to compare its requested workload size against what the dataset supports.