### PR TITLE
docs(training): drop retired --open/--closed/--loops CLI flags from README

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -26,9 +26,23 @@ The benchmark execution process requires these steps:
 2. Datagen - Generate the required dataset
 3. Run - Execute the benchmark
 
+> **Note — CLI shape (v3.0):** The current command line uses positional arguments for
+> submission mode, model, and storage type. The general shape is:
+>
+> ```
+> mlpstorage <closed|open|whatif> training <model> <command> [file|object] [OPTIONS]
+> ```
+>
+> The `--open`, `--closed`, and `--loops` flags that appear in some historical
+> help snippets below have all been retired and no longer exist. Use the leading
+> positional mode instead (`mlpstorage closed training …`, `mlpstorage open
+> training …`, `mlpstorage whatif training …`). Run `mlpstorage -h` and
+> `mlpstorage closed training -h` for the authoritative current help; the pasted
+> help blocks below are being refreshed and may otherwise lag the real CLI.
+
 ```bash
 [root@localhost ]# mlpstorage training --help
-usage: mlpstorage training [-h] [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug] [--verbose]
+usage: mlpstorage training [-h] [--results-dir RESULTS_DIR] [--debug] [--verbose]
                            [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params] [--what-if]
                            {datasize,datagen,run,configview} ...
 
@@ -49,9 +63,6 @@ optional arguments:
 Standard Arguments:
   --results-dir RESULTS_DIR, -rd RESULTS_DIR
                         Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
 
 Output Control:
   --debug               Enable debug mode
@@ -86,7 +97,7 @@ usage: mlpstorage training datasize [-h] [--hosts HOSTS [HOSTS ...]] --model {Un
                                     --max-accelerators MAX_ACCELERATORS --accelerator-type {b200,mi355}
                                     --num-client-hosts NUM_CLIENT_HOSTS [--data-dir DATA_DIR]
                                     [--params PARAMS [PARAMS ...]]
-                                    [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug]
+                                    [--results-dir RESULTS_DIR] [--debug]
                                     [--verbose] [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params]
                                     [--what-if]
 
@@ -132,9 +143,6 @@ MPI:
 Standard Arguments:
   --results-dir RESULTS_DIR, -rd RESULTS_DIR
                         Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
 
 Output Control:
   --debug               Enable debug mode
@@ -163,7 +171,7 @@ usage: mlpstorage training datagen [-h] [--hosts HOSTS [HOSTS ...]] --model {une
                                    [--exec-type {mpi,docker}] [--mpi-bin {mpirun,mpiexec}] [--oversubscribe]
                                    [--allow-run-as-root] --num-processes NUM_PROCESSES [--data-dir DATA_DIR]
                                    [--ssh-username SSH_USERNAME] [--params PARAMS [PARAMS ...]]
-                                   [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug]
+                                   [--results-dir RESULTS_DIR] [--debug]
                                    [--verbose] [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params]
                                    [--what-if]
 
@@ -199,9 +207,6 @@ MPI:
 Standard Arguments:
   --results-dir RESULTS_DIR, -rd RESULTS_DIR
                         Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
 
 Output Control:
   --debug               Enable debug mode
@@ -231,7 +236,7 @@ usage: mlpstorage training run [-h] [--hosts HOSTS [HOSTS ...]] --model {unet3d,
                                [--mpi-bin {mpirun,mpiexec}] [--oversubscribe] [--allow-run-as-root] --num-accelerators
                                NUM_ACCELERATORS --accelerator-type {b200,mi355} --num-client-hosts NUM_CLIENT_HOSTS
                                [--data-dir DATA_DIR] [--ssh-username SSH_USERNAME] [--params PARAMS [PARAMS ...]]
-                               [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug] [--verbose]
+                               [--results-dir RESULTS_DIR] [--debug] [--verbose]
                                [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params] [--what-if]
 
 optional arguments:
@@ -276,9 +281,6 @@ MPI:
 Standard Arguments:
   --results-dir RESULTS_DIR, -rd RESULTS_DIR
                         Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
 
 Output Control:
   --debug               Enable debug mode
@@ -305,7 +307,7 @@ mlpstorage training run --hosts 10.117.61.121,10.117.61.165 --num-client-hosts 2
 ```bash
 # TODO: Update
 [root@localhost]# mlpstorage reports --help
-usage: mlpstorage reports [-h] [--results-dir RESULTS_DIR] [--loops LOOPS] [--open | --closed] [--debug] [--verbose]
+usage: mlpstorage reports [-h] [--results-dir RESULTS_DIR] [--debug] [--verbose]
                           [--stream-log-level STREAM_LOG_LEVEL] [--allow-invalid-params] [--what-if]
                           {reportgen} ...
 
@@ -319,9 +321,6 @@ optional arguments:
 Standard Arguments:
   --results-dir RESULTS_DIR, -rd RESULTS_DIR
                         Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
 
 Output Control:
   --debug               Enable debug mode
@@ -338,8 +337,7 @@ To generate the benchmark report,
 
 ```bash
 [root@localhost]# mlpstorage reports reportgen --help
-usage: mlpstorage reports reportgen [-h] [--output-dir OUTPUT_DIR] [--results-dir RESULTS_DIR] [--loops LOOPS]
-                                    [--open | --closed] [--debug] [--verbose] [--stream-log-level STREAM_LOG_LEVEL]
+usage: mlpstorage reports reportgen [-h] [--output-dir OUTPUT_DIR] [--results-dir RESULTS_DIR]                                    [--debug] [--verbose] [--stream-log-level STREAM_LOG_LEVEL]
                                     [--allow-invalid-params] [--what-if]
 
 optional arguments:
@@ -350,9 +348,6 @@ optional arguments:
 Standard Arguments:
   --results-dir RESULTS_DIR, -rd RESULTS_DIR
                         Directory where the benchmark results will be saved.
-  --loops LOOPS         Number of times to run the benchmark
-  --open                Run as an open submission
-  --closed              Run as a closed submission
 
 Output Control:
   --debug               Enable debug mode


### PR DESCRIPTION
## Problem

`training/README.md` still documents three CLI flags that no longer exist:

- `--open` and `--closed` — retired in PR #412 in favor of a leading positional submission mode (`closed | open | whatif`).
- `--loops` — since retired as a user-facing option.

Anyone (human or model) reading this README today sees pasted `--help` blocks whose synopsis lines will fail at argparse the moment they try to run them. It also propagates the wrong mental model of the CLI shape into downstream copy-paste.

## Fix

- Add a **CLI shape (v3.0)** Note near the top of the Usage section explaining the current positional structure and pointing readers to `mlpstorage -h` / `mlpstorage closed training -h` as the authoritative source.
- Strip `[--open | --closed]` and `[--loops LOOPS]` from all six pasted `usage:` synopsis lines (top-level `training`, `datasize`, `datagen`, `run`, `reports`, `reportgen`).
- Remove the corresponding `--open` / `--closed` / `--loops` entries from all five "Standard Arguments" blocks.

## Out of scope (deliberately)

- The remaining pasted help blocks still lag the real CLI in other ways: no positional mode, no positional `model`, no `file|object` selector, `--model` shown as a flag. The new Note flags this and points readers to `mlpstorage -h`; a full refresh of the pasted help blocks is a bigger PR.
- Example commands in `tests/*.md` and `tests/object-store/*.sh` that use `--open`.
- The `### CLOSED` / `### OPEN` parameter tables and Theory of Operations section describe **submission divisions**, not CLI flags — those are unchanged.

## Verification

```bash
grep -n -- "--open\|--closed\|--loops" training/README.md
```
Only the deliberate Note callout still mentions the retired flag names — nothing in the pasted synopsis or options blocks.