### PR TITLE
docs: add v3.0.40 entry to BugsFixedInVersions.md

### DIFF
--- a/BugsFixedInVersions.md
+++ b/BugsFixedInVersions.md
@@ -1,7 +1,7 @@
 # MLPerf Storage Benchmark v3.0 — Significant Bugs Fixed by Version
 
-**Date:** 2026-07-08
-**Covers:** Versions 3.0.3 through 3.0.38 (May 28 – July 8, 2026)
+**Date:** 2026-07-09
+**Covers:** Versions 3.0.3 through 3.0.40 (May 28 – July 9, 2026)
 
 ---
 
@@ -346,3 +346,20 @@ One mlpstorage-level fix landed in this range. The DLIO pin did not move. The s3
 - s3dlio DLIO-adapter subpackage: `AWS_ENDPOINT_URL` set in the user's environment was clobbered by the adapter's own endpoint selection — user-configured S3-compatible endpoints were silently overridden. (s3dlio PR #159)
 - s3dlio: `parse_s3_uri_full` endpoint-detection heuristic misrouted legitimate bucket names with 2+ dots, leading digits, or names containing `minio` / `ceph` / `localhost` (e.g. `mycompany.data.backups`) as custom endpoint hostnames — heuristic narrowed; use `S3DLIO_S3_ENDPOINT_HINT_TLDS` to opt back in. (s3dlio PR #159)
 - s3dlio: GCS RAPID-bucket detection had no exponential backoff on retry, and a transient failure permanently poisoned the detection cache with the wrong answer — subsequent GCS reads used the wrong code path for the rest of the process lifetime. (s3dlio PR #159)
+
+---
+
+## Version 3.0.40 (July 9, 2026)
+
+No mlpstorage-level code change landed in this range. The DLIO pin advanced twice in the same day — first to DLIO main HEAD `86945a7a` picking up DLIO PRs #46 and #47 (storage#626 concurrency work, buckets 1 and 2), then to `95c6a9d4` picking up DLIO PR #48 (storage#741 page-cache-vs-memory-guard fix). All three DLIO-side fixes are listed below; each lives entirely inside `mlcommons/DLIO_local_changes` and reached submitters via the version bump. The s3dlio floor did not move in this range.
+
+**Score-Affecting**
+
+_(None. All three DLIO fixes in this range are invocation or metadata correctness — no measured-throughput or latency change.)_
+
+**Invocation**
+- DLIO: `read_threads` per-node memory guard aborted runs 2..N of every 5-run submission on POSIX filesystems whose client pins a large reclaimable page cache (Lustre in particular). Run 1 warmed the cache; subsequent runs sampled `psutil.virtual_memory().available`, saw the cache as "unavailable," and DLIO refused to launch in `initialize()` — before the benchmark's own per-epoch page-cache flush ever got to run. `reportgen` then reported `INVALID: 0 runs` for a submission whose only real problem was launch-order timing. DLIO now drops the local host's page cache immediately before sampling `virtual_memory()`, gated on `local_rank() == 0` (not `MPI.node()`, which is unreliable under `--map-by node`) with a `Barrier()` so non-leader ranks read post-drop memory. Reuses the existing `DLIO_DROP_CACHES_TIMEOUT` env var — no new operator knob. Fail-open matches the per-epoch flush: `sudo -n` refusal, kernel timeout, `Barrier` error, and every subprocess exception are swallowed so the guard downstream still runs. (#741; DLIO PR #48)
+- DLIO: `_s3_iterable_mixin` had a latent fork-safety hazard — the module-level `_PREFETCH_POOL = ThreadPoolExecutor(...)` was created in the parent at import time, and its worker thread does not survive `os.fork()`. Any `.submit()` in a DLIO DataLoader worker enqueued work that nobody drained and `future.result()` blocked indefinitely. Currently only affected the `minio` and `s3torchconnector` code paths (the `s3dlio` path short-circuits around the pool before submitting); post-fix, the pool is per-mixin-instance and created inside `_s3_init()` — strictly after `os.fork()` — so every DataLoader worker gets its own live pool. Same shape as the LOCAL_FS hazard closed for storage#391. (#626; DLIO PR #46)
+
+**Other Significant**
+- DLIO: per-worker in-flight I/O concurrency in `_S3IterableMixin` depended on which `storage_library` a submitter chose, not on the storage system under test — s3dlio at 64, `minio` hardcoded at 16 (undocumented, 4× lower), `s3torchconnector` fully sequential (up to 64× lower). All three prefetch paths now share a single module-level `_MAX_PREFETCH_CONCURRENCY = 64`: `minio`'s `ThreadPoolExecutor` and backing `urllib3.PoolManager` raised 16 → 64, and `s3torchconnector` rewritten from sequential to a `ThreadPoolExecutor`-based path (readers drained single-threaded first because `S3IterableDataset`'s iterator isn't safe for concurrent `next()`; only `.read()`, where the real I/O happens, is fanned out). Note: this closes the *concurrency-ceiling parity* gap only — it does not eliminate the raw-throughput gap between s3dlio's native Rust engine and the Python SDK clients (`minio` in particular remains GIL-serialized on request signing / header construction / response parsing), which is a client-library implementation difference, not a DLIO benchmark-code issue. Live loopback verification at cap=64 with 2000 × 256 KiB objects: s3dlio 77 ms, minio 1,359 ms, s3torchconnector 677 ms — the concurrency lift is real (~2× on `s3torchconnector` alone), the SDK-runtime gap is not something this fix could touch. `prefetch_window` semantic-collision docs on both `_s3_iterable_mixin` and `_local_fs_iterable_mixin` updated to reflect the new shared ceiling. (#626; DLIO PR #47)


### PR DESCRIPTION
## Summary

Adds the v3.0.40 entry covering the two same-day DLIO pin advances that
shipped in the 3.0.40 line.  No mlpstorage-level code change landed in
this range; the s3dlio floor did not move.

## What's in v3.0.40

Three DLIO-side fixes, all reaching submitters via the pin bump:

- **DLIO PR #48** (storage#741) — drop the local host's page cache
  immediately before the `read_threads` per-node memory guard samples
  `virtual_memory().available`.  On POSIX filesystems whose client
  pins a large reclaimable page cache (Lustre in particular), runs
  2..N of every 5-run submission were aborted in `initialize()`
  before the benchmark's own per-epoch flush could run; `reportgen`
  then labeled the whole submission `INVALID: 0 runs`.  Gated on
  `local_rank() == 0` (`MPI.node()` is unreliable under `--map-by
  node`) with a `Barrier()`; reuses `DLIO_DROP_CACHES_TIMEOUT`; fail-
  open matches the per-epoch flush.  **Invocation.**  Shipped via
  storage PR #747.
- **DLIO PR #46** (storage#626 bucket 1) — fork-safe
  `_s3_iterable_mixin` prefetch pool.  Latent hazard: module-level
  `ThreadPoolExecutor` created in the parent at import time; worker
  thread dies on `os.fork()`; any `.submit()` in a DLIO DataLoader
  worker hung indefinitely.  Only currently affected `minio` and
  `s3torchconnector` (the `s3dlio` path short-circuits before
  submitting).  Pool now per-mixin-instance, created in `_s3_init()`
  strictly after fork.  **Invocation.**  Shipped via storage PR #746.
- **DLIO PR #47** (storage#626 bucket 2) — shared 64-way concurrency
  ceiling across `s3dlio` / `minio` / `s3torchconnector`.  Before:
  s3dlio=64, minio=16 hardcoded (4x lower), s3torchconnector fully
  sequential (up to 64x lower).  New module-level
  `_MAX_PREFETCH_CONCURRENCY = 64` shared across all three paths;
  s3torchconnector rewritten from sequential to concurrent.  Note
  called out in the doc: this closes the *concurrency-ceiling parity*
  gap only — it does not close the raw-throughput gap between s3dlio's
  native Rust engine and the Python SDK clients (a client-library
  implementation difference, not a DLIO benchmark-code issue).
  **Other Significant.**  Shipped via storage PR #746.

Score-Affecting count for v3.0.40: **0**.

## Header touch-up

- `**Date:**` 2026-07-08 -> 2026-07-09
- `**Covers:**` "3.0.3 through 3.0.38" -> "3.0.3 through 3.0.40"
  (previously stale; v3.0.39 was already in the body)

## Diff scope

`BugsFixedInVersions.md` only, +19 / -2.  No other files touched.

## Related

- storage PR #746 (DLIO pin -> 86945a7a)
- storage PR #747 (DLIO pin -> 95c6a9d4)
- DLIO PRs #46, #47 (storage#626)
- DLIO PR #48 (storage#741)