### PR TITLE
chore(storage#741): pin DLIO to 95c6a9d4 to pick up PR #48

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,12 @@ torchaudio = [{ index = "pytorch-cpu" }]
 # Pinned to a specific commit for reproducibility; bump by updating `rev` and
 # re-running `uv lock --upgrade-package dlio-benchmark`.
 # Commit history (most recent first):
+#   - DLIO PR #48 fix for storage #741: drop page cache before the
+#     read_threads memory guard — prevents run 2..N of a 5-run
+#     submission from tripping the guard on reclaimable Lustre page
+#     cache pinned by the prior run.  Gated on local_rank() == 0 (not
+#     MPI.node(), which is unreliable under --map-by node).  Reuses
+#     the existing DLIO_DROP_CACHES_TIMEOUT knob.
 #   - DLIO PR #47 fix for storage #626 (bucket 2): shared 64-way concurrency
 #     ceiling across object-storage libraries — caps s3dlio /
 #     ObjStoreLibStorage / SimpleStreamingCheckpointing on the same
@@ -170,7 +176,7 @@ torchaudio = [{ index = "pytorch-cpu" }]
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
 #   - DLIO PR #21 fix for storage #391 part 1 (TorchIterableDatasetSimple gating)
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "86945a7a203912435774e0972f6350221446229e" }
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "95c6a9d46a2a072b7f1455b65b3a5e22602b53e5" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=86945a7a203912435774e0972f6350221446229e#86945a7a203912435774e0972f6350221446229e" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=95c6a9d46a2a072b7f1455b65b3a5e22602b53e5#95c6a9d46a2a072b7f1455b65b3a5e22602b53e5" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=86945a7a203912435774e0972f6350221446229e" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=86945a7a203912435774e0972f6350221446229e" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=95c6a9d46a2a072b7f1455b65b3a5e22602b53e5" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=95c6a9d46a2a072b7f1455b65b3a5e22602b53e5" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary

Picks up `mlcommons/DLIO_local_changes#48`
(`fix(storage#741): drop page cache before read_threads memory guard`),
which merged after PR #746 had already been opened against DLIO main
HEAD `86945a7a`. This bumps the pin to the current DLIO main HEAD
(`95c6a9d4`) so #48 lands in the same 3.0.40 line before it ships.

**Storage version not bumped**: this is a pure DLIO-side pin advance
with no mlp-storage code change. #746 already carried 3.0.39 → 3.0.40.

## What DLIO #48 fixes

The `read_threads` per-node memory guard in
`ConfigArguments.validate` samples `psutil.virtual_memory().available`
and caps `read_threads` against it. On POSIX filesystems whose client
pins a large reclaimable page cache (Lustre in particular),
`MemAvailable` understates by the size of that cache — so after run
1 warms the cache, runs 2..N of a 5-run submission see the cache as
"unavailable" and DLIO refuses to launch in `initialize()`, before
the per-epoch flush ever gets to run. `reportgen` then reports
`INVALID: 0 runs` for a submission whose only real problem is that
the benchmark's own per-epoch flush hadn't run yet.

DLIO #48 drops the local host's page cache right before
`virtual_memory()` is sampled, gated on `local_rank() == 0` (not
`MPI.node()`, which is unreliable under `--map-by node`) with a
`Barrier` so non-leaders read post-drop memory. Reuses the existing
`DLIO_DROP_CACHES_TIMEOUT` env var — no new operator knob.

## DLIO pin

- Before: `86945a7a203912435774e0972f6350221446229e`
- After:  `95c6a9d46a2a072b7f1455b65b3a5e22602b53e5` (DLIO main HEAD)

## Test plan

- [x] `uv lock --upgrade-package dlio-benchmark` — clean resolution,
      only `dlio-benchmark` source URL changed.
- [x] Full CI test matrix (all four suites):
  - `uv run pytest tests/unit -q` — 2689 passed, 1 skipped
  - `uv run pytest mlpstorage_py/tests -q` — 840 passed
  - `uv run pytest vdb_benchmark/tests -q` — 174 passed
  - `uv run pytest kv_cache_benchmark/tests -q` — 238 passed
  - **Total: 3941 passed, 1 skipped**

## Related

- `mlcommons/storage#741`
- `mlcommons/DLIO_local_changes#48`
- Follow-up to `mlcommons/storage#746`