### PR TITLE
feat(validation): --skip-ssh-check + auto-skip SSH preflight for PALS/Slurm launchers

### DIFF
--- a/mlpstorage_py/cli/common_args.py
+++ b/mlpstorage_py/cli/common_args.py
@@ -321,6 +321,17 @@ def add_universal_arguments(parser, req_results, req_systemname=False):
         help="Skip environment validation (MPI, SSH, DLIO checks). Useful for debugging.",
     )
     validation_args.add_argument(
+        "--skip-ssh-check",
+        action="store_true",
+        help=(
+            "Skip only the SSH connectivity preflight to remote hosts. Use for "
+            "scheduler-launched runs (HPE/Cray PALS 'mpiexec', Slurm 'srun') "
+            "where ranks are spawned by the batch daemon rather than over SSH. "
+            "Unlike --skip-validation, all other checks (MPI/DLIO dependencies, "
+            "filesystem separation, paths) still run."
+        ),
+    )
+    validation_args.add_argument(
         "--skip-fs-separation-gate",
         action="store_true",
         help=(

--- a/mlpstorage_py/main.py
+++ b/mlpstorage_py/main.py
@@ -213,7 +213,10 @@ def run_benchmark(args, run_datetime):
             logger=logger
         ) as (update, set_desc):
             # Errors from validation will propagate after progress cleanup
-            validate_benchmark_environment(args, logger=logger)
+            validate_benchmark_environment(
+                args, logger=logger,
+                skip_remote_checks=getattr(args, 'skip_ssh_check', False),
+            )
     else:
         logger.warning("Skipping environment validation (--skip-validation flag)")
 

--- a/mlpstorage_py/tests/test_validation_ssh_skip.py
+++ b/mlpstorage_py/tests/test_validation_ssh_skip.py
@@ -1,0 +1,53 @@
+"""Tests for the SSH-connectivity preflight bypass.
+
+The SSH reachability probe in ``validate_benchmark_environment`` is only a
+prerequisite for SSH-bootstrapped MPI. Scheduler launchers (HPE/Cray PALS
+``mpiexec``, Slurm ``srun``) spawn ranks via the batch daemon, so the probe
+must be bypassable — both automatically (launcher/env detection) and via the
+``--skip-ssh-check`` flag (``skip_remote_checks``).
+"""
+import types
+
+from mlpstorage_py.validation_helpers import _launcher_bypasses_ssh
+
+
+def _args(**kw):
+    return types.SimpleNamespace(**kw)
+
+
+def test_srun_under_slurm_bypasses(monkeypatch):
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+    assert _launcher_bypasses_ssh(_args(mpi_bin="srun")) is True
+
+
+def test_pals_mpiexec_bypasses(monkeypatch):
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.setenv("PALS_NODEFILE", "/var/spool/pals/nodes")
+    # Full path is fine — only the basename matters.
+    assert _launcher_bypasses_ssh(_args(mpi_bin="/opt/cray/pals/1.8/bin/mpiexec")) is True
+
+
+def test_plain_mpirun_still_uses_ssh(monkeypatch):
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.delenv("PALS_NODEFILE", raising=False)
+    assert _launcher_bypasses_ssh(_args(mpi_bin="mpirun")) is False
+
+
+def test_hydra_mpiexec_without_pals_still_uses_ssh(monkeypatch):
+    # MPICH-Hydra mpiexec on a generic cluster bootstraps over SSH by default;
+    # without PALS_* env we must NOT bypass.
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.delenv("PALS_NODEFILE", raising=False)
+    assert _launcher_bypasses_ssh(_args(mpi_bin="mpiexec")) is False
+
+
+def test_srun_without_slurm_env_does_not_bypass(monkeypatch):
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.delenv("PALS_NODEFILE", raising=False)
+    assert _launcher_bypasses_ssh(_args(mpi_bin="srun")) is False
+
+
+def test_missing_mpi_bin_does_not_bypass(monkeypatch):
+    monkeypatch.setenv("PALS_NODEFILE", "/var/spool/pals/nodes")
+    # No mpi_bin attribute at all -> safe default (do not bypass).
+    assert _launcher_bypasses_ssh(_args()) is False

--- a/mlpstorage_py/validation_helpers.py
+++ b/mlpstorage_py/validation_helpers.py
@@ -515,6 +515,25 @@ def _is_distributed_run(args) -> bool:
     return False
 
 
+def _launcher_bypasses_ssh(args) -> bool:
+    """True when the configured MPI launcher spawns ranks via a batch-scheduler
+    daemon rather than SSH, so SSH reachability is not a prerequisite.
+
+    Recognized conservatively — only inside the matching allocation, so a
+    generic-cluster ``mpirun`` / MPICH-Hydra ``mpiexec`` (which bootstrap over
+    SSH by default) still trigger the SSH preflight:
+
+      * Slurm ``srun``            when ``SLURM_JOB_ID`` is set
+      * HPE/Cray PALS ``mpiexec`` when ``PALS_*`` env vars are present
+    """
+    launcher = os.path.basename((getattr(args, 'mpi_bin', '') or '').strip())
+    if launcher == 'srun' and os.environ.get('SLURM_JOB_ID'):
+        return True
+    if launcher == 'mpiexec' and any(k.startswith('PALS_') for k in os.environ):
+        return True
+    return False
+
+
 def _requires_dlio(args) -> bool:
     """
     Determine if DLIO benchmark is required.
@@ -603,8 +622,11 @@ def validate_benchmark_environment(
                 logger.debug(f"DLIO check failed: {e}")
             issues.append(e)
 
-    # Check SSH connectivity for distributed runs (unless skipped)
-    if _is_distributed_run(args) and not skip_remote_checks:
+    # Check SSH connectivity for distributed runs (unless skipped, or the MPI
+    # launcher does not bootstrap ranks over SSH — e.g. PALS mpiexec / Slurm
+    # srun spawn via the batch daemon, so SSH reachability is irrelevant).
+    if _is_distributed_run(args) and not skip_remote_checks \
+            and not _launcher_bypasses_ssh(args):
         hosts = getattr(args, 'hosts', [])
         if hosts:
             if logger:
@@ -635,6 +657,13 @@ def validate_benchmark_environment(
                 if logger:
                     logger.debug(f"SSH check failed: {e}")
                 issues.append(e)
+    elif _is_distributed_run(args):
+        if logger:
+            logger.info(
+                "Skipping SSH connectivity preflight: MPI launcher does not "
+                "bootstrap ranks over SSH (scheduler launcher), or "
+                "--skip-ssh-check was set."
+            )
 
     # Issue #447: warn (don't fail) when systemd-logind RemoveIPC=yes could
     # reap POSIX semaphores out from under the benchmark's spawn workers.


### PR DESCRIPTION
## Problem

`mlpstorage`'s fail-fast environment preflight runs an **SSH connectivity probe** for every multi-host run:

```python
# mlpstorage_py/validation_helpers.py
if _is_distributed_run(args) and not skip_remote_checks:
    ssh_results = validate_ssh_connectivity(hosts)   # ssh <host> hostname
    ...
    issues.append(ValidationIssue(severity='error', ...))  # -> propagates, aborts run
```

But the benchmark does **not** launch ranks over SSH. With `--exec-type mpi --mpi-bin mpiexec` on **HPE/Cray PALS** (e.g. ALCF Aurora/Polaris/Crux) ranks are spawned by `palsd` from the batch allocation; with `srun` on **Slurm**, by `slurmstepd`. On these systems passwordless SSH between compute nodes is frequently disabled by site policy, so a **valid** distributed run is aborted by a probe for a transport it never uses.

Today the only escape is the blanket `--skip-validation`, which *also* drops the CAP-02 shared-FS probe and every dependency/path check. Users who want a properly validated run should not have to disable *all* validation to dodge an irrelevant SSH check.

Note: `validate_benchmark_environment` already has a `skip_remote_checks` parameter gating this block — it was simply never wired to the CLI.

## Fix

1. **`--skip-ssh-check`** — skips *only* the SSH probe (wires the existing `skip_remote_checks`). Unlike `--skip-validation`, the MPI/DLIO dependency, filesystem-separation, and path checks still run.
2. **Auto-skip** when a non-SSH scheduler launcher is detected: `srun` + `SLURM_JOB_ID`, or `mpiexec` + `PALS_*` env vars. Logged at INFO.
3. Unit tests for the detection logic (`_launcher_bypasses_ssh`).

Conservative by design: plain `mpirun` and generic MPICH-Hydra `mpiexec` (which bootstrap over SSH by default) **still** probe SSH — the bypass only triggers inside a PALS/Slurm allocation whose launcher provably does not use SSH.

## Backward compatibility

Default behavior unchanged: without the flag and without PALS/Slurm env, the SSH preflight runs exactly as before.

## Related

Same class of "PALS is not SSH-bootstrapped" fix as #549 (launcher) and #564 (cluster_collector).
