### PR TITLE
fix(storage#767): write datagen metadata before leaf-completeness check

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -1041,6 +1041,23 @@ class TrainingBenchmark(DLIOBenchmark):
         object-storage URIs via ``--data-dir``'s scheme and dispatches
         to s3dlio internally, so this method is backend-agnostic.
         """
+        # storage#767: write metadata BEFORE the leaf check. The
+        # required-artifact set includes ``training_<ts>_metadata.json``
+        # (mlpstorage-injected — see DATAGEN_REQUIRED_FILES), but
+        # main.py's ``benchmark.write_metadata()`` runs in a ``finally``
+        # block AFTER ``benchmark.run()`` returns. Without this
+        # pre-write the validator false-positived on every datagen run,
+        # reporting the metadata file missing and refusing to write the
+        # manifest. Errors here are logged but not fatal — if the write
+        # actually fails, the leaf check below will surface the
+        # still-missing metadata file with the same loud error path.
+        try:
+            self.write_metadata()
+        except Exception as e:
+            self.logger.warning(
+                f'Failed to write datagen metadata before leaf check: {e}'
+            )
+
         missing = validate_datagen_leaf(self.run_result_output)
         if missing:
             for item in missing:

--- a/tests/integration/test_datagen_hierarchy_wiring.py
+++ b/tests/integration/test_datagen_hierarchy_wiring.py
@@ -401,6 +401,57 @@ class TestPostRunLeafGate:
             f"Unexpected leaf-incomplete errors on healthy leaf: {error_msgs}"
         )
 
+    def test_dlio_only_leaf_succeeds_without_pre_seeded_metadata(self, tmp_path):
+        """storage#767: production DLIO never writes the mlpstorage metadata
+        file; that file is written by ``Benchmark.write_metadata()`` in
+        main.py's ``finally`` block, i.e. AFTER ``_run`` returns. Before
+        the fix, ``_post_datagen_actions`` ran the leaf check first and
+        false-positived on every real datagen run with
+        ``ERROR: Datagen output leaf incomplete: training_.*_metadata.json``.
+        This test seeds only the four artifacts DLIO actually produces and
+        asserts SUCCESS + a written manifest + the metadata file present
+        on disk after ``_run``.
+        """
+        (tmp_path / "data").mkdir()
+        benchmark, logger = _instantiate_datagen_benchmark(tmp_path)
+        # Seed only what production DLIO writes — deliberately NO metadata.
+        leaf = benchmark.run_result_output
+        for name in (
+            "training_datagen.stdout.log",
+            "training_datagen.stderr.log",
+            "dlio.log",
+        ):
+            open(os.path.join(leaf, name), "w").close()
+        dlio_cfg = os.path.join(leaf, "dlio_config")
+        os.makedirs(dlio_cfg)
+        for name in ("config.yaml", "hydra.yaml", "overrides.yaml"):
+            open(os.path.join(dlio_cfg, name), "w").close()
+
+        result = benchmark._run()
+
+        assert result == EXIT_CODE.SUCCESS
+        error_msgs = [
+            call.args[0]
+            for call in logger.error.call_args_list
+            if call.args and "Datagen output leaf" in call.args[0]
+        ]
+        assert error_msgs == [], (
+            f"storage#767 regression: leaf check false-positived on "
+            f"metadata file that _post_datagen_actions is now responsible "
+            f"for writing pre-check. Errors: {error_msgs}"
+        )
+        assert os.path.isfile(benchmark.metadata_file_path), (
+            f"Expected metadata file {benchmark.metadata_file_path} to "
+            f"exist after _run — _post_datagen_actions must write it "
+            f"before the leaf check."
+        )
+        manifest_path = os.path.join(
+            benchmark.args.data_dir, "unet3d", DATAGEN_MANIFEST_FILENAME
+        )
+        assert os.path.isfile(manifest_path), (
+            f"Expected manifest at {manifest_path}; not found."
+        )
+
 
 class TestDLIOFailureGate:
     """storage#744: non-zero DLIO exit code fails the run — no manifest written."""


### PR DESCRIPTION
## Summary

Fixes #767. Every `mlpstorage training datagen` run has been false-positiving with:

```
ERROR: Datagen output leaf incomplete: training_.*_metadata.json
ERROR: Datagen leaf under "..." is missing 1 required artifact(s); skipping
       datagen manifest write. The dataset ... is incomplete and must be
       regenerated.
```

storage#744's leaf-completeness gate lists `training_<ts>_metadata.json` in `DATAGEN_REQUIRED_FILES`, and `TrainingBenchmark._post_datagen_actions()` runs `validate_datagen_leaf()` before returning from `_run()`. But that metadata file is written by `Benchmark.write_metadata()` from `main.py`'s `finally` block — which only executes **after** `benchmark.run()` returns. So at check time the file does not yet exist, the leaf is (correctly) reported incomplete, the manifest write is skipped, and the operator is falsely told the dataset must be regenerated.

Fix: call `self.write_metadata()` at the top of `_post_datagen_actions()`, before the leaf check. `main.py`'s `finally` block still runs and idempotently overwrites the same file. Errors from the pre-write are logged as warnings; if the write actually fails, the leaf check will surface the still-missing metadata file through the same loud error path.

## Test plan

- [x] New regression test `test_dlio_only_leaf_succeeds_without_pre_seeded_metadata` seeds only the four artifacts production DLIO actually writes (deliberately NOT the metadata file) and asserts `_run` succeeds, the manifest lands under `<data-dir>/<model>/`, and the metadata file is present on disk after `_run`.
- [x] Verified the new test FAILS without the fix (reverted the source change temporarily) and PASSES with it.
- [x] `uv run pytest tests` — 2878 passed
- [x] `uv run pytest mlpstorage_py/tests` — 844 passed
- [x] `uv run pytest vdb_benchmark/tests` — 174 passed
- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed