### PR TITLE
fix(storage#760): tag dataset.total_disk_bytes as tool-injected

### DIFF
--- a/mlpstorage_py/rules/run_checkers/training.py
+++ b/mlpstorage_py/rules/run_checkers/training.py
@@ -69,6 +69,15 @@ class TrainingRunRulesChecker(RunRulesChecker):
         'storage.storage_options.storage_library',
         'storage.storage_options.uri_scheme',
         'storage.s3_force_path_style',
+        # datasize() persists this sizing output into params_dict so the
+        # datasize metadata file captures the sentinel end-to-end (#760).
+        # It is never user-typed via --params and has no CLOSED_ALLOWED
+        # entry, so without this line reportgen loading a datasize run's
+        # metadata marks the run INVALID for a value the tool itself wrote.
+        # (num_files_train / num_subfolders_train are also tool-written on
+        # datasize runs but appear in CLOSED_ALLOWED_PARAMS for run commands
+        # where they are genuine user overrides — leave those to that path.)
+        'dataset.total_disk_bytes',
     })
 
     def check_benchmark_type(self) -> Optional[Issue]:

--- a/tests/unit/test_rules_checkers.py
+++ b/tests/unit/test_rules_checkers.py
@@ -493,6 +493,38 @@ class TestTrainingRunRulesChecker:
         assert all(i.parameter == "Tool-Injected Parameters" for i in tool_msgs)
         assert all(i.parameter == "Overrode Parameters" for i in closed_msgs)
 
+    def test_check_allowed_params_datasize_total_disk_bytes_not_invalid(self, mock_logger):
+        """Regression for #760: reportgen loading a datasize run's metadata
+        marked the run INVALID because dataset.total_disk_bytes — written by
+        datasize() into params_dict as a sentinel for downstream tools — was
+        not listed as tool-injected."""
+        data = BenchmarkRunData(
+            benchmark_type=BENCHMARK_TYPES.training,
+            model="retinanet",
+            command="datasize",
+            run_datetime="20260710_093802",
+            num_processes=40,
+            parameters={
+                "dataset": {"num_files_train": 160234914, "num_subfolders_train": 0},
+                "reader": {"read_threads": 8}
+            },
+            override_parameters={
+                # The exact key that surfaced in #760's reportgen output.
+                "dataset.total_disk_bytes": 51748987120698,
+            }
+        )
+        run = BenchmarkRun.from_data(data, mock_logger)
+        checker = TrainingRunRulesChecker(run, logger=mock_logger)
+        issues = checker.check_allowed_params()
+
+        assert all(i.validation != PARAM_VALIDATION.INVALID for i in issues), (
+            f"dataset.total_disk_bytes is tool-written by datasize(); it must "
+            f"not be marked INVALID. Got: {[(i.message, i.validation) for i in issues]}"
+        )
+        tool_msgs = [i for i in issues if i.message.startswith("Tool-injected parameter:")]
+        assert len(tool_msgs) == 1
+        assert "dataset.total_disk_bytes" in tool_msgs[0].message
+
     def test_tool_injected_params_constant_includes_storage_keys(self):
         """All known tool-side setters in dlio.py must have their keys listed.
         Drift between the setters and this constant re-introduces #494-class bugs."""
@@ -515,6 +547,12 @@ class TestTrainingRunRulesChecker:
 
         # Key touched by add_datadir_param.
         assert "dataset.data_folder" in TrainingRunRulesChecker.TOOL_INJECTED_PARAMS
+
+        # Key persisted by datasize() into params_dict so the metadata file
+        # captures the sizing sentinel end-to-end (#760). Without this,
+        # reportgen loads the datasize metadata and marks the run INVALID
+        # for a value the tool itself wrote.
+        assert "dataset.total_disk_bytes" in TrainingRunRulesChecker.TOOL_INJECTED_PARAMS
 
     def test_check_odirect_unsupported_model(self, mock_logger):
         """check_odirect_supported_model returns INVALID for non-unet3d."""


### PR DESCRIPTION
## Summary

Fixes #760.

The training run-rules checker was marking otherwise-valid \`datasize\` runs INVALID because \`dataset.total_disk_bytes\` — written into \`params_dict\` by \`DLIOBenchmark.datasize()\` at \`mlpstorage_py/benchmarks/dlio.py:949\` as a metadata sentinel (Rules.md §3.3.1) — was not listed in \`TrainingRunRulesChecker.TOOL_INJECTED_PARAMS\`.

When \`reportgen\` loaded the datasize run's metadata, the checker saw \`dataset.total_disk_bytes\` in \`override_parameters\`, found no matching allow-list entry, and returned:

\`\`\`
[INVALID] Disallowed parameter override: dataset.total_disk_bytes = 51748987120698
\`\`\`

That INVALID run then cascaded into a \"Training submission requires 5 runs\" gate failure for a submission that was otherwise complete (issue #760 report).

Same fix pattern as #494 (skip_listing / listing_validation_interval): the key belongs in \`TOOL_INJECTED_PARAMS\` so it's reported under \"Tool-Injected Parameters\" at CLOSED validation, not against the user-override allow-list.

Only \`total_disk_bytes\` is added. \`num_files_train\` / \`num_subfolders_train\` are also tool-written on datasize runs but are genuine user overrides on \`run\` commands and are already in \`CLOSED_ALLOWED_PARAMS\`, so leaving those alone preserves the correct labeling on run commands.

## Test plan

- [x] New regression test: \`test_check_allowed_params_datasize_total_disk_bytes_not_invalid\` — feeds \`dataset.total_disk_bytes\` as an override on a datasize run and asserts no INVALID issue is produced. Fails on pre-fix code, passes on post-fix.
- [x] Drift-guard test extended: \`test_tool_injected_params_constant_includes_storage_keys\` now also asserts \`dataset.total_disk_bytes\` is in the constant, so future removal breaks the build.
- [x] Full CI suite passes locally, matching \`.github/workflows/test.yml\` (all four groups): \`uv run pytest tests\` (2864 passed), \`uv run pytest mlpstorage_py/tests\` (844 passed), \`uv run pytest vdb_benchmark/tests\` (174 passed), \`uv run pytest kv_cache_benchmark/tests\` (238 passed).