### PR TITLE
chore(storage#715,storage#701): bump s3dlio floor 0.9.106 -> 0.9.110; bump 3.0.38 -> 3.0.39

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.38"
+version = "3.0.39"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -23,7 +23,7 @@ dependencies = [
     "minio>=7.2.20",
     "s3torchconnector>=1.5.0",
     "python-dotenv>=1.0.0",
-    "s3dlio>=0.9.106",
+    "s3dlio>=0.9.110",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.38"
+version = "3.0.39"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -616,7 +616,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'vectordb-milvus'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'vectordb-pgvector'", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "s3dlio", specifier = ">=0.9.106" },
+    { name = "s3dlio", specifier = ">=0.9.110" },
     { name = "s3torchconnector", specifier = ">=1.5.0" },
     { name = "tabulate", marker = "extra == 'vectordb'", specifier = ">=0.9" },
     { name = "tabulate", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=0.9" },
@@ -1202,15 +1202,15 @@ wheels = [
 
 [[package]]
 name = "s3dlio"
-version = "0.9.106"
+version = "0.9.110"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", marker = "sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/b8/5db92b8687fd6f7a7535c07f3956cf5d469ed4d84a3f15405982e67bb0dd/s3dlio-0.9.106.tar.gz", hash = "sha256:d991b9113813950bd23cebc7ceb03f7dfb0f36fe3704957256f2171b2b5484d9", size = 1599795, upload-time = "2026-07-01T03:27:35.304Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/e7/db4ce2f660a85f2a74b2c1734eaa86519f9ad3ae7575562f1874f62850f6/s3dlio-0.9.110.tar.gz", hash = "sha256:63f7665b8e6816fecce9c8e20ab4e95a93ac0c784ddbbdf222917d808683f575", size = 1783920, upload-time = "2026-07-09T03:50:52.78Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/43/e5f2aa8948db6c77289c55fdab616c2ad942d3a35e680c1f85ea5443fd0e/s3dlio-0.9.106-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a0c129a84761a46e27b0c15faf7725c9795551f3a81e9cf402c4ea4336c11c6", size = 12412558, upload-time = "2026-07-01T03:27:26.375Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/4d/94553e72ffd42441c7e4bf24ede1bbc1caa8af58a9019f35e13e9d742b82/s3dlio-0.9.106-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2202d5b6fa0c80b3c0c19819921432259c15abb9110438bddc4501a80ca7aee", size = 12834880, upload-time = "2026-07-01T03:27:28.761Z" },
+    { url = "https://files.pythonhosted.org/packages/37/73/bbdeeb03ec9ea8700c7092be3d31ddac75548b1d32e04ac7dec67b61bf30/s3dlio-0.9.110-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:321ad82e49b45fba51d2105ca2fc18b14b30dcc557ea8f300a64c753578f838c", size = 12466650, upload-time = "2026-07-09T03:50:44.54Z" },
+    { url = "https://files.pythonhosted.org/packages/31/7c/6905d1e7af9402b9aa9ebdd63446b03a04d545941b7e4faba0dd8b688a12/s3dlio-0.9.110-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ea8913ab6aca32b8f4143a23b3383151b3574ef3e2f585a5638cf3297283e3b", size = 12877434, upload-time = "2026-07-09T03:50:46.436Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps mlp-storage's own `s3dlio` dependency floor from `>=0.9.106` to `>=0.9.110`, picking up the [v0.9.109 + v0.9.110 audit-fix release chain](https://github.com/russfellows/s3dlio/releases/tag/v0.9.110) (russfellows/s3dlio#151–#157, 39 bug fixes across Phases A–F). Two directly affect submitters using this repo:

- **#715** — DLIO's s3dlio-backed adapter (`S3dlioStorage`, inside the s3dlio wheel itself) hardcoded a 32 MiB multipart threshold with no env-var override, unlike the sibling `ObjStoreLibStorage` adapter. s3dlio v0.9.110 wires `S3DLIO_MULTIPART_THRESHOLD_MB` / `_PART_SIZE_MB` / `_MAX_IN_FLIGHT` / `DISABLE_MULTIPART` through that adapter too. **Already closed** on this repo (referencing the `DLIO_local_changes` bucket-1 merge) — not re-closed by this PR, since GitHub's closing keywords are a no-op on an already-closed issue. This PR is what actually makes that fix reachable from `mlp-storage`'s own installed dependency graph, not just from `DLIO_local_changes`.
- **#701** — s3dlio's per-process GET throughput wall (~1.1 GB/s, flat regardless of prefetch depth) on unet3d-style object-storage reads. Fixed in s3dlio v0.9.108 (spawn-per-fetch loader, HTTP/1.1 default, zero-copy range assembly, streaming connector) and unchanged since — this bump brings the floor into range so a fresh `uv sync` actually resolves to a fixed version rather than relying on the absence of an upper bound.

Closes #701

Also bumps the package version `3.0.38` → `3.0.39` per repo convention (every merged change increments it — see e.g. `75414e4` for the precedent of a same-shaped s3dlio-floor + version-bump commit).

## What this PR intentionally does NOT touch

- **The `dlio-benchmark` git-rev pin** (`24b13d76...`) — unchanged. Neither `#715` nor `#701`'s fix touches `DLIO_local_changes`' own code; both live entirely inside the s3dlio wheel. The rev pin only matters for `#626` (the object-storage/local-FS concurrency-parity work), which is tracked separately — bucket 1 merged into `DLIO_local_changes`, bucket 2 is still in WG review.
- **`BugsFixedInVersions.md`** — no entry added. This is a dependency-floor bump with no behavior change in `mlp-storage`'s own code; it doesn't fit any of that doc's three stated categories (Score-Affecting / Invocation / Other Significant), and the git history pattern shows such entries typically land later in dedicated docs passes (e.g. `#739` for v3.0.38) rather than in the version-bumping commit itself. Happy to add one if that's not the right read.
- **`tests/unit/test_mpu_retry.py`** — found this untracked in the working tree while preparing this PR. It's a well-constructed 12-test suite, but it tests `dlio_benchmark.storage.obj_store_lib.ObjStoreLibStorage._mpu_upload_with_retry` — a `DLIO_local_changes` internal method, not `mlp-storage`'s own code. Left out of this PR; the right home for it is `DLIO_local_changes`' own test suite (which currently has thinner coverage of that method's retry/abort/backoff mechanics than this file does) — will follow up there separately.

## Verification

```
$ uv lock
Resolved 108 packages in 648ms
Updated s3dlio v0.9.106 -> v0.9.110
Updated mlpstorage v3.0.38 -> v3.0.39

$ uv sync --active && uv pip list | grep s3dlio
s3dlio  0.9.110

$ uv run pytest tests/unit -q
2701 passed, 1 skipped in 22.02s
```

Diff is minimal by design: `pyproject.toml` (2 lines) + `uv.lock` (the `s3dlio` and `mlpstorage` package entries only).

Refs: mlcommons/storage#715 (already closed — not re-closed by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)