### PR TITLE
fix: allow (and require) datasize/ training phase in STRUCT-12

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -105,7 +105,7 @@ configuration of storage system and to link together those results with the .pdf
 
 2.1.11. **trainingWorkloads** --  Within the "training" directory, there must be one or more of the following *workload directories*, and nothing else: "unet3d" and/or "retinanet".  These names are case-sensitive.
 
-2.1.12. **trainingPhases** --  Within the *workload directories* in the "training" hierarchy, there must exist *phase directories* named "datagen" and "run", and nothing else.  These names are case-sensitive.
+2.1.12. **trainingPhases** --  Within the *workload directories* in the "training" hierarchy, there must exist *phase directories* named "datasize", "datagen", and "run", and nothing else.  These names are case-sensitive.
 
 2.1.13. **datagenTimestamp** --  Within the "datagen" *phase directory* within the "training" directory hierarchy, there must be exactly one *timestamp directory* named *YYYYMMDD_HHmmss" that represent a *timestamp* of when that part of the test run was completed.  Where Y's are replaced with the year the run was performed, M's are replaced with the month, D's with the day, H's with the hour (in 24-hour format), m's with the minute, and s's with the second.  The timestamps should be relative to the local timezone where the test was actually run.
 
@@ -376,7 +376,7 @@ root_folder (or any name you prefer)
 
 ## 3.3. Training Run Options
 
-3.3.1. **trainingRunDataMatchesDatasize** -- The amount of data the *run* phase is told to use must be exactly equal to the *datasize* value calculated earlier, but can be less than the value used in the *datagen* phase.  To express that, you can run the benchmark on a subset of that dataset by setting `num_files_train` or `num_files_eval` smaller than the number of files available in the dataset folder, but `num_subfolders_train` and `num_subfolders_eval` must be to be equal to the actual number of subfolders inside the dataset folder in order to generate valid results.
+3.3.1. **trainingRunDataMatchesDatasize** -- The amount of data the *run* phase is told to use must be exactly equal to the *datasize* value calculated earlier, but can be less than the value used in the *datagen* phase.  To express that, you can run the benchmark on a subset of that dataset by setting `num_files_train` or `num_files_eval` smaller than the number of files available in the dataset folder, but `num_subfolders_train` and `num_subfolders_eval` must be to be equal to the actual number of subfolders inside the dataset folder in order to generate valid results.  Within the *timestamp directory* in the "datasize" *phase directory*, there must exist a ``*_metadata.json`` file whose ``parameters.dataset`` block records the outputs of the datasize calculation --- `num_files_train`, `num_subfolders_train`, and `total_disk_bytes` --- and whose ``args`` block records the inputs that produced them --- `model`, `accelerator_type`, `max_accelerators`, `client_host_memory_in_gb`, and `data_dir`.  These are the values the *run* phase is cross-checked against.
 
 3.3.2. **trainingAcceleratorUtilizationCheck** -- To pass a benchmark run, the AU (Accelerator Utilization) should be equal to or greater than the minimum value:
   * `total_compute_time = (records_per_file * total_files) / simulated_accelerators / batch_size * computation_time * epochs`

--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -942,6 +942,11 @@ class TrainingBenchmark(DLIOBenchmark):
         # num_files_train that datasize reported on stderr.
         self.params_dict['dataset.num_files_train'] = num_files_train
         self.params_dict['dataset.num_subfolders_train'] = num_subfolders_train
+        # Persist the total-bytes output alongside the file/subfolder outputs
+        # so a manual reviewer (or future run-checker cross-check against
+        # datagen actual bytes) can read the datasize sentinel end-to-end
+        # from datasize/<ts>/*_metadata.json. See Rules.md §3.3.1.
+        self.params_dict['dataset.total_disk_bytes'] = int(total_disk_bytes)
 
         self.logger.result(f'Number of training files: {num_files_train}')
         self.logger.result(f'Number of training subfolders: {num_subfolders_train}')

--- a/mlpstorage_py/submission_checker/checks/submission_structure_checks.py
+++ b/mlpstorage_py/submission_checker/checks/submission_structure_checks.py
@@ -86,7 +86,15 @@ _VALID_WORKLOAD_CATEGORIES = frozenset({
 _VALID_TRAINING_WORKLOADS = frozenset({"unet3d", "retinanet"})
 
 # Valid training phase directories under training/<workload>/
-_VALID_TRAINING_PHASES = frozenset({"datagen", "run"})
+_VALID_TRAINING_PHASES = frozenset({"datasize", "datagen", "run"})
+# datasize/ is treated as required-but-warn-only during the current submission
+# window: it became a required phase after PR #611 (issue #608) taught the
+# loader and rule 3.3.1 to consume its metadata, but submissions produced
+# before that landing shipped without it. Rules.md §2.1.12 requires the
+# directory; the checker warns rather than errors on this specific phase
+# to avoid retroactively invalidating pre-#611 work already on disk. Missing
+# `datagen/` or `run/` remains a hard structural error.
+_WARN_ONLY_MISSING_TRAINING_PHASES = frozenset({"datasize"})
 
 # Valid checkpointing workload names under checkpointing/
 _VALID_CHECKPOINTING_WORKLOADS = frozenset({"llama3-8b", "llama3-70b", "llama3-405b", "llama3-1t"})
@@ -833,7 +841,12 @@ class SubmissionStructureCheck(BaseCheck):
 
     @rule("2.1.12", "trainingPhases")
     def training_phases_check(self):
-        """STRUCT-12: each training workload dir must contain exactly {datagen, run}."""
+        """STRUCT-12: each training workload dir must contain exactly {datasize, datagen, run}.
+
+        Missing `datagen/` or `run/` is a hard error. Missing `datasize/`
+        emits a `[2.1.12 DATASIZE-MISSING]` warning instead — see the
+        `_WARN_ONLY_MISSING_TRAINING_PHASES` note for rationale.
+        """
         valid = True
         for _division, _submitter, sub_path in self._iter_submitter_dirs():
             results_path = os.path.join(sub_path, "results")
@@ -852,6 +865,16 @@ class SubmissionStructureCheck(BaseCheck):
                     extra = phases - _VALID_TRAINING_PHASES
 
                     for m in sorted(missing):
+                        if m in _WARN_ONLY_MISSING_TRAINING_PHASES:
+                            self.warn_violation(
+                                "2.1.12", "trainingPhases",
+                                os.path.join(workload_path, m),
+                                "[2.1.12 DATASIZE-MISSING] required phase directory "
+                                "%r missing from training/%s",
+                                m, workload,
+                            )
+                            # warn-only: do not flip `valid`
+                            continue
                         self.log_violation(
                             "2.1.12", "trainingPhases",
                             os.path.join(workload_path, m),
@@ -865,7 +888,7 @@ class SubmissionStructureCheck(BaseCheck):
                             "2.1.12", "trainingPhases",
                             os.path.join(workload_path, e),
                             "unexpected directory %r in training/%s "
-                            "(only 'datagen' and 'run' allowed)",
+                            "(only 'datasize', 'datagen', and 'run' allowed)",
                             e, workload,
                         )
                         valid = False

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -332,6 +332,8 @@ class TrainingCheck(BaseCheck):
                 "[3.3.1 DATASIZE-MISSING] no datasize/ phase found; "
                 "rule 3.3.1 cross-check skipped",
             )
+        else:
+            self._warn_malformed_datasize_metadata(datasize_files)
         if not datagen_files:
             self.warn_violation(
                 "3.3.1", "trainingRunDataMatchesDatasize", self.path,
@@ -409,6 +411,39 @@ class TrainingCheck(BaseCheck):
 
         # Warn-only invariant: rule passes regardless of warnings recorded.
         return valid
+
+    _DATASIZE_REQUIRED_OUTPUT_KEYS = ("num_files_train", "num_subfolders_train", "total_disk_bytes")
+
+    def _warn_malformed_datasize_metadata(self, datasize_files):
+        """Warn when a datasize sentinel omits the Rules.md §3.3.1 output keys.
+
+        Every ``training/<model>/datasize/<ts>/`` sentinel must record its
+        computed outputs — ``num_files_train``, ``num_subfolders_train``,
+        and ``total_disk_bytes`` — under ``parameters.dataset`` so a
+        reviewer (and, once wired, the datagen cross-check) can verify
+        that datagen produced at least what datasize prescribed. Absent
+        metadata or absent keys emit ``[3.3.1 DATASIZE-MALFORMED]``
+        (warn-level, submission-window doctrine).
+        """
+        for _summary, metadata, ts in datasize_files:
+            if metadata is None:
+                self.warn_violation(
+                    "3.3.1", "trainingRunDataMatchesDatasize", self.path,
+                    "[3.3.1 DATASIZE-MALFORMED] datasize/%s has no readable "
+                    "metadata file; sentinel cannot be cross-checked",
+                    ts,
+                )
+                continue
+            dataset_params = (metadata.get("parameters", {}) or {}).get("dataset", {}) or {}
+            missing = [k for k in self._DATASIZE_REQUIRED_OUTPUT_KEYS if dataset_params.get(k) is None]
+            if missing:
+                self.warn_violation(
+                    "3.3.1", "trainingRunDataMatchesDatasize", self.path,
+                    "[3.3.1 DATASIZE-MALFORMED] datasize/%s metadata missing "
+                    "required output key(s) %s under parameters.dataset; "
+                    "sentinel cannot be fully cross-checked",
+                    ts, ", ".join(missing),
+                )
 
     @staticmethod
     def _to_int(v):

--- a/mlpstorage_py/tests/conftest.py
+++ b/mlpstorage_py/tests/conftest.py
@@ -96,6 +96,18 @@ _RUN_TIMESTAMPS = [
 # One datagen timestamp
 _DATAGEN_TIMESTAMPS = ["20250111_130000"]
 
+# One datasize timestamp — parallel to datagen. Rules.md §2.1.12 (post
+# STRUCT-12 datasize-phase landing) requires the phase directory. The
+# sentinel metadata written into datasize/<ts>/ carries the outputs of
+# the datasize calculation that rule 3.3.1 (and, in future, a datagen
+# cross-check) reads back.
+_DATASIZE_TIMESTAMPS = ["20250111_125900"]
+_DATASIZE_DEFAULT_OUTPUTS = {
+    "num_files_train": 14000,
+    "num_subfolders_train": 0,
+    "total_disk_bytes": 68_090_280_000,
+}
+
 # Two checkpointing timestamps — Rules.md 2.1.23 in conjunction with 4.7.1
 # allows 1 or 2 invocations (one timestamp dir per invocation). The fixture
 # uses the two-invocation shape (write phase + read phase) so split-mode
@@ -399,6 +411,15 @@ def build_submission(tmp_path, **overrides) -> Path:
     wrong_training_phase = overrides.pop("wrong_training_phase", None)
     datagen_timestamps_count = overrides.pop("datagen_timestamps", None)
     bad_datagen_timestamp_format = overrides.pop("bad_datagen_timestamp_format", False)
+    # STRUCT-12 datasize-phase kwargs (Rules.md §2.1.12 / §3.3.1):
+    #   ``omit_datasize_phase`` — skip building datasize/ entirely (exercises the
+    #                              warn-level DATASIZE-MISSING path in STRUCT-12
+    #                              and rule 3.3.1).
+    #   ``datasize_missing_output_keys`` — iterable of parameters.dataset.<key>
+    #                              names to drop from the datasize metadata
+    #                              (exercises DATASIZE-MALFORMED in rule 3.3.1).
+    omit_datasize_phase = overrides.pop("omit_datasize_phase", False)
+    datasize_missing_output_keys = overrides.pop("datasize_missing_output_keys", None)
     wrong_checkpointing_workload = overrides.pop("wrong_checkpointing_workload", None)
     # Phase 2 Plan 02-02: system YAML mutation kwargs for SystemYamlSchemaCheck tests.
     system_yaml_bad_capabilities = overrides.pop("system_yaml_bad_capabilities", None)
@@ -585,6 +606,28 @@ def build_submission(tmp_path, **overrides) -> Path:
 
             unet3d_path = training_path / "unet3d"
             unet3d_path.mkdir()
+
+            # datasize timestamp (Rules.md §2.1.12 / §3.3.1 sentinel)
+            if not omit_datasize_phase:
+                datasize_dir = unet3d_path / "datasize"
+                datasize_dir.mkdir()
+                for ts in _DATASIZE_TIMESTAMPS:
+                    ts_dir = datasize_dir / ts
+                    ts_dir.mkdir()
+                    ds_meta = copy.deepcopy(_DEFAULT_METADATA)
+                    ds_meta["benchmark_type"] = "training"
+                    ds_meta["model"] = "unet3d"
+                    ds_meta["args"]["model"] = "unet3d"
+                    ds_meta["args"]["command"] = "datasize"
+                    ds_dataset = {
+                        k: v for k, v in _DATASIZE_DEFAULT_OUTPUTS.items()
+                        if datasize_missing_output_keys is None
+                        or k not in datasize_missing_output_keys
+                    }
+                    ds_meta["parameters"] = {"dataset": ds_dataset}
+                    (ts_dir / "metadata.json").write_text(
+                        json.dumps(ds_meta), encoding="utf-8"
+                    )
 
             # datagen timestamps
             datagen_dir = unet3d_path / "datagen"

--- a/mlpstorage_py/tests/test_submission_checker_structure.py
+++ b/mlpstorage_py/tests/test_submission_checker_structure.py
@@ -965,6 +965,49 @@ class TestStruct12_TrainingPhases:
         assert result is False
         assert any("[2.1.12 trainingPhases]" in m for m in mock_logger.errors)
 
+    def test_missing_datasize_phase_warns_but_passes(self, tmp_path, mock_logger):
+        """Missing datasize/ → warn-level (DATASIZE-MISSING), rule still passes.
+
+        Rules.md §2.1.12 requires the datasize phase, but the checker enforces
+        it at warn-level during the current submission window (see
+        ``_WARN_ONLY_MISSING_TRAINING_PHASES`` note). Regression pin against
+        the retroactive-invalidation concern raised when datasize/ was
+        first added to the required set.
+        """
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(tmp_path, omit_datasize_phase=True)
+        check = _make_check(root, mock_logger)
+        result = run_one_check(check, "training_phases_check", mock_logger)
+        assert result is True
+        assert any(
+            "[2.1.12 trainingPhases]" in m and "DATASIZE-MISSING" in m
+            for m in mock_logger.warnings
+        )
+        # Must NOT surface as an error (warn-only doctrine).
+        assert not any(
+            "DATASIZE-MISSING" in m for m in mock_logger.errors
+        )
+
+    def test_missing_datagen_phase_still_errors(self, tmp_path, mock_logger):
+        """Missing datagen/ → hard error, unchanged from pre-datasize behavior.
+
+        Pins that the warn-only carve-out is scoped to `datasize` — the
+        other required phases must still fail the check.
+        """
+        import shutil
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(tmp_path)
+        # Remove the datagen dir the fixture built.
+        datagen_dir = (
+            root / "closed" / "Acme" / "results" / "acme-storage-v1"
+            / "training" / "unet3d" / "datagen"
+        )
+        shutil.rmtree(datagen_dir)
+        check = _make_check(root, mock_logger)
+        result = run_one_check(check, "training_phases_check", mock_logger)
+        assert result is False
+        assert any("[2.1.12 trainingPhases]" in m for m in mock_logger.errors)
+
 
 # ---------------------------------------------------------------------------
 # TestStruct13_DatagenTimestamp  (STRUCT-13, rule 2.1.13)

--- a/tests/unit/test_submission_checker_run_matches_datasize.py
+++ b/tests/unit/test_submission_checker_run_matches_datasize.py
@@ -33,6 +33,8 @@ def _write_metadata(
     num_files_train: int,
     data_dir: str,
     num_files_eval: Optional[int] = None,
+    num_subfolders_train: Optional[int] = 0,
+    total_disk_bytes: Optional[int] = 68_090_280_000,
 ) -> Path:
     """Write a `<benchmark>_<ts>_metadata.json` matching the producer shape.
 
@@ -40,17 +42,21 @@ def _write_metadata(
     with `parameters.dataset.num_files_train` (DLIO-merged) and
     `args.data_dir` (raw CLI namespace). The validator-side rule reads
     those exact paths.
+
+    `num_subfolders_train` and `total_disk_bytes` are populated with
+    non-None defaults so callers writing datasize metadata satisfy the
+    3.3.1 DATASIZE-MALFORMED check by default. Pass ``None`` explicitly
+    to omit either key (used by ``TestDatasizeMalformedCases``).
     """
     metadata_path = timestamp_dir / f"{benchmark}_{timestamp}_metadata.json"
+    dataset: dict = {"num_files_train": num_files_train}
+    if num_subfolders_train is not None:
+        dataset["num_subfolders_train"] = num_subfolders_train
+    if total_disk_bytes is not None:
+        dataset["total_disk_bytes"] = total_disk_bytes
     metadata: dict = {
-        "parameters": {
-            "dataset": {
-                "num_files_train": num_files_train,
-            },
-        },
-        "args": {
-            "data_dir": data_dir,
-        },
+        "parameters": {"dataset": dataset},
+        "args": {"data_dir": data_dir},
     }
     if num_files_eval is not None:
         metadata["parameters"]["dataset"]["num_files_eval"] = num_files_eval
@@ -385,6 +391,67 @@ class TestWarningCases:
         )
         assert result is True
         assert _has_token(records, "[3.3.1 EVAL-FIELD-MISSING]")
+
+
+class TestDatasizeMalformedCases:
+    """Rule 3.3.1 must warn when a datasize sentinel omits its output keys.
+
+    Rules.md §3.3.1 requires the datasize `*_metadata.json` to record
+    ``num_files_train``, ``num_subfolders_train``, and ``total_disk_bytes``
+    under ``parameters.dataset`` so a reviewer (or future run-checker
+    cross-check against datagen's actual output) can verify that datagen
+    produced at least what datasize prescribed. Missing outputs surface as
+    `[3.3.1 DATASIZE-MALFORMED]` (warn-only, submission-window doctrine).
+    """
+
+    def _build_and_drop_datasize_key(self, tmp_path, caplog, drop_key: str):
+        workload_dir = _build_training_tree(
+            tmp_path,
+            datasize_num_files=84_375,
+            datagen_num_files=84_375,
+            run_num_files=84_375,
+        )
+        # Rewrite the datasize metadata without the target key.
+        datasize_ts_dir = workload_dir / "datasize" / "20260630_100000"
+        meta_path = next(datasize_ts_dir.glob("*_metadata.json"))
+        meta = json.loads(meta_path.read_text())
+        meta["parameters"]["dataset"].pop(drop_key, None)
+        meta_path.write_text(json.dumps(meta))
+        root = _scaffold_division_root(tmp_path, workload_dir)
+        return _run_rule(root, caplog)
+
+    def test_missing_num_subfolders_train_warns(self, tmp_path, caplog):
+        result, records = self._build_and_drop_datasize_key(
+            tmp_path, caplog, "num_subfolders_train",
+        )
+        assert result is True
+        assert _has_token(records, "[3.3.1 DATASIZE-MALFORMED]")
+        assert any(
+            "num_subfolders_train" in r.getMessage() and "DATASIZE-MALFORMED" in r.getMessage()
+            for r in records
+        )
+
+    def test_missing_total_disk_bytes_warns(self, tmp_path, caplog):
+        result, records = self._build_and_drop_datasize_key(
+            tmp_path, caplog, "total_disk_bytes",
+        )
+        assert result is True
+        assert _has_token(records, "[3.3.1 DATASIZE-MALFORMED]")
+        assert any(
+            "total_disk_bytes" in r.getMessage() and "DATASIZE-MALFORMED" in r.getMessage()
+            for r in records
+        )
+
+    def test_all_output_keys_present_does_not_warn(self, tmp_path, caplog):
+        """Positive control — the default `_write_metadata` shape must not fire."""
+        result, records = _materialize_scenario(
+            tmp_path, caplog,
+            datasize_num_files=84_375,
+            datagen_num_files=84_375,
+            run_num_files=84_375,
+        )
+        assert result is True
+        assert not _has_token(records, "[3.3.1 DATASIZE-MALFORMED]")
 
 
 # ---------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Rule 2.1.12 (**trainingPhases**) previously required training workload directories to contain exactly `{datagen, run}`, but PR #611 (issue #608) taught the loader and rule 3.3.1 to read `training/<model>/datasize/<ts>/metadata.json` — which the `mlpstorage training datasize` CLI has been writing all along via `generate_output_location()`. That left submitters in a catch-22:

- Keep the `datasize/` directory the tool produced → `[2.1.12 trainingPhases] unexpected directory 'datasize'` (error).
- Delete it before submitting → `[3.3.1 DATASIZE-MISSING]` (warning) and the whole point of the #608 cross-check is lost.

This PR closes the loop end-to-end.

### Rules.md (declarative only)
- **§2.1.12**: enumeration now `{datasize, datagen, run}`.
- **§3.3.1**: specifies the sentinel's required contents so a manual reviewer knows what to grep for — under `parameters.dataset`: `num_files_train`, `num_subfolders_train`, `total_disk_bytes`; under `args`: `model`, `accelerator_type`, `max_accelerators`, `client_host_memory_in_gb`, `data_dir`.

### Structure checker (STRUCT-12)
- `_VALID_TRAINING_PHASES` now includes `datasize`.
- Missing `datasize/` emits `[2.1.12 DATASIZE-MISSING]` at **warn-level** so submissions produced before the phase was required don't retroactively invalidate. Missing `datagen/` or `run/` remains a hard error.

### Rule 3.3.1
- New `[3.3.1 DATASIZE-MALFORMED]` warning fires per-timestamp when the sentinel omits any of the three required output keys under `parameters.dataset`.

### `dlio.py`
- `datasize()` now persists `total_disk_bytes` in `params_dict` alongside `num_files_train` / `num_subfolders_train` so the sentinel is complete when `main.py`'s finally-block calls `write_metadata()`.

### Files produced vs. consumed in `datasize/<ts>/`
Verified end-to-end:

| File | Producer | Consumer |
|------|----------|----------|
| `training_<datetime>_metadata.json` | `main.py:287` finally block (unconditional) | Loader `find_metadata_path`; rule 3.3.1; new DATASIZE-MALFORMED |
| `.mlps-code-image` | `capture_or_verify_code_image` (gated on `command in {datasize, datagen, run}`) + belt-and-suspenders in `Benchmark.__init__` | CHECK-01 (poolPointerResolution), CHECK-03 (poolOrphanCheck) walk every datetime leaf |
| `fs_separation.json` | `_pre_execution_gate()` writes when destination is local | Not read from `datasize/` — pre-existing producer-side redundancy, not addressed here |

datasize does NOT invoke DLIO (`dlio.py:929` is pure-Python size calculation), so no `stdout.log`/`stderr.log`/`dlio.log`/`output.json`/`summary.json`/`dlio_config/` land under `datasize/<ts>/`.

## Test plan
- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed
- [x] `uv run pytest tests` — 2855 passed
- [x] `uv run pytest mlpstorage_py/tests` — 842 passed
- [x] `uv run pytest vdb_benchmark/tests` — 174 passed
- New STRUCT-12 tests pin both branches: `test_missing_datasize_phase_warns_but_passes` and `test_missing_datagen_phase_still_errors`.
- New rule-3.3.1 tests cover DATASIZE-MALFORMED for each of the two newly-required output keys plus a positive control.

## Not touched
- `BugsFixedInVersions.md` and version bump — left for the next release cycle per standing policy.
- `fs_separation.json` producer-side orphan under `datasize/` — pre-existing, harmless, and a future rule 3.4.2 extension could consume it.