### PR TITLE
fix(#733): backfill training metrics from summary.json when metadata omits them

### DIFF
--- a/mlpstorage_py/rules/models.py
+++ b/mlpstorage_py/rules/models.py
@@ -924,15 +924,30 @@ class ResultFilesExtractor:
             pass  # TODO: Reconstruct system_info
 
         # DLIO's summary.json is the source of truth for phase end timestamps
-        # (Rules.md §4.7.1 cache-flush gap check). The run tool doesn't populate
-        # metadata['end_datetime'] for checkpointing, so fall back to summary
-        # to keep the metadata- and summary-based extraction paths agreeing
-        # on that field. Issue #618.
+        # (Rules.md §4.7.1 cache-flush gap check) AND for training per-run
+        # metric series. The run tool doesn't populate metadata['end_datetime']
+        # for checkpointing, and training's Benchmark.write_metadata never
+        # writes a 'metrics' block at all — the training AU only lives in
+        # summary.json under metric.train_au_percentage etc. Reuse a single
+        # summary read to backfill both. Issues #618 and #733.
         end_datetime = metadata.get('end_datetime', '')
-        if not end_datetime:
+        run_metrics = metadata.get('metrics')
+        if not end_datetime or not run_metrics:
             summary = self._load_summary(result_dir)
             if summary:
-                end_datetime = summary.get('end_time') or summary.get('end', '')
+                if not end_datetime:
+                    end_datetime = summary.get('end_time') or summary.get('end', '')
+                if not run_metrics:
+                    metric_block = summary.get('metric')
+                    if isinstance(metric_block, dict):
+                        # Filter to list-valued keys so _aggregate_training's
+                        # fmean(metric_list) doesn't blow up on scalars like
+                        # train_au_mean_percentage or strings like
+                        # train_au_meet_expectation.
+                        run_metrics = {
+                            k: v for k, v in metric_block.items()
+                            if isinstance(v, list)
+                        } or None
 
         return BenchmarkRunData(
             benchmark_type=benchmark_type,
@@ -944,7 +959,7 @@ class ResultFilesExtractor:
             parameters=metadata.get('parameters', {}),
             override_parameters=metadata.get('override_parameters', {}),
             system_info=system_info,
-            metrics=metadata.get('metrics'),
+            metrics=run_metrics,
             result_dir=result_dir,
             accelerator=metadata.get('accelerator'),
         )

--- a/tests/unit/test_rules_extractors.py
+++ b/tests/unit/test_rules_extractors.py
@@ -540,6 +540,94 @@ class TestResultFilesExtractor:
 
         assert result is None
 
+    def test_from_metadata_falls_back_to_summary_metric_when_missing(
+        self, mock_logger, tmp_path,
+    ):
+        """Issue #733 — training metadata.json omits the `metric` block, so
+        `_from_metadata` must fall back to summary.json's `metric` dict
+        (filtered to list-valued keys) instead of returning `metrics=None`.
+        Otherwise `_aggregate_training` sees the metric-key intersection as
+        empty and silently emits {} for the whole run set — the AU never
+        makes it into results.json.
+        """
+        result_dir = tmp_path / "training_run"
+        result_dir.mkdir()
+
+        # Real training metadata.json does NOT include a 'metrics' key.
+        metadata = {
+            "benchmark_type": "training",
+            "model": "unet3d",
+            "command": "run",
+            "run_datetime": "20260701_100000",
+            "num_processes": 8,
+            "parameters": {"dataset": {"num_files_train": 400}},
+        }
+        with open(result_dir / "training_20260701_100000_metadata.json", 'w') as f:
+            json.dump(metadata, f)
+
+        # summary.json's `metric` block has list-valued per-epoch series
+        # (used by _aggregate_training) alongside scalar/string entries
+        # that fmean cannot consume — the fallback must filter these out.
+        summary = {
+            "start": "2026-07-01 10:00:00",
+            "end": "2026-07-01 10:15:00",
+            "metric": {
+                "train_au_percentage": [96.1, 95.8, 96.4],
+                "train_throughput_samples_per_second": [128.0, 130.0, 129.5],
+                "train_au_mean_percentage": 96.1,
+                "train_au_meet_expectation": "success",
+            },
+        }
+        with open(result_dir / "summary.json", 'w') as f:
+            json.dump(summary, f)
+
+        extractor = ResultFilesExtractor()
+        result = extractor._from_metadata(metadata, str(result_dir))
+
+        assert result.metrics is not None, (
+            "training metadata.json lacks 'metrics'; _from_metadata must "
+            "fall back to summary.json's 'metric' block (#733)"
+        )
+        assert "train_au_percentage" in result.metrics
+        assert result.metrics["train_au_percentage"] == [96.1, 95.8, 96.4]
+        assert "train_throughput_samples_per_second" in result.metrics
+        # Scalar/string entries must be filtered out so aggregation's
+        # `fmean(metric_list)` doesn't blow up on non-iterables.
+        assert "train_au_mean_percentage" not in result.metrics
+        assert "train_au_meet_expectation" not in result.metrics
+
+    def test_from_metadata_prefers_explicit_metrics_over_summary(
+        self, mock_logger, tmp_path,
+    ):
+        """When metadata.json DOES carry a populated `metrics` block
+        (checkpointing case), the summary.json fallback must not clobber
+        it — the metadata value wins.
+        """
+        result_dir = tmp_path / "checkpointing_run"
+        result_dir.mkdir()
+
+        metadata = {
+            "benchmark_type": "checkpointing",
+            "model": "llama3-8b",
+            "command": "run",
+            "run_datetime": "20260701_100000",
+            "num_processes": 8,
+            "parameters": {},
+            "metrics": {"checkpoint_save_time": [1.2, 1.3, 1.1]},
+        }
+        with open(result_dir / "checkpointing_20260701_100000_metadata.json", 'w') as f:
+            json.dump(metadata, f)
+
+        # A stray summary.json should not overwrite the explicit metadata.
+        summary = {"metric": {"unrelated_key": [999.0]}}
+        with open(result_dir / "summary.json", 'w') as f:
+            json.dump(summary, f)
+
+        extractor = ResultFilesExtractor()
+        result = extractor._from_metadata(metadata, str(result_dir))
+
+        assert result.metrics == {"checkpoint_save_time": [1.2, 1.3, 1.1]}
+
 
 class TestExtractorIntegration:
     """Integration tests using fixture data from tests/fixtures."""


### PR DESCRIPTION
## Summary

Fixes #733. After the #730 warmup fix, a 6-invocation CLOSED training submission validates cleanly, but `reports reportgen` writes no `train_mean_of_au_percentage` (or any `train_mean_of_*`) into `results.json` — the headline AU silently disappears.

## Root cause

`ResultFilesExtractor._from_metadata` (`mlpstorage_py/rules/models.py`) returns `metrics=metadata.get('metrics')`. Training's `Benchmark.write_metadata` never writes a `metrics` block into `metadata.json` — the per-epoch AU series only lives in `summary.json` under `metric.train_au_percentage`. So training runs load with `metrics=None`, and `_aggregate_training` intersects an empty key-set across the 5 measured runs and emits `{}`. Checkpointing is unaffected because its `metadata.json` already carries `metrics`.

## Fix

Extend the existing #618 summary-fallback (originally added for `end_datetime`) to also backfill the metric block when metadata's `metrics` is empty:

- Reuse the single `_load_summary(result_dir)` call for both fields.
- Copy `summary['metric']` filtered to **list-valued** entries only, so `_aggregate_training`'s `fmean(metric_list)` is safe against scalar/string neighbors like `train_au_mean_percentage` / `train_au_meet_expectation` that also live in the same dict.
- Explicit `metadata['metrics']` still wins — the fallback only fires when metadata is missing the block (regression guard covered by test).

## Test plan

- [x] RED test committed first (b2a99bf): asserts fallback happens for training-shaped metadata + summary, and that explicit metadata metrics take precedence.
- [x] GREEN after fix (773c40b) — all 26 `test_rules_extractors.py` tests pass, aggregation/accumulation suites still pass.
- [x] Full CI-equivalent sweep locally: `tests/` (2840 passed), `mlpstorage_py/tests` (834), `vdb_benchmark/tests` (174), `kv_cache_benchmark/tests` (238). No regressions.
- [ ] Reproducer from the issue: 6-invocation unet3d CLOSED run + `reports reportgen`, confirm `train_mean_of_au_percentage` now populated (hardware-gated).

Distinct from the #719/#720/#722/#730 warmup-detection fixes — different code path (loader vs aggregator), both required for training AU to reach `results.json`.