### PR TITLE
fix(storage#758): loud-fail kvcache runs that produce no result files

### DIFF
--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -305,9 +305,17 @@ class KVCacheBenchmark(Benchmark):
         global_kv_args = self._build_global_kvcache_args(is_closed)
 
         option_results = {}
+        # Track (trial_index, exit_code, stderr_log_path) per option so the
+        # operator can go straight to the log that captured the underlying
+        # kv-cache.py error when a trial produced no rank result files
+        # (issue #758). We don't bail early — later options usually hit the
+        # same environment problem, and running them gives the operator the
+        # full log surface to inspect in one pass.
+        option_trial_failures: dict = {}
         for option in [1, 2, 3]:
             option_kv_args = self._build_option_kvcache_args(option, is_closed)
             trial_dirs = []
+            trial_failures: list = []
 
             for trial in range(trials):
                 option_trial_dir = (
@@ -329,18 +337,54 @@ class KVCacheBenchmark(Benchmark):
                 )
 
                 self.logger.status(f"Running option {option} trial {trial + 1}/{trials}...")
-                self._execute_command(
+                trial_prefix = f"kvcache_opt{option}_trial{trial}_{self.run_datetime}"
+                _, _, trial_rc = self._execute_command(
                     wrapper_cmd,
-                    output_file_prefix=f"kvcache_opt{option}_trial{trial}_{self.run_datetime}",
+                    output_file_prefix=trial_prefix,
                     print_stdout=True,
                     print_stderr=True,
                 )
                 trial_dirs.append(str(option_trial_dir))
 
+                if trial_rc != 0:
+                    stderr_log = Path(self.run_result_output) / f"{trial_prefix}.stderr.log"
+                    trial_failures.append((trial, trial_rc, str(stderr_log)))
+                    self.logger.error(
+                        f"Option {option} trial {trial + 1}/{trials}: mpirun "
+                        f"exited with code {trial_rc}. See {stderr_log} for "
+                        f"the underlying kv-cache.py error."
+                    )
+
+            if trial_failures:
+                option_trial_failures[option] = trial_failures
+
             if not getattr(self.args, 'what_if', False):
                 option_results[option] = self._aggregate_option_results(
                     option, trial_dirs, total_ranks
                 )
+                # Issue #758: when every rank across every trial failed to
+                # produce a result file, surface a loud error rather than
+                # silently averaging zeros into summary.json. The per-rank
+                # WARNING inside _aggregate_option_results still covers the
+                # partial-failure case (subset of ranks missing on a multi-
+                # host run); this block covers the total-loss case Nutanix
+                # hit.
+                expected_files = total_ranks * trials
+                missing_files = option_results[option].get('missing_files', [])
+                if expected_files > 0 and len(missing_files) >= expected_files:
+                    first_stderr = (
+                        Path(self.run_result_output)
+                        / f"kvcache_opt{option}_trial0_{self.run_datetime}.stderr.log"
+                    )
+                    self.logger.error(
+                        f"Option {option}: no kvcache_results_*.json produced "
+                        f"by any of the {total_ranks} rank(s) across "
+                        f"{trials} trial(s). kv-cache.py exited without "
+                        f"writing its output file. Inspect {first_stderr} "
+                        f"(and the sibling .stderr.log files for other "
+                        f"trials) for the underlying error; do not treat "
+                        f"summary.json aggregates as valid results."
+                    )
             else:
                 self.logger.info(f"what-if: skipping aggregation for option {option}")
 
@@ -348,10 +392,40 @@ class KVCacheBenchmark(Benchmark):
                 self._interruptible_sleep(inter_option_delay)
 
         if not getattr(self.args, 'what_if', False):
-            self._write_run_summary(option_results, npernode, len(hosts), total_ranks, trials)
+            self._write_run_summary(
+                option_results,
+                npernode,
+                len(hosts),
+                total_ranks,
+                trials,
+                option_trial_failures=option_trial_failures,
+            )
 
         self.write_metadata()
         self.write_cluster_info()
+
+        # Loud-failure verdict: if any option produced zero result files, the
+        # run's aggregates are meaningless. Exit non-zero so callers (CI,
+        # submission tooling, the operator's own shell $?) can't mistake a
+        # zero-value summary.json for a successful benchmark. Trials that
+        # exited non-zero but still produced SOME rank data fall through as
+        # partial_failure (existing behavior).
+        if not getattr(self.args, 'what_if', False):
+            expected_files_per_option = total_ranks * trials
+            zero_data_options = [
+                opt for opt, res in option_results.items()
+                if expected_files_per_option > 0
+                and len(res.get('missing_files', [])) >= expected_files_per_option
+            ]
+            if zero_data_options:
+                self.logger.error(
+                    f"kvcache run failed: option(s) {sorted(zero_data_options)} "
+                    f"produced no result files. summary.json has been written "
+                    f"but its aggregates are meaningless — this run is NOT a "
+                    f"valid MLPerf submission."
+                )
+                return 1
+
         return 0
 
     # ------------------------------------------------------------------
@@ -809,8 +883,27 @@ class KVCacheBenchmark(Benchmark):
         host_count: int,
         total_ranks: int,
         trials: int,
+        option_trial_failures: dict = None,
     ) -> None:
-        """Write aggregated run summary JSON to run_result_output."""
+        """Write aggregated run summary JSON to run_result_output.
+
+        ``option_trial_failures`` maps option number → list of
+        ``(trial_index, exit_code, stderr_log_path)`` for trials whose
+        mpirun invocation returned non-zero. Serialized under the
+        ``trial_failures`` key so an operator inspecting summary.json
+        after the fact can find the exact stderr log to read (issue #758).
+        """
+        serializable_failures = {}
+        for opt, failures in (option_trial_failures or {}).items():
+            serializable_failures[opt] = [
+                {
+                    'trial': trial_idx,
+                    'exit_code': rc,
+                    'stderr_log': stderr_path,
+                }
+                for (trial_idx, rc, stderr_path) in failures
+            ]
+
         summary = {
             'schema_version': '1.0',
             'run_datetime': self.run_datetime,
@@ -822,6 +915,7 @@ class KVCacheBenchmark(Benchmark):
             'partial_failure': any(
                 r.get('partial_failure', False) for r in option_results.values()
             ),
+            'trial_failures': serializable_failures,
         }
         # `summary.json` matches the filename training/checkpointing DLIO
         # writes and the name the submission checker's loader looks for

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -1145,6 +1145,262 @@ class TestExecuteRun:
         assert rc == 0
 
 
+class TestLoudFailureOnMissingResultFiles:
+    """Issue #758: kvcache must NOT silently succeed when kv-cache.py exits
+    without writing kvcache_results_*.json. When an option's rank result
+    files are entirely absent, _execute_run must return non-zero, emit an
+    ERROR log pointing at the specific stderr log, and mirror the trial
+    failures into summary.json under 'trial_failures'.
+    """
+
+    @pytest.fixture
+    def bm(self, tmp_path):
+        return _make_run_benchmark(tmp_path, what_if=False)
+
+    def _zero_data_agg_result(self, option, expected_files):
+        """Aggregate result shape for an option where every rank/trial was missing."""
+        return {
+            'option': option,
+            'aggregated_read_bandwidth_gbps': 0.0,
+            'aggregated_write_bandwidth_gbps': 0.0,
+            'aggregated_avg_throughput_tokens_per_sec': 0.0,
+            'aggregated_storage_throughput_tokens_per_sec': 0.0,
+            'aggregated_p95_latency_ms': None,
+            'rank_count': 2,
+            'trial_count': 3,
+            'partial_failure': True,
+            'missing_files': [f'missing_{i}' for i in range(expected_files)],
+            'cpu_tier_ranks': [],
+        }
+
+    def _healthy_agg_result(self, option):
+        return {
+            'option': option,
+            'aggregated_read_bandwidth_gbps': 1.0,
+            'aggregated_write_bandwidth_gbps': 1.0,
+            'aggregated_avg_throughput_tokens_per_sec': 1.0,
+            'aggregated_storage_throughput_tokens_per_sec': 1.0,
+            'aggregated_p95_latency_ms': 5.0,
+            'rank_count': 2,
+            'trial_count': 3,
+            'partial_failure': False,
+            'missing_files': [],
+            'cpu_tier_ranks': [],
+        }
+
+    def test_returns_1_when_option_has_zero_result_files(self, bm):
+        """When every rank/trial for an option produced no result file,
+        _execute_run must return 1 rather than falsely succeeding."""
+        bm.args.trials = 3
+        bm.args.inter_option_delay = 0
+        # 2 ranks × 3 trials = 6 expected files per option; option 3 has all 6 missing.
+        agg_side_effect = [
+            self._healthy_agg_result(1),
+            self._healthy_agg_result(2),
+            self._zero_data_agg_result(3, expected_files=6),
+        ]
+        with patch.object(bm, '_execute_command', return_value=('', '', 0)), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results', side_effect=agg_side_effect), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'):
+            rc = bm._execute_run()
+        assert rc == 1
+
+    def test_returns_0_when_all_options_have_result_files(self, bm):
+        """Sanity: healthy runs still return 0."""
+        bm.args.trials = 3
+        bm.args.inter_option_delay = 0
+        with patch.object(bm, '_execute_command', return_value=('', '', 0)), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results',
+                          side_effect=[self._healthy_agg_result(i) for i in (1, 2, 3)]), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'):
+            rc = bm._execute_run()
+        assert rc == 0
+
+    def test_returns_0_when_only_partial_failure(self, bm):
+        """A partial failure (some rank files missing but not all) is still
+        recorded as partial_failure and returns 0 — the existing behavior
+        for the multi-host visibility case must not regress."""
+        bm.args.trials = 3
+        bm.args.inter_option_delay = 0
+        # Option 3 has only some ranks missing (3 of 6), not all — this is
+        # the multi-host partial visibility case and should NOT trigger a
+        # non-zero exit.
+        partial = self._healthy_agg_result(3)
+        partial['partial_failure'] = True
+        partial['missing_files'] = ['a', 'b', 'c']
+        with patch.object(bm, '_execute_command', return_value=('', '', 0)), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results',
+                          side_effect=[self._healthy_agg_result(1),
+                                       self._healthy_agg_result(2),
+                                       partial]), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'):
+            rc = bm._execute_run()
+        assert rc == 0
+
+    def test_trial_failure_rc_captured_and_logged(self, bm):
+        """When _execute_command returns a non-zero exit code, an ERROR log
+        must be emitted that names the stderr log path so the operator can
+        go straight to the underlying kv-cache.py traceback."""
+        bm.args.trials = 1
+        bm.args.inter_option_delay = 0
+        # Trial 0 of option 1 fails; the rest succeed.
+        rc_sequence = [
+            ('', '', 137),  # option 1 trial 0 → OOM-kill style
+            ('', '', 0),    # option 2 trial 0
+            ('', '', 0),    # option 3 trial 0
+        ]
+        with patch.object(bm, '_execute_command', side_effect=rc_sequence), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results',
+                          side_effect=[self._healthy_agg_result(i) for i in (1, 2, 3)]), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'), \
+             patch.object(bm.logger, 'error') as mock_error:
+            bm._execute_run()
+        error_messages = [call.args[0] for call in mock_error.call_args_list]
+        matching = [m for m in error_messages if 'exit' in m.lower() and '137' in m]
+        assert matching, (
+            f"Expected an ERROR log mentioning the trial exit code 137. "
+            f"Got: {error_messages}"
+        )
+        # Must reference the stderr log path so the operator knows where to look.
+        assert any('.stderr.log' in m for m in matching), (
+            f"Trial-failure ERROR must include the stderr log path. Got: {matching}"
+        )
+
+    def test_zero_data_option_error_names_stderr_log(self, bm):
+        """The 'no result files' ERROR must include an actual stderr log path
+        so the operator can inspect the underlying kv-cache.py error without
+        grepping through the output directory (loud-failure principle)."""
+        bm.args.trials = 3
+        bm.args.inter_option_delay = 0
+        agg_side_effect = [
+            self._healthy_agg_result(1),
+            self._healthy_agg_result(2),
+            self._zero_data_agg_result(3, expected_files=6),
+        ]
+        with patch.object(bm, '_execute_command', return_value=('', '', 0)), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results', side_effect=agg_side_effect), \
+             patch.object(bm, '_write_run_summary'), \
+             patch.object(bm, 'write_metadata'), \
+             patch.object(bm.logger, 'error') as mock_error:
+            bm._execute_run()
+        error_messages = [call.args[0] for call in mock_error.call_args_list]
+        no_result_msgs = [
+            m for m in error_messages
+            if 'no kvcache_results_' in m or 'no result files' in m.lower()
+        ]
+        assert no_result_msgs, (
+            f"Expected a loud ERROR about missing result files. Got: {error_messages}"
+        )
+        assert any('kvcache_opt3_trial0_' in m and '.stderr.log' in m
+                   for m in no_result_msgs), (
+            f"Missing-files ERROR must point at the per-trial stderr log "
+            f"(kvcache_opt3_trial0_<datetime>.stderr.log). Got: {no_result_msgs}"
+        )
+
+    def test_summary_receives_trial_failures(self, bm):
+        """_write_run_summary must be called with the option_trial_failures
+        map so summary.json records the exit code and stderr log path for
+        each failed trial."""
+        bm.args.trials = 1
+        bm.args.inter_option_delay = 0
+        # option 1 trial 0 fails with rc=42; others succeed
+        rc_sequence = [('', '', 42), ('', '', 0), ('', '', 0)]
+        with patch.object(bm, '_execute_command', side_effect=rc_sequence), \
+             patch.object(bm, '_interruptible_sleep'), \
+             patch.object(bm, '_aggregate_option_results',
+                          side_effect=[self._healthy_agg_result(i) for i in (1, 2, 3)]), \
+             patch.object(bm, '_write_run_summary') as mock_ws, \
+             patch.object(bm, 'write_metadata'):
+            bm._execute_run()
+        assert mock_ws.call_count == 1
+        _, kwargs = mock_ws.call_args
+        assert 'option_trial_failures' in kwargs, (
+            f"_write_run_summary must receive option_trial_failures kwarg. "
+            f"Got kwargs: {list(kwargs.keys())}"
+        )
+        failures = kwargs['option_trial_failures']
+        assert 1 in failures, f"Expected option 1 in failures, got {failures}"
+        trial_idx, rc, stderr_path = failures[1][0]
+        assert trial_idx == 0
+        assert rc == 42
+        assert '.stderr.log' in stderr_path
+
+
+class TestWriteRunSummaryTrialFailures:
+    """Issue #758: summary.json must expose trial_failures so post-hoc
+    inspection reveals which trial's stderr log contains the actual error."""
+
+    def _healthy_option_result(self, option):
+        return {
+            'option': option,
+            'aggregated_read_bandwidth_gbps': 1.0,
+            'aggregated_write_bandwidth_gbps': 1.0,
+            'aggregated_avg_throughput_tokens_per_sec': 1.0,
+            'aggregated_storage_throughput_tokens_per_sec': 1.0,
+            'aggregated_p95_latency_ms': 5.0,
+            'rank_count': 2,
+            'trial_count': 3,
+            'partial_failure': False,
+            'missing_files': [],
+            'cpu_tier_ranks': [],
+        }
+
+    def test_trial_failures_key_present_when_empty(self, tmp_path):
+        """summary.json always contains a trial_failures key so downstream
+        readers can rely on its presence."""
+        bm = _make_run_benchmark(tmp_path)
+        output_dir = str(tmp_path / 'summary_out')
+        os.makedirs(output_dir, exist_ok=True)
+        bm.run_result_output = output_dir
+        bm._write_run_summary(
+            {1: self._healthy_option_result(1)},
+            npernode=2, host_count=1, total_ranks=2, trials=3,
+        )
+        with open(Path(output_dir) / 'summary.json') as f:
+            data = json.load(f)
+        assert 'trial_failures' in data
+        assert data['trial_failures'] == {}
+
+    def test_trial_failures_serialized_with_exit_code_and_stderr(self, tmp_path):
+        """When option_trial_failures is provided, each entry must serialize
+        with trial, exit_code, and stderr_log fields."""
+        bm = _make_run_benchmark(tmp_path)
+        output_dir = str(tmp_path / 'summary_out')
+        os.makedirs(output_dir, exist_ok=True)
+        bm.run_result_output = output_dir
+        failures = {
+            3: [
+                (0, 137, '/mnt/logs/.../kvcache_opt3_trial0_20260710_154835.stderr.log'),
+                (1, 137, '/mnt/logs/.../kvcache_opt3_trial1_20260710_154835.stderr.log'),
+            ],
+        }
+        bm._write_run_summary(
+            {3: self._healthy_option_result(3)},
+            npernode=2, host_count=1, total_ranks=2, trials=3,
+            option_trial_failures=failures,
+        )
+        with open(Path(output_dir) / 'summary.json') as f:
+            data = json.load(f)
+        # JSON keys are strings after serialization
+        tf = data['trial_failures']
+        assert '3' in tf or 3 in tf
+        entries = tf.get('3', tf.get(3))
+        assert len(entries) == 2
+        first = entries[0]
+        assert first['trial'] == 0
+        assert first['exit_code'] == 137
+        assert first['stderr_log'].endswith('.stderr.log')
+
+
 class TestClosedEnforcement:
     """Tests for CLOSED submission enforcement in _execute_run."""
 


### PR DESCRIPTION
## Summary

Fixes #758. When `kv-cache.py` exits without writing its output JSON, the mlpstorage kvcache benchmark was:

1. Discarding the mpirun/wrapper exit code in `_execute_run`.
2. Downgrading missing rank files to a per-rank `WARNING` in `_aggregate_option_results`.
3. Averaging zeros into `summary.json` and returning success.

The operator saw a "successful" run whose aggregates were meaningless. Nutanix hit this on option 3 (llama3.1-70b-instruct); the stderr log with the underlying error was on disk the whole time but nobody surfaced it.

## Change

- **`_execute_run`** now captures each trial's `_execute_command` return code. On non-zero it emits an `ERROR` that names the exact `<run>/kvcache_opt{N}_trial{T}_<datetime>.stderr.log` file to inspect. If any option produced zero rank result files across all trials, `_execute_run` returns `1` and emits a loud "this run is NOT a valid MLPerf submission" error.
- **`_write_run_summary`** takes a new `option_trial_failures` kwarg and serializes it under a top-level `trial_failures` key in `summary.json` (list of `{trial, exit_code, stderr_log}` per option). Post-hoc inspection of `summary.json` alone reveals which log to read.
- **Preserved:** partial-failure case (some ranks succeed, some don't) still returns 0 and records `partial_failure=True` — no regression for the multi-host visibility case that #521's probe already covers. `what-if` unchanged.

Root cause of *why* kv-cache.py exited (OOM under 70b-instruct, missing dep, config error, etc.) is environment-specific and not fixable from mlpstorage; this PR makes the failure visible so the operator can act on the stderr log.

## Test plan

- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed
- [x] `uv run pytest tests` — 2863 passed
- [x] `uv run pytest mlpstorage_py/tests` — 842 passed
- [x] `uv run pytest vdb_benchmark/tests` — 174 passed
- [x] +8 new tests in `TestLoudFailureOnMissingResultFiles` and `TestWriteRunSummaryTrialFailures` covering: rc=1 verdict on total-loss option, rc=0 preservation on partial failure, trial-failure ERROR log names the stderr path, missing-files ERROR names the trial-0 stderr path, `_write_run_summary` receives and serializes `trial_failures`.