### PR TITLE
fix(#725): stop migration from writing pointers into leaf subdirs + safety-net leaf pointer

### DIFF
--- a/mlpstorage_py/benchmarks/base.py
+++ b/mlpstorage_py/benchmarks/base.py
@@ -43,6 +43,7 @@ import types
 import uuid
 from argparse import Namespace
 from datetime import datetime
+from pathlib import Path
 from typing import Tuple, Dict, Any, List, Optional, Callable, Set, TYPE_CHECKING
 
 from functools import wraps
@@ -174,6 +175,22 @@ class Benchmark(BenchmarkInterface, abc.ABC):
 
         self.command_output_files = list()
         self.run_result_output = self._reserve_run_directory()
+
+        # #725 Bug 2 safety net: write the .mlps-code-image pointer to the
+        # ACTUAL reserved leaf. capture_or_verify_code_image already writes
+        # one at a leaf path derived from a shim namespace + DATETIME_STR,
+        # but the reported repro showed pool images with no referring leaf
+        # pointer — meaning the shim-based write either raised silently or
+        # targeted a path that diverged from self.run_result_output. This
+        # second write is guaranteed against the real leaf and is a no-op
+        # when args._validated_pool_hash is absent (unit tests that bypass
+        # capture, or non-submission modes gated off in capture at D-10).
+        pool_hash = getattr(self.args, '_validated_pool_hash', None)
+        if pool_hash:
+            from mlpstorage_py.submission_checker.tools.code_image import (
+                _write_pointer_atomic,
+            )
+            _write_pointer_atomic(Path(self.run_result_output), pool_hash, self.logger)
 
         # Code-image capture happens in ``mlpstorage_py/main.py`` (call to
         # ``capture_or_verify_code_image``) BEFORE ``Benchmark`` construction.

--- a/mlpstorage_py/submission_checker/tools/code_image.py
+++ b/mlpstorage_py/submission_checker/tools/code_image.py
@@ -1057,6 +1057,16 @@ def capture_or_verify_code_image(args, env, log):
         pool_dir = _capture_new_pool_image(org_root, source_root, live_hash, log)
         log.status(f"captured new pool image at {pool_dir}")
 
+    # #725 Bug 2 safety net: stash the live hash on args so Benchmark.__init__
+    # can re-write the pointer to the ACTUAL reserved leaf after
+    # _reserve_run_directory returns. The shim-based pointer write below
+    # computes its target via generate_output_location(shim), which can drift
+    # from Benchmark's own generate_output_location(self, self.run_datetime)
+    # under conditions we could not reproduce statically but that produce
+    # orphaned pool images in the field. Publishing the hash gives the
+    # benchmark base class a guaranteed leaf-write path.
+    args._validated_pool_hash = live_hash
+
     # Issue #716: ensure the .mlps-image-pool sentinel exists whenever a pool
     # image does. CHECK-04 D-91 hard-fails validation when pool dirs exist
     # without the sentinel. Deferred import breaks the code_image ↔
@@ -1112,9 +1122,13 @@ def capture_or_verify_code_image(args, env, log):
     except CodeImageError:
         raise
     except Exception as e:
-        # Non-fatal: pool image is on disk. Log and continue so the caller
-        # observes the successful capture even if the leaf-side plumbing
-        # (e.g. a stale test fixture without args.model) is incomplete.
-        log.debug("skipping pointer write (leaf computation failed: %s)", e)
+        # Non-fatal: pool image is on disk, and Benchmark.__init__ writes a
+        # second pointer to self.run_result_output as a safety net (#725
+        # Bug 2). Elevate from debug to warning so any recurrence is visible
+        # in normal-run output rather than hidden behind --debug.
+        log.warning(
+            "skipping capture-time pointer write (leaf computation failed: %s); "
+            "Benchmark.__init__ will write to the reserved leaf instead", e,
+        )
 
     return pool_dir

--- a/mlpstorage_py/submission_checker/tools/legacy_migration.py
+++ b/mlpstorage_py/submission_checker/tools/legacy_migration.py
@@ -25,6 +25,7 @@ Public API:
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -50,6 +51,15 @@ from mlpstorage_py.rules.utils import MLPSTORAGE_ORGNAME_ENVVAR
 
 # Authoritative "migration done" signal per D-72.
 _SENTINEL_FILENAME = ".mlps-image-pool"
+
+# Datetime-shaped run-leaf directory names: `YYYYMMDD_HHMMSS`. Mirrors
+# `_TIMESTAMP_RE` in submission_checker/checks/pool_structure_checks.py so
+# migration and CHECK-01 agree on what counts as a run leaf. Without this
+# filter the fixed-depth globs below match subdirectories of a leaf
+# (`dlio_config/`, `collector-staging/`, `.chk_iterations/`, ...), and
+# pointer files land inside `dlio_config/` — breaking the 2.1.15/2.1.20/
+# 2.1.26 exact-file-set checks (#725 Bug 1).
+_LEAF_NAME_RE = re.compile(r"^\d{8}_\d{6}$")
 
 
 @dataclass(frozen=True)
@@ -238,6 +248,12 @@ def _enumerate_run_leaves(subtree_root: Path, log) -> list[Path]:
     - Training/kv_cache (5-level): ``results/<sys>/<bench>/<model>/<cmd>/<dt>/``
     - Checkpointing (4-level): ``results/<sys>/checkpointing/<model>/<dt>/``
     - Vector_database (6-level): ``results/<sys>/<bench>/<eng>/<idx>/<cmd>/<dt>/``
+
+    Each yielded dir's basename must match ``YYYYMMDD_HHMMSS``. The globs
+    overlap between shapes (e.g. training's 5-level glob also matches
+    checkpointing subdirs like ``<dt>/dlio_config``), so an explicit
+    filename filter is required to keep pointer writes out of leaf
+    subdirectories (#725 Bug 1).
     """
     results = subtree_root / "results"
     if not results.is_dir():
@@ -246,18 +262,14 @@ def _enumerate_run_leaves(subtree_root: Path, log) -> list[Path]:
     leaves: list[Path] = []
     seen: set[Path] = set()
 
-    for p in results.glob("*/*/*/*/*"):
-        if p.is_dir() and p not in seen:
-            leaves.append(p)
-            seen.add(p)
-
-    for p in results.glob("*/*/*/*"):
-        if p.is_dir() and p not in seen and "checkpointing" in p.parts:
-            leaves.append(p)
-            seen.add(p)
-
-    for p in results.glob("*/*/*/*/*/*"):
-        if p.is_dir() and p not in seen:
+    for glob in ("*/*/*/*", "*/*/*/*/*", "*/*/*/*/*/*"):
+        for p in results.glob(glob):
+            if p in seen:
+                continue
+            if not _LEAF_NAME_RE.match(p.name):
+                continue
+            if not p.is_dir():
+                continue
             leaves.append(p)
             seen.add(p)
 

--- a/tests/integration/test_migration_flow.py
+++ b/tests/integration/test_migration_flow.py
@@ -224,6 +224,79 @@ class TestMigrateBenchmarkShapes:
             assert ptr.exists(), f"pointer missing in vector_database datetime leaf {leaf}"
 
 
+class TestMigrateLeafSubdirs:
+    """#725 Bug 1: migration must not drop pointers into leaf subdirectories.
+
+    Real DLIO run leaves contain ``dlio_config/``, ``collector-staging/``,
+    ``.chk_iterations/`` and similar subdirs. The migration's fixed-depth
+    globs overlap between benchmark shapes (training's 5-level glob also
+    matches checkpointing's ``<dt>/dlio_config``), and only a leaf-name
+    filter keeps pointer writes off those subdirectories. Without it,
+    2.1.15 / 2.1.20 / 2.1.26 fail on previously-valid submissions.
+    """
+
+    def test_training_leaf_subdirs_do_not_receive_pointer(
+        self, tmp_path, legacy_tree_factory, log
+    ):
+        """A training leaf's ``dlio_config/`` and ``collector-staging/`` must
+        NOT receive a ``.mlps-code-image`` pointer.
+        """
+        rd = legacy_tree_factory(
+            orgname="Acme", benchmark_shape="training", n_run_leaves=1
+        )
+        base = (
+            rd / "closed" / "Acme" / "results" / "sys1"
+            / "training" / "unet3d" / "run"
+        )
+        leaf = next(base.iterdir())
+        (leaf / "dlio_config").mkdir()
+        (leaf / "dlio_config" / "hydra.yaml").write_text("")
+        (leaf / "dlio_config" / "overrides.yaml").write_text("")
+        (leaf / "dlio_config" / "config.yaml").write_text("")
+        (leaf / "collector-staging").mkdir()
+
+        migrate_legacy_layout(rd, "Acme", log)
+
+        assert (leaf / ".mlps-code-image").exists(), (
+            "training leaf root must still receive a pointer"
+        )
+        assert not (leaf / "dlio_config" / ".mlps-code-image").exists(), (
+            "Bug 1: dlio_config/ must NOT receive a pointer (2.1.20 breaker)"
+        )
+        assert not (leaf / "collector-staging" / ".mlps-code-image").exists(), (
+            "Bug 1: collector-staging/ must NOT receive a pointer"
+        )
+
+    def test_checkpointing_leaf_subdirs_do_not_receive_pointer(
+        self, tmp_path, legacy_tree_factory, log
+    ):
+        """A checkpointing leaf's ``dlio_config/`` and ``collector-staging/``
+        must NOT receive a pointer (2.1.26 breaker in the reported repro).
+        """
+        rd = legacy_tree_factory(
+            orgname="Acme", benchmark_shape="checkpointing", n_run_leaves=1
+        )
+        base = (
+            rd / "closed" / "Acme" / "results" / "sys1"
+            / "checkpointing" / "llama3-8b"
+        )
+        leaf = next(base.iterdir())
+        (leaf / "dlio_config").mkdir()
+        (leaf / "collector-staging").mkdir()
+
+        migrate_legacy_layout(rd, "Acme", log)
+
+        assert (leaf / ".mlps-code-image").exists(), (
+            "checkpointing leaf root must still receive a pointer"
+        )
+        assert not (leaf / "dlio_config" / ".mlps-code-image").exists(), (
+            "Bug 1: dlio_config/ must NOT receive a pointer (2.1.26 breaker)"
+        )
+        assert not (leaf / "collector-staging" / ".mlps-code-image").exists(), (
+            "Bug 1: collector-staging/ must NOT receive a pointer"
+        )
+
+
 class TestMigrateEmptyRunLeaves:
     """Edge cases for trees with zero or absent run-leaf dirs."""
 

--- a/tests/integration/test_pointer_safety_net.py
+++ b/tests/integration/test_pointer_safety_net.py
@@ -1,0 +1,136 @@
+"""#725 Bug 2 safety-net: Benchmark.__init__ writes .mlps-code-image to the
+ACTUAL reserved leaf.
+
+Field report showed a completed checkpointing run whose reserved leaf held
+no ``.mlps-code-image`` pointer, so CHECK-01/CHECK-03 flagged the fresh pool
+image as orphaned. The capture-time pointer write inside
+``capture_or_verify_code_image`` targets a leaf computed via a
+``SimpleNamespace`` shim + ``DATETIME_STR`` — a path that can diverge from
+Benchmark's own ``generate_output_location(self, self.run_datetime)`` under
+conditions the static repro could not surface. The fix stashes
+``args._validated_pool_hash`` during capture and has ``Benchmark.__init__``
+re-emit the pointer at ``self.run_result_output`` after
+``_reserve_run_directory`` returns.
+
+These tests bypass ``capture_or_verify_code_image`` entirely — they set
+``args._validated_pool_hash`` directly and instantiate a Benchmark subclass.
+Without the safety net the reserved leaf holds no pointer (RED).
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.fixtures.sample_data import create_sample_benchmark_args
+
+
+_LIVE_HASH = "0123456789abcdef0123456789abcdef"
+
+
+@pytest.fixture(autouse=True)
+def _bypass_capacity_gate():
+    with patch(
+        "mlpstorage_py.benchmarks.base.Benchmark._pre_execution_gate",
+        return_value=None,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _mock_cluster_information():
+    with patch("mlpstorage_py.benchmarks.base.ClusterInformation") as mock_ci:
+        mock_ci.return_value = MagicMock()
+        mock_ci.return_value.total_memory_bytes = 256 * 1024**3
+        mock_ci.return_value.host_info_list = []
+        yield mock_ci
+
+
+def _training_args(tmp_path):
+    args = create_sample_benchmark_args(
+        benchmark_type="training",
+        command="run",
+        model="unet3d",
+        accelerator_type="h100",
+        num_accelerators=8,
+        client_host_memory_in_gb=256,
+        hosts=["127.0.0.1"],
+        data_dir=str(tmp_path / "data"),
+    )
+    args.mode = "closed"
+    args.results_dir = str(tmp_path / "results")
+    args.dry_run = True
+    args.what_if = False
+    return args
+
+
+class TestPointerSafetyNet:
+    """Benchmark.__init__ writes the pointer to the actual reserved leaf."""
+
+    def test_reserved_leaf_receives_pointer_from_stashed_hash(self, tmp_path):
+        """With ``args._validated_pool_hash`` set (as capture stashes it),
+        the reserved leaf must hold ``.mlps-code-image`` on return from
+        ``Benchmark.__init__`` — even when capture's own shim-based write
+        never fires.
+        """
+        (tmp_path / "results").mkdir()
+        args = _training_args(tmp_path)
+        args._validated_pool_hash = _LIVE_HASH
+
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        try:
+            benchmark = TrainingBenchmark(args, logger=MagicMock())
+        except BaseException:
+            # Downstream init may raise for unrelated reasons in a
+            # test-only environment (no MPI, no datagen tree). What
+            # matters is whether the pointer landed before that raise.
+            reserved = None
+            for root, _dirs, files in os.walk(tmp_path / "results"):
+                if ".mlps-code-image" in files:
+                    reserved = root
+                    break
+            assert reserved is not None, (
+                "no .mlps-code-image pointer under results/ after "
+                "Benchmark.__init__ raised"
+            )
+            return
+
+        pointer = os.path.join(benchmark.run_result_output, ".mlps-code-image")
+        assert os.path.isfile(pointer), (
+            f".mlps-code-image missing at reserved leaf "
+            f"{benchmark.run_result_output!r} — safety net did not fire"
+        )
+        content = open(pointer).read().strip()
+        assert content == f"md5-tree-v2:{_LIVE_HASH}", (
+            f"pointer content mismatch: {content!r}"
+        )
+
+    def test_missing_stashed_hash_leaves_pointer_absent(self, tmp_path):
+        """When ``args._validated_pool_hash`` is unset (unit-test paths,
+        non-submission modes gated off in capture at D-10), Benchmark
+        must not synthesize a pointer. The safety net is opt-in.
+        """
+        (tmp_path / "results").mkdir()
+        args = _training_args(tmp_path)
+        # NOTE: no _validated_pool_hash
+
+        from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+        try:
+            benchmark = TrainingBenchmark(args, logger=MagicMock())
+            leaf = benchmark.run_result_output
+        except BaseException:
+            # Downstream init may fail before we reach the assertion —
+            # in that case just confirm no pointer appeared anywhere.
+            for root, _dirs, files in os.walk(tmp_path / "results"):
+                assert ".mlps-code-image" not in files, (
+                    f"pointer written at {root!r} without stashed hash"
+                )
+            return
+
+        pointer = os.path.join(leaf, ".mlps-code-image")
+        assert not os.path.exists(pointer), (
+            f"pointer must not appear without _validated_pool_hash: {pointer}"
+        )


### PR DESCRIPTION
## Summary

Fixes the two coupled bugs from #725 in the content-addressed code-image pool shipped by #710.

**Bug 1** — migration wrote `.mlps-code-image` into `<leaf>/dlio_config/`, `<leaf>/collector-staging/`, etc. The fixed-depth globs in `_enumerate_run_leaves` overlap between benchmark shapes: training's 5-level glob matches checkpointing's `<dt>/dlio_config`, and the vector_database 6-level glob does the same for training's leaf subdirs. Once migration ran, 2.1.15 / 2.1.20 / 2.1.26 rejected the extra file inside `dlio_config/` and marked previously-valid submissions broken.

Constrain leaf enumeration to dirs whose basename matches `YYYYMMDD_HHMMSS` — the same shape CHECK-01's `_iter_datetime_leaves` uses to identify run leaves during validation. Also drops the now-redundant `"checkpointing in parts"` filter: any dir named `YYYYMMDD_HHMMSS` at depths 4–6 is a real leaf regardless of the segment before it.

**Bug 2** — a completed CLOSED checkpointing run's reserved leaf contained no pointer, so CHECK-01 / CHECK-03 flagged the new pool image as orphan. `capture_or_verify_code_image` writes `.mlps-code-image` via a `SimpleNamespace` shim + `DATETIME_STR`; that path can drift from Benchmark's own `generate_output_location(self, self.run_datetime)`, and any exception is swallowed at `log.debug` — invisible during a normal run.

Stash `args._validated_pool_hash` during capture and re-emit the pointer from `Benchmark.__init__` against `self.run_result_output` after `_reserve_run_directory` returns. The safety-net write hits the actual reserved leaf regardless of any shim-path divergence and is idempotent with capture's write on the happy path. Also elevate capture's silent-debug swallow to a `log.warning` so future recurrence is visible.

## Test plan

- [x] RED tests committed first for both bugs (leaf-subdir pointer isolation for Bug 1, direct `Benchmark.__init__` wiring for Bug 2)
- [x] `TestMigrateLeafSubdirs` plants realistic `dlio_config/` + `collector-staging/` under both training and checkpointing leaves; asserts no pointer lands in them
- [x] `TestPointerSafetyNet` bypasses capture, sets `_validated_pool_hash` directly, instantiates `TrainingBenchmark`, asserts pointer at `benchmark.run_result_output`; second test locks the opt-in (no hash → no pointer)
- [x] Full CI matrix run locally in parallel: 4088 passed, 1 skipped, 15 deselected
    - `tests/` — 2842 passed
    - `mlpstorage_py/tests` — 834 passed
    - `vdb_benchmark/tests` — 174 passed
    - `kv_cache_benchmark/tests` — 238 passed

Closes #725.