### PR TITLE
fix(#721): history rerun re-resolves orgname from historical --results-dir sentinel

### DIFF
--- a/mlpstorage_py/cli/utility_args.py
+++ b/mlpstorage_py/cli/utility_args.py
@@ -80,9 +80,12 @@ def add_history_arguments(parser):
         help="ID of the command to re-run"
     )
 
-    for _parser in [history, rerun]:
-        # D-10 / LAY-04: history subcommands are scoped per-systemname.
-        add_universal_arguments(_parser, req_results=True, req_systemname=True)
+    # Issue #721: history subcommands take no universal arguments. ``show``
+    # only reads ~/mlps_history; ``rerun`` replays the stored command line
+    # verbatim (--results-dir / --systemname / logging / etc. come from the
+    # stored command, not the rerun invocation). Any such flag on the rerun
+    # invocation would be misleading — argparse now rejects them with
+    # "unrecognized arguments".
 
 
 def add_version_arguments(parser):

--- a/mlpstorage_py/main.py
+++ b/mlpstorage_py/main.py
@@ -288,6 +288,53 @@ def run_benchmark(args, run_datetime):
     return ret_code
 
 
+def _apply_lay03_orgname_gate(args):
+    """LAY-03 orgname-resolution gate — pin ``args.orgname`` from the
+    ``<results_dir>/mlperf-results.yaml`` sentinel.
+
+    Extracted so ``history rerun`` can re-run the gate on the post-swap
+    args (issue #721): the pre-swap gate resolves against the rerun
+    invocation's results-dir, then ``args = new_args`` from
+    ``handle_history_command`` clobbers the resolved orgname. The
+    post-swap invocation of this helper resolves against the historical
+    command's results-dir — which is the dir the Benchmark actually
+    writes to.
+
+    The error message backticks are LOCKED VERBATIM per CONTEXT.md
+    LAY-03 / ROADMAP success criterion #2.
+    """
+    if args.mode in NON_BENCHMARK_NO_ORGNAME_MODES:
+        return
+    results_dir_value = getattr(args, 'results_dir', None)
+    if not results_dir_value:
+        return
+    try:
+        args.orgname = resolve_orgname(results_dir_value)
+    except ResultsDirNotInitializedError as e:
+        raise ConfigurationError(
+            f"results-dir `{results_dir_value}` has not been initialized.",
+            suggestion=f"Run `mlpstorage init <orgname> {results_dir_value}` first.",
+            code=ErrorCode.CONFIG_MISSING_REQUIRED,
+        ) from e
+    # WR-06: defense-in-depth re-validation. See historical inline
+    # comment (retained here for the invariants it enumerates):
+    #   * a future Pydantic-version bump that regresses to
+    #     non-anchored regex semantics,
+    #   * a switch to v1's ``regex=`` keyword (different match
+    #     semantics),
+    #   * any unit-test path that constructs args.orgname directly
+    #     without going through ``read_sentinel``.
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", args.orgname):
+        raise ConfigurationError(
+            f"sentinel orgname {args.orgname!r} contains invalid characters",
+            suggestion=(
+                "Re-initialize the results-dir with a clean orgname "
+                "(matches [A-Za-z0-9._-]+)."
+            ),
+            code=ErrorCode.CONFIG_INVALID_VALUE,
+        )
+
+
 def _main_impl():
     """
     Main implementation with error handling.
@@ -346,57 +393,19 @@ def _main_impl():
         from mlpstorage_py.submission_checker.tools.rules_coverage import run as run_rules_coverage
         return run_rules_coverage(args)
 
-    # ------------------------------------------------------------------ #
-    # LAY-03 orgname-resolution gate.
-    #
-    # Every gated mode that supplies `--results-dir` must have a valid
-    # `mlperf-results.yaml` sentinel in that directory; the gate reads the
-    # sentinel, pins `args.orgname` for downstream consumers (path generator,
-    # banner, benchmark base), and fails fast with the EXACT CONTEXT.md
-    # message when the sentinel is missing or malformed.
-    #
-    # The error message backticks are LOCKED VERBATIM per CONTEXT.md LAY-03
-    # / ROADMAP success criterion #2 — do NOT switch to single quotes (`!r`
-    # would render `'…'`) and do NOT add backslash escapes (the backtick is
-    # not a Python escape sequence; `\\`` produces `\` + backtick on screen).
-    # ------------------------------------------------------------------ #
-    if args.mode not in NON_BENCHMARK_NO_ORGNAME_MODES:
-        results_dir_value = getattr(args, 'results_dir', None)
-        if results_dir_value:
-            try:
-                args.orgname = resolve_orgname(results_dir_value)
-            except ResultsDirNotInitializedError as e:
-                raise ConfigurationError(
-                    f"results-dir `{results_dir_value}` has not been initialized.",
-                    suggestion=f"Run `mlpstorage init <orgname> {results_dir_value}` first.",
-                    code=ErrorCode.CONFIG_MISSING_REQUIRED,
-                ) from e
-            # WR-06: defense-in-depth re-validation at the gate. The schema
-            # (Pydantic v2) already full-match-validates the sentinel's
-            # ``orgname`` against ``[A-Za-z0-9._-]+`` on read, so a properly-
-            # written sentinel cannot reach here with a path separator or
-            # other unsafe character. But ``args.orgname`` lands in
-            # ``os.path.join(..., orgname, "results", ...)`` immediately
-            # downstream, so we want a paranoid post-resolution assertion
-            # that catches:
-            #   * a future Pydantic-version bump that regresses to
-            #     non-anchored regex semantics,
-            #   * a switch to v1's ``regex=`` keyword (which used different
-            #     match semantics),
-            #   * any unit-test path that constructs args.orgname directly
-            #     without going through ``read_sentinel``.
-            if not re.fullmatch(r"[A-Za-z0-9._-]+", args.orgname):
-                raise ConfigurationError(
-                    f"sentinel orgname {args.orgname!r} contains invalid characters",
-                    suggestion=(
-                        "Re-initialize the results-dir with a clean orgname "
-                        "(matches [A-Za-z0-9._-]+)."
-                    ),
-                    code=ErrorCode.CONFIG_INVALID_VALUE,
-                )
+    # LAY-03 orgname-resolution gate — resolve args.orgname from the
+    # <results_dir>/mlperf-results.yaml sentinel for every gated mode that
+    # supplies --results-dir. For history mode this pre-swap invocation is
+    # essentially a no-op (history subparsers no longer take --results-dir;
+    # see issue #721) — the real resolution happens post-swap below.
+    _apply_lay03_orgname_gate(args)
 
-    # Handle history command separately (now AFTER the gate so it inherits
-    # a resolved args.orgname when --results-dir is supplied; D-12).
+    # Handle history command separately. Issue #721: history subparsers no
+    # longer accept --results-dir / --systemname / logging flags (the rerun
+    # replays the stored command line verbatim). After the swap we re-run
+    # the LAY-03 gate against the *historical* command's results-dir — that
+    # is the dir the Benchmark will actually write to — and re-apply logging
+    # options from the (now-swapped) args.
     if args.mode == 'history':
         new_args = hist.handle_history_command(args)
 
@@ -406,14 +415,9 @@ def _main_impl():
             return new_args
 
         elif isinstance(new_args, object) and hasattr(new_args, 'mode'):
-            # Check if logging options have changed
-            if (hasattr(new_args, 'debug') and new_args.debug != args.debug) or \
-               (hasattr(new_args, 'verbose') and new_args.verbose != args.verbose) or \
-               (hasattr(new_args, 'stream_log_level') and new_args.stream_log_level != args.stream_log_level):
-                # Apply the new logging options
-                apply_logging_options(logger, new_args)
-
             args = new_args
+            apply_logging_options(logger, args)
+            _apply_lay03_orgname_gate(args)
         else:
             # If handle_history_command returned an exit code, return it
             return new_args

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -615,7 +615,14 @@ class TestAddReportsArguments:
 
 
 class TestAddHistoryArguments:
-    """Tests for add_history_arguments function."""
+    """Tests for add_history_arguments function.
+
+    Issue #721: history subcommands accept NO universal arguments.
+    ``show`` only reads ~/mlps_history; ``rerun`` replays the stored
+    command line verbatim (so --results-dir / --systemname / logging
+    flags on the rerun invocation would be misleading — argparse
+    rejects them).
+    """
 
     @pytest.fixture
     def parser(self):
@@ -626,28 +633,59 @@ class TestAddHistoryArguments:
 
     def test_show_subcommand_exists(self, parser):
         """History should have show subcommand."""
-        args = parser.parse_args(['show', '--results-dir', '/tmp',
-                                  '--systemname', 'sys-v1'])
+        args = parser.parse_args(['show'])
         assert args.command == 'show'
 
     def test_show_limit_argument(self, parser):
         """Show should accept --limit argument."""
-        args = parser.parse_args(['show', '--results-dir', '/tmp',
-                                  '--systemname', 'sys-v1', '--limit', '10'])
+        args = parser.parse_args(['show', '--limit', '10'])
         assert args.limit == 10
 
     def test_show_id_argument(self, parser):
         """Show should accept --id argument."""
-        args = parser.parse_args(['show', '--results-dir', '/tmp',
-                                  '--systemname', 'sys-v1', '--id', '5'])
+        args = parser.parse_args(['show', '--id', '5'])
         assert args.id == 5
 
     def test_rerun_subcommand_exists(self, parser):
         """History should have rerun subcommand."""
-        args = parser.parse_args(['rerun', '42', '--results-dir', '/tmp',
-                                  '--systemname', 'sys-v1'])
+        args = parser.parse_args(['rerun', '42'])
         assert args.command == 'rerun'
         assert args.rerun_id == 42
+
+    def test_show_rejects_results_dir(self, parser):
+        """Issue #721: ``history show --results-dir X`` is unrecognized."""
+        with pytest.raises(SystemExit):
+            parser.parse_args(['show', '--results-dir', '/tmp'])
+
+    def test_show_rejects_systemname(self, parser):
+        """Issue #721: ``history show --systemname X`` is unrecognized."""
+        with pytest.raises(SystemExit):
+            parser.parse_args(['show', '--systemname', 'sys-v1'])
+
+    def test_rerun_rejects_results_dir(self, parser):
+        """Issue #721: ``history rerun 6 --results-dir X`` is unrecognized.
+
+        The stored command line is the sole source of truth for
+        --results-dir on rerun; overriding it on the rerun invocation
+        was never respected, and the misleading UX drove issue #721.
+        """
+        with pytest.raises(SystemExit):
+            parser.parse_args(['rerun', '6', '--results-dir', '/tmp'])
+
+    def test_rerun_rejects_systemname(self, parser):
+        """Issue #721: ``history rerun 6 --systemname X`` is unrecognized."""
+        with pytest.raises(SystemExit):
+            parser.parse_args(['rerun', '6', '--systemname', 'sys-v1'])
+
+    def test_rerun_rejects_logging_flags(self, parser):
+        """Issue #721: rerun invocation cannot override logging.
+
+        The stored command's logging flags are re-applied post-swap;
+        any override on the rerun invocation was never used and is
+        now rejected as an unrecognized argument.
+        """
+        with pytest.raises(SystemExit):
+            parser.parse_args(['rerun', '6', '--debug'])
 
 
 class TestValidateArgs:
@@ -1050,10 +1088,11 @@ class TestParseArgumentsStoragePositional:
         assert not hasattr(args, "object")
 
     def test_history_does_not_need_storage_positional(self, monkeypatch, tmp_path):
-        """`history show` must parse cleanly (no storage positional)."""
-        args = self._run(monkeypatch, ["mlpstorage", "history", "show",
-                                        "--results-dir", str(tmp_path),
-                                        "--systemname", "sys-v1"])
+        """`history show` must parse cleanly (no storage positional).
+
+        Issue #721: history subcommands accept no universal arguments.
+        """
+        args = self._run(monkeypatch, ["mlpstorage", "history", "show"])
         assert args.mode == "history"
         assert args.command == "show"
         assert not hasattr(args, "file")

--- a/tests/unit/test_cli_parser.py
+++ b/tests/unit/test_cli_parser.py
@@ -92,7 +92,8 @@ class TestCLIStructureAndCombinations:
 
         # Utilities — top-level siblings, no mode prefix needed (they are their own mode)
         ("12", ['reports', 'reportgen', '-rd', '/tmp', '-sn', 'sys-v1'], 'reports', 'reportgen'),
-        ("13", ['history', 'show', '-rd', '/tmp', '-sn', 'sys-v1'], 'history', 'show'),
+        # Issue #721: history takes no universal arguments.
+        ("13", ['history', 'show'], 'history', 'show'),
         ("14", ['lockfile', 'generate', '-rd', '/tmp'], 'lockfile', 'generate'),
         ("15", ['lockfile', 'verify', '-rd', '/tmp'], 'lockfile', 'verify'),
     ])
@@ -362,9 +363,11 @@ class TestModeAndBenchmarkAttributes:
         assert not hasattr(args, 'benchmark')
 
     def test_history_sets_mode(self):
-        """history subcommand should set mode='history'."""
-        with patch('sys.argv', ['mlpstorage', 'history', 'show',
-                                '--results-dir', '/tmp', '--systemname', 'sys-v1']):
+        """history subcommand should set mode='history'.
+
+        Issue #721: history subcommands accept no universal arguments.
+        """
+        with patch('sys.argv', ['mlpstorage', 'history', 'show']):
             args = parse_arguments()
         assert args.mode == 'history'
         assert not hasattr(args, 'benchmark')
@@ -400,13 +403,18 @@ class TestSystemname:
 
     Per CONTEXT.md D-10, --systemname is required on every emitting subcommand:
     training {datagen, run, configview, datasize}, checkpointing {datagen, run,
-    configview, validate}, vectordb {datagen, run}, kvcache {run, datagen}, plus
-    history (show, rerun). ``reports reportgen`` accepts --systemname but does
-    NOT require it (omitting it aggregates a global summary across all systems
-    under the org's canonical ``results/`` folder).
+    configview, validate}, vectordb {datagen, run}, kvcache {run, datagen}.
+    ``reports reportgen`` accepts --systemname but does NOT require it (omitting
+    it aggregates a global summary across all systems under the org's canonical
+    ``results/`` folder).
 
     Pure utility commands (lockfile, version, init, rules-coverage) are exempt
     and continue to parse without --systemname.
+
+    Issue #721: history {show, rerun} accept NO universal arguments — ``show``
+    just prints ~/mlps_history; ``rerun`` replays the stored command line
+    verbatim so --results-dir / --systemname on the rerun invocation would be
+    misleading. Argparse rejects them.
     """
 
     # Sets of full argv (without --systemname) that should each accept the flag.
@@ -450,9 +458,8 @@ class TestSystemname:
         ('reports-reportgen', [
             'reports', 'reportgen', '--results-dir', '/r',
         ]),
-        ('history-show', [
-            'history', 'show', '--results-dir', '/r',
-        ]),
+        # Issue #721: history subcommands accept no universal arguments;
+        # ``history show --results-dir X --systemname Y`` is unrecognized.
     ]
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_main_orgname_gate.py
+++ b/tests/unit/test_main_orgname_gate.py
@@ -162,10 +162,12 @@ def test_failure_message_text(tmp_path):
                     "--num-processes", "1"]),
         # reports reportgen takes --results-dir + --systemname.
         ("reports", ["reports", "reportgen", "--systemname", "sys-v1"]),
-        # history show takes --results-dir + --systemname.
-        ("history", ["history", "show", "--systemname", "sys-v1"]),
+        # Issue #721: history subcommands no longer accept --results-dir on
+        # the CLI, so they can't reach the pre-swap LAY-03 gate. The
+        # post-swap gate on the historical command's --results-dir is
+        # covered by TestHistoryRerunOrgnameGate below.
     ],
-    ids=["closed", "open", "whatif", "reports", "history"],
+    ids=["closed", "open", "whatif", "reports"],
 )
 def test_gated_commands_fail_uninitialized(tmp_path, mode, extra_argv):
     """Every mode that takes ``--results-dir`` (per D-12 gated scope) must
@@ -489,14 +491,13 @@ def test_history_rerun_redispatches_bypass_mode(replayed_mode, tmp_path):
     from mlpstorage_py import main as main_mod
     from mlpstorage_py.config import EXIT_CODE
 
-    # Initial argv: history rerun with --results-dir (orgname gate fires
-    # only on the original args, which is fine — history is not bypassed).
+    # Initial argv: history rerun. Issue #721: history subparsers accept
+    # no universal arguments, so --results-dir / --systemname are supplied
+    # only via the *stored* command's replayed Namespace (the ``replayed``
+    # NS below). The pre-swap LAY-03 gate skips history because there's
+    # no args.results_dir; the post-swap gate honors the bypass mode.
     init_dir = _init_results_dir(tmp_path)
-    argv = [
-        "mlpstorage", "history", "rerun", "1",
-        "--results-dir", init_dir,
-        "--systemname", "sys-v1",
-    ]
+    argv = ["mlpstorage", "history", "rerun", "1"]
 
     # Build a replayed Namespace that lands in the requested bypass mode.
     # Keep the attributes minimal — only ``mode`` and the bare-minimum
@@ -544,3 +545,152 @@ def test_history_rerun_redispatches_bypass_mode(replayed_mode, tmp_path):
     mock_update_args.assert_not_called()
     mock_run_benchmark.assert_not_called()
     mock_print_summary.assert_not_called()
+
+
+# ---------------------------------------------------------------------------- #
+# Issue #721 — history rerun must re-resolve orgname from the *historical*     #
+# command's --results-dir sentinel after the args swap.                        #
+# ---------------------------------------------------------------------------- #
+
+
+class TestHistoryRerunOrgnameGate:
+    """Issue #721 regression tests for post-swap LAY-03 gate."""
+
+    def test_history_rerun_populates_orgname_from_historical_sentinel(self, tmp_path):
+        """The stored command's --results-dir sentinel drives orgname.
+
+        Pre-fix: LAY-03 ran only on the pre-swap args (which had no
+        --results-dir because the rerun subparser now rejects it), so
+        the swap left args.orgname unset and Benchmark.__init__ raised
+        E101 (issue #721). Post-fix: after args = new_args, LAY-03 is
+        re-run against new_args.results_dir and populates args.orgname
+        from the historical dir's sentinel.
+        """
+        from mlpstorage_py import main as main_mod
+
+        init_dir = _init_results_dir(tmp_path, orgname="Hammerspace")
+
+        # Simulate: user ran a benchmark that stored a training run against
+        # ``init_dir``. handle_history_command reparses that stored line —
+        # here we mock it to return the corresponding Namespace.
+        replayed = Namespace(
+            mode="closed",
+            benchmark="training",
+            command="run",
+            debug=False,
+            verbose=False,
+            stream_log_level="INFO",
+            quiet=False,
+            results_dir=init_dir,
+        )
+
+        argv = ["mlpstorage", "history", "rerun", "1"]
+
+        # Capture the args that flow past the gate. run_benchmark is patched
+        # so we don't need to construct a valid full benchmark Namespace.
+        captured = {}
+
+        def _capture_args(args, *_a, **_kw):
+            captured["orgname"] = getattr(args, "orgname", None)
+            captured["results_dir"] = getattr(args, "results_dir", None)
+            from mlpstorage_py.config import EXIT_CODE
+            return EXIT_CODE.SUCCESS
+
+        with patch.object(main_mod, "update_args"), \
+             patch.object(main_mod, "run_benchmark", side_effect=_capture_args), \
+             patch.object(main_mod, "validate_benchmark_environment"), \
+             patch("mlpstorage_py.run_summary.print_run_summary"), \
+             patch("mlpstorage_py.history.HistoryTracker.handle_history_command",
+                   return_value=replayed), \
+             patch("sys.argv", argv):
+            try:
+                main_mod._main_impl()
+            except SystemExit:
+                pass
+
+        assert captured.get("orgname") == "Hammerspace", (
+            f"post-swap LAY-03 gate did not resolve orgname from historical "
+            f"--results-dir sentinel; got {captured!r}"
+        )
+        assert captured.get("results_dir") == init_dir
+
+    def test_history_rerun_uninitialized_historical_dir_fails_lay03(self, tmp_path):
+        """Post-swap gate raises the standard LAY-03 error when the
+        historical --results-dir has no sentinel (mirrors the pre-swap
+        gate's contract on other modes)."""
+        from mlpstorage_py import main as main_mod
+        from mlpstorage_py.errors import ConfigurationError
+
+        uninit = tmp_path / "uninit"
+        uninit.mkdir()
+
+        replayed = Namespace(
+            mode="closed",
+            benchmark="training",
+            command="run",
+            debug=False,
+            verbose=False,
+            stream_log_level="INFO",
+            quiet=False,
+            results_dir=str(uninit),
+        )
+
+        argv = ["mlpstorage", "history", "rerun", "1"]
+
+        with patch.object(main_mod, "update_args"), \
+             patch.object(main_mod, "run_benchmark"), \
+             patch.object(main_mod, "validate_benchmark_environment"), \
+             patch("mlpstorage_py.run_summary.print_run_summary"), \
+             patch("mlpstorage_py.history.HistoryTracker.handle_history_command",
+                   return_value=replayed), \
+             patch("sys.argv", argv):
+            with pytest.raises(ConfigurationError) as excinfo:
+                main_mod._main_impl()
+
+        assert "has not been initialized" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "bypass_mode",
+        ["version", "lockfile", "rules-coverage", "init"],
+    )
+    def test_history_rerun_skips_post_swap_gate_for_bypass_modes(
+        self, bypass_mode, tmp_path,
+    ):
+        """Post-swap gate must respect the NON_BENCHMARK_NO_ORGNAME_MODES
+        skip set, so a replayed bypass entry never hits the sentinel gate
+        even if its results_dir is bogus / uninitialized.
+        """
+        from mlpstorage_py import main as main_mod
+        from mlpstorage_py.config import EXIT_CODE
+
+        uninit = tmp_path / "uninit"
+        uninit.mkdir()
+
+        replayed = Namespace(
+            mode=bypass_mode,
+            debug=False,
+            verbose=False,
+            stream_log_level="INFO",
+            quiet=False,
+            # Deliberately uninitialised — the gate would raise if it fired.
+            results_dir=str(uninit),
+        )
+
+        argv = ["mlpstorage", "history", "rerun", "1"]
+
+        with patch("mlpstorage_py.results_dir.init.run_init",
+                   return_value=EXIT_CODE.SUCCESS), \
+             patch.object(main_mod, "handle_lockfile_command",
+                          return_value=EXIT_CODE.SUCCESS), \
+             patch("mlpstorage_py.submission_checker.tools.rules_coverage.run",
+                   return_value=EXIT_CODE.SUCCESS, create=True), \
+             patch("mlpstorage_py.history.HistoryTracker.handle_history_command",
+                   return_value=replayed), \
+             patch("sys.argv", argv):
+            try:
+                main_mod._main_impl()
+            except SystemExit:
+                # version raises SystemExit(0); accept.
+                pass
+            # If the gate fired against uninit, this would raise
+            # ConfigurationError, which we would NOT catch here.


### PR DESCRIPTION
## Summary
Closes #721.

`mlpstorage history rerun N` failed with `[E101] orgname was not resolved before Benchmark instantiation` because the LAY-03 gate ran only on the pre-swap args. `handle_history_command` re-parses the stored command line into a fresh Namespace and `args = new_args` clobbered the resolved orgname. Downstream `Benchmark.__init__` then had no orgname to work with.

## Fix — two coordinated changes

### 1. CLI cleanup (`mlpstorage_py/cli/utility_args.py`)
`history show` and `history rerun` take **no universal arguments** anymore. Rationale:
- `show` only reads `~/mlps_history`.
- `rerun` replays the stored command line verbatim — `create_args_from_command` calls `parse_arguments()` on the stored tokens, so `--results-dir` / `--systemname` / `--debug` / logging flags on the rerun invocation were always consumed by argparse but discarded on the swap. Requiring them was misleading UX; accepting-then-discarding was worse.

Removing the `add_universal_arguments(_parser, req_results=True, req_systemname=True)` call from both subparsers makes argparse reject those flags naturally with `unrecognized arguments` (exit code 2).

### 2. Post-swap LAY-03 gate (`mlpstorage_py/main.py`)
Extract the LAY-03 gate into `_apply_lay03_orgname_gate(args)` and call it a second time on `new_args` after the history swap. The historical command's `--results-dir` is the dir the Benchmark actually writes to, so its sentinel is authoritative for orgname. The helper respects `NON_BENCHMARK_NO_ORGNAME_MODES` on both invocations, so replayed bypass entries (`version` / `lockfile` / `rules-coverage` / `init`) skip it — matching the pre-swap behavior.

Also drops the stale `main.py:410-414` "did rerun-invocation change logging vs historical?" comparison. With the CLI cleanup the rerun invocation can't override logging anyway, and the comparison would AttributeError against a post-strip pre-swap args namespace. Just re-apply `new_args`'s logging unconditionally.

## Test plan
- [x] New `TestHistoryRerunOrgnameGate` class in `test_main_orgname_gate.py`:
  - `test_history_rerun_populates_orgname_from_historical_sentinel` — direct #721 regression.
  - `test_history_rerun_uninitialized_historical_dir_fails_lay03` — post-swap gate raises the standard LAY-03 error on an uninitialized historical dir.
  - `test_history_rerun_skips_post_swap_gate_for_bypass_modes[version|lockfile|rules-coverage|init]` — bypass-mode skip set is respected on both invocations of the helper.
- [x] `TestAddHistoryArguments` in `test_cli.py` expanded with 5 rejection tests (--results-dir / --systemname / --debug variants on both show and rerun).
- [x] Existing parametrized tests updated to drop the retired `history-show --results-dir ... --systemname ...` entries.
- [x] Full CI matrix: `tests` (2755), `mlpstorage_py/tests` (834), `vdb_benchmark/tests` (174), `kv_cache_benchmark/tests` (238) → **4001 passed**, 0 failed.