### PR TITLE
chore: pin DLIO to a7d56e73 to pick up PR #49

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,14 @@ torchaudio = [{ index = "pytorch-cpu" }]
 # Pinned to a specific commit for reproducibility; bump by updating `rev` and
 # re-running `uv lock --upgrade-package dlio-benchmark`.
 # Commit history (most recent first):
+#   - DLIO PR #49 fix for storage #754: race-tolerant Hydra job-dir
+#     bootstrap on multi-node runs — Hydra's own run_job/_save_config
+#     internals call pathlib.Path(...).mkdir(exist_ok=True) on the shared
+#     hydra.run.dir / output_subdir from every rank on every node, and
+#     pathlib's post-FileExistsError is_dir() recheck can observe stale
+#     metadata from a peer's just-completed mkdir on shared/networked FS
+#     and re-raise. Fix monkeypatches Path.mkdir for the duration of the
+#     run_benchmark() call so the race is absorbed instead of aborting.
 #   - DLIO PR #48 fix for storage #741: drop page cache before the
 #     read_threads memory guard — prevents run 2..N of a 5-run
 #     submission from tripping the guard on reclaimable Lustre page
@@ -176,7 +184,7 @@ torchaudio = [{ index = "pytorch-cpu" }]
 #   - DLIO PR #23 fix for storage #391 part 2 (sudo -n + warn-once for drop_caches)
 #   - DLIO PR #22 fix for storage #415 (mpi4py auto-init in spawn workers)
 #   - DLIO PR #21 fix for storage #391 part 1 (TorchIterableDatasetSimple gating)
-dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "95c6a9d46a2a072b7f1455b65b3a5e22602b53e5" }
+dlio-benchmark = { git = "https://github.com/mlcommons/DLIO_local_changes.git", rev = "a7d56e73ed4630e47f89720436290a23c0f94b6c" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.2"
-source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=95c6a9d46a2a072b7f1455b65b3a5e22602b53e5#95c6a9d46a2a072b7f1455b65b3a5e22602b53e5" }
+source = { git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=a7d56e73ed4630e47f89720436290a23c0f94b6c#a7d56e73ed4630e47f89720436290a23c0f94b6c" }
 dependencies = [
     { name = "dgen-py", marker = "sys_platform == 'linux'" },
     { name = "h5py", marker = "sys_platform == 'linux'" },
@@ -583,8 +583,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=95c6a9d46a2a072b7f1455b65b3a5e22602b53e5" },
-    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=95c6a9d46a2a072b7f1455b65b3a5e22602b53e5" },
+    { name = "dlio-benchmark", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=a7d56e73ed4630e47f89720436290a23c0f94b6c" },
+    { name = "dlio-benchmark", marker = "extra == 'full'", git = "https://github.com/mlcommons/DLIO_local_changes.git?rev=a7d56e73ed4630e47f89720436290a23c0f94b6c" },
     { name = "elasticsearch", marker = "extra == 'vectordb'", specifier = ">=8.0" },
     { name = "elasticsearch", marker = "extra == 'vectordb-elasticsearch'", specifier = ">=8.0" },
     { name = "minio", specifier = ">=7.2.20" },


### PR DESCRIPTION
## Summary

- Bumps `dlio-benchmark` from `95c6a9d4` (DLIO PR #48, storage#741 page-cache drop) to `a7d56e73` (DLIO PR #49, storage#754 race-tolerant Hydra job-dir bootstrap on multi-node runs).
- Regenerates `uv.lock` via `uv lock --upgrade-package dlio-benchmark`.
- Adds a changelog entry to the `[tool.uv.sources]` comment block describing PR #49.

## Why

DLIO PR #49 fixes storage#754: Hydra's own `run_job` / `_save_config` internals call `pathlib.Path(...).mkdir(exist_ok=True)` on the shared `hydra.run.dir` / `output_subdir` from every rank on every node. On a networked/shared filesystem, pathlib's post-`FileExistsError` `is_dir()` recheck can observe transiently stale metadata from a peer node's just-completed `mkdir()` and re-raise even though the directory now exists. PR #49 monkeypatches `pathlib.Path.mkdir` for the duration of `run_benchmark()` so the race is absorbed instead of aborting the run.

## Test plan

- [ ] `uv sync` resolves cleanly with the new pin
- [ ] Run a multi-node checkpointing benchmark to confirm the Hydra job-dir race no longer trips
- [ ] Existing unit test suite still passes