### PR TITLE
fix(storage#761): loud-fail training/checkpointing runs that produce no DLIO outputs

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -16,7 +16,9 @@ from mlpstorage_py.errors import ConfigurationError, ErrorCode
 from mlpstorage_py.rules import calculate_training_data_size, HostInfo, HostMemoryInfo, HostCPUInfo, ClusterInformation
 from mlpstorage_py.rules.datagen_hierarchy import (
     assert_data_dir_hierarchy_absent,
+    validate_checkpoint_leaf,
     validate_datagen_leaf,
+    validate_run_leaf,
     validate_supported_model,
     write_datagen_manifest,
 )
@@ -995,6 +997,37 @@ class TrainingBenchmark(DLIOBenchmark):
                     f'Post-datagen validation failed: {e}'
                 )
                 return EXIT_CODE.FAILURE
+        # Post-run loud-fail (storage#761). Mirrors the datagen block:
+        # storage#744 landed rc + leaf checks for datagen but not for
+        # run, so a DLIO training-run subprocess that died silently
+        # (crashed, killed, wrote no outputs) was reported as SUCCESS
+        # here and only surfaced later when ``mlpstorage validate``
+        # rejected the missing files. mlpstorage owns the verdict; the
+        # operator should not have to grep stdout logs to know whether
+        # their run produced valid artifacts.
+        if self.args.command == "run" and self.args.mode != "whatif":
+            rc = getattr(self, '_last_command_rc', 0)
+            if rc != 0:
+                self.logger.error(
+                    f'DLIO training-run command exited with non-zero '
+                    f'status ({rc}). Inspect the stdout/stderr logs '
+                    f'under "{self.run_result_output}" for the '
+                    f'underlying failure; this run\'s artifacts are '
+                    f'incomplete and must be re-run.'
+                )
+                return EXIT_CODE.FAILURE
+            missing = validate_run_leaf(self.run_result_output)
+            if missing:
+                for item in missing:
+                    self.logger.error(f'Training-run output leaf incomplete: {item}')
+                self.logger.error(
+                    f'Training-run leaf under "{self.run_result_output}" '
+                    f'is missing {len(missing)} required artifact(s) '
+                    f'despite a zero exit code. This run cannot be '
+                    f'submitted; re-run and inspect the DLIO stdout/'
+                    f'stderr logs for the underlying failure.'
+                )
+                return EXIT_CODE.FAILURE
         return EXIT_CODE.SUCCESS
 
     def _post_datagen_actions(self) -> bool:
@@ -1116,6 +1149,35 @@ class CheckpointingBenchmark(DLIOBenchmark):
                 return EXIT_CODE.INVALID_ARGUMENTS
         except Exception as e:
             return EXIT_CODE.FAILURE
+        # Post-run loud-fail (storage#761 sibling). Same silent-success
+        # gap as TrainingBenchmark's run branch: execute_command captures
+        # the DLIO rc into self._last_command_rc but the checkpointing
+        # _run returned SUCCESS regardless. A DLIO checkpointing run
+        # that dies without writing summary.json / dlio.log now surfaces
+        # as ERROR here instead of only at ``mlpstorage validate`` time.
+        if self.args.command == "run" and getattr(self.args, 'mode', None) != "whatif":
+            rc = getattr(self, '_last_command_rc', 0)
+            if rc != 0:
+                self.logger.error(
+                    f'DLIO checkpointing-run command exited with non-zero '
+                    f'status ({rc}). Inspect the stdout/stderr logs '
+                    f'under "{self.run_result_output}" for the '
+                    f'underlying failure; this run\'s artifacts are '
+                    f'incomplete and must be re-run.'
+                )
+                return EXIT_CODE.FAILURE
+            missing = validate_checkpoint_leaf(self.run_result_output)
+            if missing:
+                for item in missing:
+                    self.logger.error(f'Checkpointing-run output leaf incomplete: {item}')
+                self.logger.error(
+                    f'Checkpointing-run leaf under "{self.run_result_output}" '
+                    f'is missing {len(missing)} required artifact(s) '
+                    f'despite a zero exit code. This run cannot be '
+                    f'submitted; re-run and inspect the DLIO stdout/'
+                    f'stderr logs for the underlying failure.'
+                )
+                return EXIT_CODE.FAILURE
         return EXIT_CODE.SUCCESS
 
     # ------------------------------------------------------------------

--- a/mlpstorage_py/rules/datagen_hierarchy.py
+++ b/mlpstorage_py/rules/datagen_hierarchy.py
@@ -1,22 +1,27 @@
-"""Training datagen hierarchy validation and self-describing manifest.
+"""DLIO leaf hierarchy validation and self-describing datagen manifest.
 
-This module packages the four helpers used by:
+This module packages the helpers used by:
 
 - the training benchmark's datagen path in ``mlpstorage_py/benchmarks/``
   (pre-run guard + post-run manifest write + leaf WARN)
 - the report_generator's datagen group handling in
   ``mlpstorage_py/report_generator.py``
   (supported-model INVALID gate + leaf WARN)
+- the training and checkpointing benchmarks' post-run loud-fail hooks
+  (storage#761 sibling of storage#744 for datagen and storage#759 for
+  kvcache) — ``validate_run_leaf`` / ``validate_checkpoint_leaf``.
 
 Design notes
 ------------
 
-The DLIO datagen leaf under ``<results-dir>/.../training/<model>/datagen/<ts>/``
-carries the files listed in
+Each DLIO leaf under
+``<results-dir>/.../{training/<model>/{datagen,run},checkpointing/<model>}/<ts>/``
+carries a required-file set listed in
 ``mlpstorage_py/submission_checker/constants.py``
-(DATAGEN_REQUIRED_FILES / DATAGEN_REQUIRED_FOLDERS). We reuse those constants
-so the same file-set contract is enforced from three call sites (submission
-checker, run-checker, reportgen) without drift.
+(DATAGEN_REQUIRED_FILES / RUN_REQUIRED_FILES / CHECKPOINT_REQUIRED_FILES and
+their _FOLDERS counterparts). We reuse those constants so the same file-set
+contract is enforced from every call site (submission checker, run-checker,
+reportgen) without drift.
 
 The manifest at ``<data-dir>/<model>/.mlps-datagen-manifest.json`` is the
 self-describing record a future ``training run`` command will read to compare
@@ -53,8 +58,12 @@ from mlpstorage_py.config import (
 )
 from mlpstorage_py.errors import ConfigurationError, ErrorCode
 from mlpstorage_py.submission_checker.constants import (
+    CHECKPOINT_REQUIRED_FILES,
+    CHECKPOINT_REQUIRED_FOLDERS,
     DATAGEN_REQUIRED_FILES,
     DATAGEN_REQUIRED_FOLDERS,
+    RUN_REQUIRED_FILES,
+    RUN_REQUIRED_FOLDERS,
 )
 
 
@@ -293,6 +302,48 @@ def _select_regex_set(mapping: Dict[str, List[str]]) -> List[str]:
     return mapping.get("v3.0") or mapping.get("default") or []
 
 
+def _validate_leaf(
+    leaf_path: str,
+    files_map: Dict[str, List[str]],
+    folders_map: Dict[str, List[str]],
+    leaf_kind: str,
+) -> List[str]:
+    """Stat-only presence check against a required-files / folders contract.
+
+    Shared helper for the three DLIO leaf validators: datagen, run,
+    and checkpointing. Each leaf carries a different required-file
+    regex set (see ``submission_checker/constants.py``) but the check
+    shape — presence of the regex-matched files plus presence of the
+    ``dlio_config/`` folder with its three inner YAMLs — is identical.
+
+    Returns:
+        Human-readable missing-item strings; empty list means complete.
+    """
+    if not os.path.isdir(leaf_path):
+        return [f"{leaf_kind} leaf directory not found: {leaf_path}"]
+
+    missing: List[str] = []
+    entries = os.listdir(leaf_path)
+
+    for pattern in _select_regex_set(files_map):
+        if not any(re.search(pattern, name) for name in entries):
+            missing.append(_pretty_file_pattern(pattern))
+
+    for folder in _select_regex_set(folders_map):
+        folder_path = os.path.join(leaf_path, folder)
+        if not os.path.isdir(folder_path):
+            missing.append(f"required folder missing: {folder}/")
+            # No point drilling into the folder's expected inner files
+            # if the folder itself is absent — one message is clearer.
+            continue
+        inner_entries = set(os.listdir(folder_path))
+        for inner_name in _DLIO_CONFIG_REQUIRED_FILES:
+            if inner_name not in inner_entries:
+                missing.append(f"{folder}/{inner_name}")
+
+    return missing
+
+
 def validate_datagen_leaf(leaf_path: str) -> List[str]:
     """Return a list of missing-item descriptions for a datagen leaf.
 
@@ -307,29 +358,40 @@ def validate_datagen_leaf(leaf_path: str) -> List[str]:
         A list of human-readable missing-item strings. Empty list
         means the leaf is complete. Never raises.
     """
-    if not os.path.isdir(leaf_path):
-        return [f"datagen leaf directory not found: {leaf_path}"]
+    return _validate_leaf(
+        leaf_path, DATAGEN_REQUIRED_FILES, DATAGEN_REQUIRED_FOLDERS, "datagen"
+    )
 
-    missing: List[str] = []
-    entries = os.listdir(leaf_path)
 
-    for pattern in _select_regex_set(DATAGEN_REQUIRED_FILES):
-        if not any(re.search(pattern, name) for name in entries):
-            missing.append(_pretty_file_pattern(pattern))
+def validate_run_leaf(leaf_path: str) -> List[str]:
+    """Return a list of missing-item descriptions for a training-run leaf.
 
-    for folder in _select_regex_set(DATAGEN_REQUIRED_FOLDERS):
-        folder_path = os.path.join(leaf_path, folder)
-        if not os.path.isdir(folder_path):
-            missing.append(f"required folder missing: {folder}/")
-            # No point drilling into the folder's expected inner files
-            # if the folder itself is absent — one message is clearer.
-            continue
-        inner_entries = set(os.listdir(folder_path))
-        for inner_name in _DLIO_CONFIG_REQUIRED_FILES:
-            if inner_name not in inner_entries:
-                missing.append(f"{folder}/{inner_name}")
+    Mirrors ``validate_datagen_leaf`` but against the run-side contract
+    (``RUN_REQUIRED_FILES`` / ``RUN_REQUIRED_FOLDERS``). Used by the
+    training benchmark's post-run loud-fail hook so that a DLIO
+    subprocess which exits non-zero — or exits zero but writes no
+    outputs — surfaces as an ERROR at run time rather than a silent
+    "success" the operator only discovers when
+    ``mlpstorage validate`` rejects the submission (storage#761).
+    """
+    return _validate_leaf(
+        leaf_path, RUN_REQUIRED_FILES, RUN_REQUIRED_FOLDERS, "run"
+    )
 
-    return missing
+
+def validate_checkpoint_leaf(leaf_path: str) -> List[str]:
+    """Return a list of missing-item descriptions for a checkpointing leaf.
+
+    Same shape as ``validate_run_leaf`` but against
+    ``CHECKPOINT_REQUIRED_FILES`` / ``CHECKPOINT_REQUIRED_FOLDERS``.
+    Called from ``CheckpointingBenchmark._run`` to close the
+    silent-success gap on the checkpointing subprocess (sibling of
+    storage#761).
+    """
+    return _validate_leaf(
+        leaf_path, CHECKPOINT_REQUIRED_FILES, CHECKPOINT_REQUIRED_FOLDERS,
+        "checkpoint",
+    )
 
 
 def _pretty_file_pattern(pattern: str) -> str:

--- a/tests/unit/test_datagen_hierarchy.py
+++ b/tests/unit/test_datagen_hierarchy.py
@@ -40,7 +40,9 @@ from mlpstorage_py.rules.datagen_hierarchy import (
     DATAGEN_MANIFEST_FILENAME,
     DATAGEN_MANIFEST_SCHEMA_VERSION,
     assert_data_dir_hierarchy_absent,
+    validate_checkpoint_leaf,
     validate_datagen_leaf,
+    validate_run_leaf,
     validate_supported_model,
     write_datagen_manifest,
 )
@@ -229,6 +231,167 @@ class TestValidateDatagenLeaf:
         missing = validate_datagen_leaf(str(tmp_path / "does_not_exist"))
         assert len(missing) == 1
         assert "does_not_exist" in missing[0]
+
+
+# --------------------------------------------------------------------------- #
+# validate_run_leaf                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def _make_healthy_run_leaf(root: pathlib.Path, ts: str = "20260710_095915") -> pathlib.Path:
+    """Create a healthy training-run leaf: all required files + dlio_config."""
+    leaf = root / ts
+    leaf.mkdir(parents=True)
+    (leaf / "training_run.stdout.log").write_text("")
+    (leaf / "training_run.stderr.log").write_text("")
+    (leaf / "dlio.log").write_text("")
+    # RUN_REQUIRED_FILES uses the `.*<name>.json` regex family — the DLIO
+    # training loop prefixes these with the workload+timestamp; drop a
+    # representative name here so the regex matches.
+    (leaf / f"unet3d_{ts}_output.json").write_text("{}")
+    (leaf / f"unet3d_{ts}_per_epoch_stats.json").write_text("{}")
+    (leaf / f"unet3d_{ts}_summary.json").write_text("{}")
+    dlio_cfg = leaf / "dlio_config"
+    dlio_cfg.mkdir()
+    (dlio_cfg / "config.yaml").write_text("")
+    (dlio_cfg / "hydra.yaml").write_text("")
+    (dlio_cfg / "overrides.yaml").write_text("")
+    return leaf
+
+
+class TestValidateRunLeaf:
+    """Stat-only completeness check of the ``training/<model>/run/<ts>/`` leaf.
+
+    Mirrors ``TestValidateDatagenLeaf`` against ``RUN_REQUIRED_FILES`` /
+    ``RUN_REQUIRED_FOLDERS`` (submission_checker/constants.py:83-93).
+    Wired into ``TrainingBenchmark._run`` post-run so a DLIO subprocess
+    that crashes silently surfaces at run time instead of at
+    ``mlpstorage validate`` time (storage#761).
+    """
+
+    def test_healthy_leaf_returns_empty_list(self, tmp_path):
+        leaf = _make_healthy_run_leaf(tmp_path)
+        assert validate_run_leaf(str(leaf)) == []
+
+    def test_missing_dlio_log_reported(self, tmp_path):
+        # The exact signature of storage#761: DLIO crashed before
+        # writing dlio.log — the wrapper stdout log is present but the
+        # DLIO-native artifacts are not.
+        leaf = _make_healthy_run_leaf(tmp_path)
+        (leaf / "dlio.log").unlink()
+        missing = validate_run_leaf(str(leaf))
+        assert any("dlio.log" in m for m in missing), missing
+
+    def test_missing_summary_json_reported(self, tmp_path):
+        leaf = _make_healthy_run_leaf(tmp_path, ts="20260710_100000")
+        (leaf / "unet3d_20260710_100000_summary.json").unlink()
+        missing = validate_run_leaf(str(leaf))
+        assert any("summary.json" in m for m in missing), missing
+
+    def test_missing_output_json_reported(self, tmp_path):
+        leaf = _make_healthy_run_leaf(tmp_path, ts="20260710_100000")
+        (leaf / "unet3d_20260710_100000_output.json").unlink()
+        missing = validate_run_leaf(str(leaf))
+        assert any("output.json" in m for m in missing), missing
+
+    def test_missing_per_epoch_stats_reported(self, tmp_path):
+        leaf = _make_healthy_run_leaf(tmp_path, ts="20260710_100000")
+        (leaf / "unet3d_20260710_100000_per_epoch_stats.json").unlink()
+        missing = validate_run_leaf(str(leaf))
+        assert any("per_epoch_stats.json" in m for m in missing), missing
+
+    def test_missing_dlio_config_folder_reported(self, tmp_path):
+        leaf = _make_healthy_run_leaf(tmp_path)
+        for entry in (leaf / "dlio_config").iterdir():
+            entry.unlink()
+        (leaf / "dlio_config").rmdir()
+        missing = validate_run_leaf(str(leaf))
+        assert any("dlio_config" in m for m in missing), missing
+
+    def test_all_dlio_artifacts_missing_reports_all(self, tmp_path):
+        # The exact storage#761 scenario: DLIO never wrote anything.
+        # The wrapper stdout/stderr are present but no dlio.log,
+        # no *.json outputs, no dlio_config/. Expect the helper to
+        # enumerate every miss rather than short-circuit after the first.
+        leaf = tmp_path / "20260710_095915"
+        leaf.mkdir(parents=True)
+        (leaf / "training_run.stdout.log").write_text("")
+        (leaf / "training_run.stderr.log").write_text("")
+        missing = validate_run_leaf(str(leaf))
+        # Expect: dlio.log, output.json, per_epoch_stats.json, summary.json, dlio_config/
+        assert any("dlio.log" in m for m in missing), missing
+        assert any("output.json" in m for m in missing), missing
+        assert any("per_epoch_stats.json" in m for m in missing), missing
+        assert any("summary.json" in m for m in missing), missing
+        assert any("dlio_config" in m for m in missing), missing
+
+    def test_leaf_does_not_exist_reports_leaf_missing(self, tmp_path):
+        missing = validate_run_leaf(str(tmp_path / "does_not_exist"))
+        assert len(missing) == 1
+        assert "does_not_exist" in missing[0]
+        assert "run" in missing[0]
+
+
+# --------------------------------------------------------------------------- #
+# validate_checkpoint_leaf                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def _make_healthy_checkpoint_leaf(root: pathlib.Path, ts: str = "20260710_120000") -> pathlib.Path:
+    """Create a healthy checkpointing-run leaf per CHECKPOINT_REQUIRED_FILES."""
+    leaf = root / ts
+    leaf.mkdir(parents=True)
+    (leaf / "checkpointing_run.stdout.log").write_text("")
+    (leaf / "checkpointing_run.stderr.log").write_text("")
+    (leaf / "dlio.log").write_text("")
+    (leaf / f"llama3_8b_{ts}_output.json").write_text("{}")
+    (leaf / f"llama3_8b_{ts}_per_epoch_stats.json").write_text("{}")
+    (leaf / f"llama3_8b_{ts}_summary.json").write_text("{}")
+    dlio_cfg = leaf / "dlio_config"
+    dlio_cfg.mkdir()
+    (dlio_cfg / "config.yaml").write_text("")
+    (dlio_cfg / "hydra.yaml").write_text("")
+    (dlio_cfg / "overrides.yaml").write_text("")
+    return leaf
+
+
+class TestValidateCheckpointLeaf:
+    """Stat-only completeness check of the checkpointing leaf.
+
+    Mirrors ``TestValidateRunLeaf`` against
+    ``CHECKPOINT_REQUIRED_FILES`` / ``CHECKPOINT_REQUIRED_FOLDERS``
+    (submission_checker/constants.py:98-108). Wired into
+    ``CheckpointingBenchmark._run`` — sibling of storage#761.
+    """
+
+    def test_healthy_leaf_returns_empty_list(self, tmp_path):
+        leaf = _make_healthy_checkpoint_leaf(tmp_path)
+        assert validate_checkpoint_leaf(str(leaf)) == []
+
+    def test_missing_dlio_log_reported(self, tmp_path):
+        leaf = _make_healthy_checkpoint_leaf(tmp_path)
+        (leaf / "dlio.log").unlink()
+        missing = validate_checkpoint_leaf(str(leaf))
+        assert any("dlio.log" in m for m in missing), missing
+
+    def test_missing_summary_json_reported(self, tmp_path):
+        leaf = _make_healthy_checkpoint_leaf(tmp_path, ts="20260710_130000")
+        (leaf / "llama3_8b_20260710_130000_summary.json").unlink()
+        missing = validate_checkpoint_leaf(str(leaf))
+        assert any("summary.json" in m for m in missing), missing
+
+    def test_missing_dlio_config_folder_reported(self, tmp_path):
+        leaf = _make_healthy_checkpoint_leaf(tmp_path)
+        for entry in (leaf / "dlio_config").iterdir():
+            entry.unlink()
+        (leaf / "dlio_config").rmdir()
+        missing = validate_checkpoint_leaf(str(leaf))
+        assert any("dlio_config" in m for m in missing), missing
+
+    def test_leaf_does_not_exist_reports_leaf_missing(self, tmp_path):
+        missing = validate_checkpoint_leaf(str(tmp_path / "does_not_exist"))
+        assert len(missing) == 1
+        assert "checkpoint" in missing[0]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Closes #761.

`mlpstorage training run` (and `mlpstorage checkpointing run`) returned `EXIT_CODE.SUCCESS` regardless of the DLIO subprocess's exit code. When DLIO crashed or was killed before writing its outputs, the operator saw a "successful" run and only discovered the failure much later, when `mlpstorage validate` complained about missing `dlio.log` / `summary.json` / `output.json` / `dlio_config/`.

This PR extends the loud-fail pattern already applied to `datagen` (#750, storage#744) and `kvcache` (#759, storage#758) to both training-run and checkpointing-run:

- **Non-zero DLIO rc** — emit an ERROR naming `run_result_output` and return `EXIT_CODE.FAILURE`.
- **rc == 0 but incomplete leaf** — stat-check against `RUN_REQUIRED_FILES` / `RUN_REQUIRED_FOLDERS` (or `CHECKPOINT_*`), emit per-item ERRORs and return `EXIT_CODE.FAILURE`.
- Same constants source of truth the submission checker uses — no drift.
- Whatif is exempted (simulation modality, per D-29).

## Changes

- `mlpstorage_py/rules/datagen_hierarchy.py` — refactor the presence check into shared `_validate_leaf`, add public `validate_run_leaf` and `validate_checkpoint_leaf`.
- `mlpstorage_py/benchmarks/dlio.py` — add post-run rc + leaf checks to `TrainingBenchmark._run` (run branch) and `CheckpointingBenchmark._run` (run branch).
- `tests/unit/test_datagen_hierarchy.py` — 15 new tests: `TestValidateRunLeaf` (7) + `TestValidateCheckpointLeaf` (4) + the exact #761 scenario (all-DLIO-artifacts-missing).

## Scope note — why bundle checkpointing here

Grep of the benchmark tree turned up exactly one sibling of the #761 bug: `CheckpointingBenchmark._run` had the same "capture rc, ignore rc, return SUCCESS" shape. Same fix pattern, same constants, same test shape. `VectorDBBenchmark` and `KVCacheBenchmark` already propagate rc correctly (the latter via #759). Bundling was cheaper than a follow-up PR.

## Not addressed (deliberately)

- **Why DLIO died on the reporter's retinanet run** — no diagnostic evidence yet. The new ERROR message points operators at their local `training_run.stdout.log` / `training_run.stderr.log`, so the next report on this failure mode will arrive with the evidence attached.
- **2.1.17 runTimestamps expected 6, found 1** — Rules.md 2.1.17 requires 1 warm-up + 5 measured runs. The submission checker is correctly enforcing that; not a code bug.

## Test plan

- [x] `uv run pytest tests mlpstorage_py/tests` — 3721 passed, 1 skipped
- [x] `uv run pytest kv_cache_benchmark/tests vdb_benchmark/tests` — 412 passed
- [x] New unit tests exercise the exact #761 scenario (leaf with wrapper stdout/stderr present but all DLIO-native artifacts missing)
- [ ] Manual: trigger a DLIO run with an intentionally-failing config and confirm the ERROR fires with the expected message shape