### PR TITLE
chore: bump 3.0.39 -> 3.0.40; pin DLIO to main HEAD (86945a7a)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.39"
+version = "3.0.40"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -132,6 +132,13 @@ torchaudio = [{ index = "pytorch-cpu" }]
 # Pinned to a specific commit for reproducibility; bump by updating `rev` and
 # re-running `uv lock --upgrade-package dlio-benchmark`.
 # Commit history (most recent first):
+#   - DLIO PR #47 fix for storage #626 (bucket 2): shared 64-way concurrency
+#     ceiling across object-storage libraries — caps s3dlio /
+#     ObjStoreLibStorage / SimpleStreamingCheckpointing on the same
+#     pool so multi-adapter runs don't blow past the tuned limit
+#   - DLIO PR #46 fix for storage #626 (bucket 1): fork-safe
+#     _s3_iterable_mixin prefetch pool — reset pool state across fork()
+#     so DataLoader worker processes don't inherit a dead pool
 #   - DLIO PR #45 fix for storage #699: os.makedirs(exist_ok=True) race on
 #     multi-host checkpoint runs — exponential-backoff retry in
 #     _makedirs_race_safe(); applied to FileStorage, ObjStoreLibStorage,
@@ -163,7 +170,7 @@ torchaudio = [{ index = "pytorch-cpu" }]
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
 #   - DLIO PR #21 fix for storage #391 part 1 (TorchIterableDatasetSimple gating)
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "24b13d7630a12e3d08624e5db254694a09f71599" }
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "86945a7a203912435774e0972f6350221446229e" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=24b13d7630a12e3d08624e5db254694a09f71599#24b13d7630a12e3d08624e5db254694a09f71599" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=86945a7a203912435774e0972f6350221446229e#86945a7a203912435774e0972f6350221446229e" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.39"
+version = "3.0.40"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=24b13d7630a12e3d08624e5db254694a09f71599" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=24b13d7630a12e3d08624e5db254694a09f71599" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=86945a7a203912435774e0972f6350221446229e" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=86945a7a203912435774e0972f6350221446229e" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary

Picks up DLIO_local_changes PRs #46 and #47 (both closing
`mlcommons/storage#626` concurrency work) and bumps mlpstorage
`3.0.39 -> 3.0.40`.

- **DLIO PR #46** — fork-safe `_s3_iterable_mixin` prefetch pool
  (storage#626 bucket 1). Resets pool state across `fork()` so
  PyTorch DataLoader worker processes don't inherit a dead pool.
- **DLIO PR #47** — shared 64-way concurrency ceiling across
  s3dlio / `ObjStoreLibStorage` / `SimpleStreamingCheckpointing`
  (storage#626 bucket 2). Caps them on the same pool so
  multi-adapter runs don't blow past the tuned limit.

Neither fix touches mlp-storage's own code — both live entirely
inside DLIO_local_changes — so the diff is minimal by design:
`pyproject.toml` (rev + comment history) and `uv.lock` (the
`dlio-benchmark` + `mlpstorage` entries).

## DLIO pin

- Before: `24b13d7630a12e3d08624e5db254694a09f71599`
- After:  `86945a7a203912435774e0972f6350221446229e` (DLIO main HEAD)

## Test plan

- [x] `uv lock --upgrade-package dlio-benchmark` — clean resolution,
      only expected entries changed.
- [x] Full CI test matrix (all four suites):
  - `uv run pytest tests/unit -q` — 2689 passed, 1 skipped
  - `uv run pytest mlpstorage_py/tests -q` — 840 passed
  - `uv run pytest vdb_benchmark/tests -q` — 174 passed
  - `uv run pytest kv_cache_benchmark/tests -q` — 238 passed
  - **Total: 3941 passed, 1 skipped**

## Not in this bump

DLIO PR #48 (storage#741 drop-caches-before-memory-guard) is still
open pending review; it will be picked up in a follow-on bump after
merge. This PR intentionally captures only what's already on DLIO main.

## Related

- `mlcommons/storage#626`
- `mlcommons/DLIO_local_changes#46`, `#47`