### PR TITLE
fix(#768): unregister child-side resource_tracker for borrowed IPC

### DIFF
--- a/mlpstorage_py/checkpointing/streaming_checkpoint.py
+++ b/mlpstorage_py/checkpointing/streaming_checkpoint.py
@@ -171,6 +171,79 @@ from typing import Optional, Dict, Any
 
 from .storage_writers import StorageWriterFactory
 
+
+# Issue #768: pre-3.13 CPython resource_tracker double-unlink workaround.
+#
+# multiprocessing.resource_tracker registers POSIX shared-memory segments and
+# named semaphores in every process that touches them via
+# SharedMemory(name=...) attach or Queue/Event pickle-unpickle. When the
+# streaming-checkpoint writer subprocess (spawned per save() on the forkserver
+# path for #642 safety) exits, its tracker races Main's to unlink the same
+# names — one wins, the other raises FileNotFoundError. On the shm side that
+# crashed Main's finally block, killing the owning MPI rank; on the semaphore
+# side it produced alarming SemLock._rebuild and "leaked" warnings that
+# spooked benchmark submitters even though nothing was actually lost.
+#
+# The documented CPython workaround for 3.12 is: in the borrowing child,
+# unregister the names from ITS tracker so single-owner semantics are
+# restored — only Main's tracker unlinks at exit. 3.13 adds a public
+# SharedMemory(..., track=False) that supersedes the shm branch below;
+# SemLock has no equivalent even in 3.13, so the semaphore branch stays
+# until we can drop 3.12.
+#
+# Only removes the child's cleanup callback for the given POSIX name; does
+# not close fds, detach shared state, or alter runtime behavior of the IPC
+# object. Every access is hasattr-guarded so a future CPython refactor of
+# the private ``_semlock`` / ``_rlock`` / ``_flag`` attrs degrades to a
+# silent no-op (returning to pre-#768 noise) rather than crashing the
+# checkpoint.
+def _unregister_ipc_from_child_tracker(*ipc_objs):
+    """Undo the child process's redundant resource_tracker registration of
+    parent-owned SharedMemory / Queue / Event primitives (issue #768)."""
+    from multiprocessing import resource_tracker
+
+    def _try(name, kind):
+        try:
+            resource_tracker.unregister(name, kind)
+        except Exception:
+            # KeyError = not tracked here (nothing to undo); anything else =
+            # tracker down / private-attr drift. Silent degrade is the goal.
+            pass
+
+    def _semlock_name(obj):
+        sl = getattr(obj, "_semlock", None)
+        return getattr(sl, "name", None) if sl is not None else None
+
+    for obj in ipc_objs:
+        if obj is None:
+            continue
+
+        # SharedMemory: single named POSIX segment. Detect by the pair of
+        # attrs SharedMemory uniquely provides — a bare object with a _name
+        # attribute would false-positive here otherwise.
+        name = getattr(obj, "_name", None)
+        if name and hasattr(obj, "unlink") and hasattr(obj, "close"):
+            _try(name, "shared_memory")
+            continue
+
+        # mp.Queue and mp.Event both carry SemLock-backed primitives. The
+        # attribute layout is undocumented but stable in CPython since 3.4;
+        # enumerate the known slots and hasattr-guard each.
+        for attr in ("_rlock", "_wlock", "_sem", "_flag"):
+            v = getattr(obj, attr, None)
+            if v is not None:
+                sem_name = _semlock_name(v)
+                if sem_name:
+                    _try(sem_name, "semaphore")
+        for attr in ("_notempty", "_notfull", "_cond"):
+            cond = getattr(obj, attr, None)
+            if cond is not None:
+                lock = getattr(cond, "_lock", None)
+                if lock is not None:
+                    sem_name = _semlock_name(lock)
+                    if sem_name:
+                        _try(sem_name, "semaphore")
+
 # Try to import dgen-py for high-performance data generation
 try:
     import dgen_py
@@ -409,10 +482,10 @@ class StreamingCheckpointing:
             raise
         
         finally:
-            # Cleanup buffers
-            for shm in buffers:
-                shm.close()
-                shm.unlink()
+            # Cleanup buffers — see _release_buffer_pool for the #768 defensive
+            # FileNotFoundError swallow that keeps a raced writer-side unlink
+            # from crashing the owning MPI rank in Main's finally.
+            self._release_buffer_pool(buffers)
         
         # Collect results
         if stats_queue.empty():
@@ -424,6 +497,35 @@ class StreamingCheckpointing:
         
         return self._format_results(stats, gen_time, time.time() - start_time, total_size_bytes)
     
+    @staticmethod
+    def _release_buffer_pool(buffers):
+        """Release Main's per-save() shared-memory buffer pool.
+
+        Defensive against #768: swallows ``FileNotFoundError`` on
+        ``shm.unlink()`` because a second unlink of an already-unlinked
+        segment is exactly the desired end state (segment gone), not a real
+        failure — that spurious exception is what crashed the owning MPI
+        rank and killed the whole job in the reporter's traceback.
+
+        Other exceptions (``PermissionError``, ``OSError`` from the IO layer)
+        still propagate: they indicate real bugs, not the resource_tracker
+        double-unlink race, and must not be masked by this shim.
+        Non-``FileNotFoundError`` ``close()`` failures on one buffer do not
+        stop cleanup of the rest — segments are independent POSIX names and
+        one bad segment shouldn't strand N-1 others as leaks.
+        """
+        for shm in buffers:
+            try:
+                shm.close()
+            except Exception:
+                pass  # keep unwinding — the remaining unlink still matters
+            try:
+                shm.unlink()
+            except FileNotFoundError:
+                # #768: writer's resource_tracker won the race. Segment is
+                # gone, which is what we wanted. Not a real error.
+                pass
+
     def _create_buffer_pool(self):
         """Create shared memory buffer pool."""
         print(f"\n[Main] Creating {self.num_buffers} buffers...")
@@ -528,7 +630,17 @@ class StreamingCheckpointing:
         for name in buffer_names:
             shm = shared_memory.SharedMemory(name=name)
             buffers.append(shm)
-        
+
+        # #768: undo this subprocess's redundant resource_tracker registration
+        # of the SharedMemory segments we just attached to AND the Queue/Event
+        # IPC objects Main passed in as args. Both would otherwise be
+        # unlinked twice at process exit — once here, once in Main — with
+        # whichever tracker lost the race crashing with FileNotFoundError.
+        # Only Main owns these; only Main should unlink.
+        _unregister_ipc_from_child_tracker(
+            *buffers, buffer_queue, stats_queue, stop_event
+        )
+
         print(f"[Writer] Attached to {len(buffers)} buffers ({chunk_size / (1024**2):.0f} MB each)")
         
         # Create storage writer

--- a/tests/unit/test_streaming_checkpoint_resource_tracker.py
+++ b/tests/unit/test_streaming_checkpoint_resource_tracker.py
@@ -1,0 +1,366 @@
+"""Tests for streaming-checkpoint IPC resource_tracker safety (issue #768).
+
+Python 3.12's ``multiprocessing.resource_tracker`` registers POSIX
+shared-memory segments and named semaphores in **every** process that
+touches them via ``SharedMemory(name=...)`` attach or ``Queue``/``Event``
+pickle-unpickle. Whichever process's tracker fires first at shutdown
+unlinks the underlying name; the second tracker races to
+``FileNotFoundError``.
+
+On the streaming-checkpoint object-storage path (writer subprocess spawned
+per ``save()`` on the ``forkserver`` context) that raced double-unlink
+surfaces as:
+
+* fatal ``shm.unlink() -> FileNotFoundError`` in Main's ``finally`` block,
+  killing the owning MPI rank and tearing down the whole job
+* non-fatal ``SemLock._rebuild -> FileNotFoundError`` noise from
+  ``forkserver``-spawned worker startups
+* ``resource_tracker: leaked semaphore/shared_memory`` warnings at exit
+  that are alarming for submitters even though they indicate no data loss
+
+Fix (documented CPython pre-3.13 workaround): in the writer subprocess,
+unregister the borrowed names from ITS ``resource_tracker`` so only Main
+ever unlinks. Plus a defensive ``FileNotFoundError`` swallow in Main's
+buffer-pool cleanup for any residual race.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mlpstorage_py.checkpointing import streaming_checkpoint as sc
+
+
+# --------------------------------------------------------------------------- #
+#  _unregister_ipc_from_child_tracker                                         #
+# --------------------------------------------------------------------------- #
+
+
+class TestUnregisterIpcFromChildTracker:
+    """The writer subprocess must unregister borrowed IPC names from its
+    own ``resource_tracker`` so only Main's tracker unlinks them at exit
+    (#768). The helper is the single injection point for that workaround."""
+
+    def test_helper_exists(self):
+        """The workaround entry point must be importable from the module."""
+        assert hasattr(sc, "_unregister_ipc_from_child_tracker"), (
+            "Missing #768 fix: writer subprocess needs a helper to "
+            "unregister resource_tracker's redundant ownership of "
+            "Main-owned SharedMemory/Queue/Event names."
+        )
+
+    def test_unregisters_shared_memory_by_name(self):
+        """SharedMemory carries a single POSIX name; the helper unregisters
+        it as kind ``shared_memory`` so the writer's tracker won't unlink it
+        on process exit — leaving that job to Main, the actual owner."""
+        shm = MagicMock(spec=["_name", "unlink", "close"])
+        shm._name = "/ckpt_probe_0"
+
+        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
+            sc._unregister_ipc_from_child_tracker(shm)
+
+        mock_unreg.assert_called_once_with("/ckpt_probe_0", "shared_memory")
+
+    def test_unregisters_all_queue_semlocks(self):
+        """A ``forkserver``-context Queue carries several SemLock-backed
+        primitives (``_rlock``, ``_wlock``, ``_sem``, ``_notempty._lock``,
+        and — for bounded queues — ``_notfull._lock``). Every one of them
+        gets registered in the child's tracker at unpickle time; each must
+        be unregistered here or the SemLock double-unlink race remains."""
+        ctx = mp.get_context("forkserver")
+        q = ctx.Queue(maxsize=4)
+
+        expected = set()
+        for attr in ("_rlock", "_wlock", "_sem"):
+            v = getattr(q, attr, None)
+            if v is not None and hasattr(v, "_semlock"):
+                expected.add((v._semlock.name, "semaphore"))
+        for attr in ("_notempty", "_notfull"):
+            cond = getattr(q, attr, None)
+            if cond is not None:
+                lock = getattr(cond, "_lock", None)
+                if lock is not None and hasattr(lock, "_semlock"):
+                    expected.add((lock._semlock.name, "semaphore"))
+
+        assert expected, (
+            "Test setup broken: forkserver Queue exposed no SemLock names."
+        )
+
+        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
+            sc._unregister_ipc_from_child_tracker(q)
+
+        actual = {call.args for call in mock_unreg.call_args_list}
+        missed = expected - actual
+        assert not missed, (
+            f"queue SemLocks not unregistered from child tracker: {missed}"
+        )
+
+    def test_unregisters_event_semlocks(self):
+        """An ``Event`` carries an internal ``_cond._lock._semlock`` (the
+        condition-variable lock) and ``_flag._semlock`` (the BoundedSemaphore
+        backing the set/unset flag). Both must be unregistered."""
+        ctx = mp.get_context("forkserver")
+        e = ctx.Event()
+
+        expected = set()
+        cond = getattr(e, "_cond", None)
+        if cond is not None:
+            lock = getattr(cond, "_lock", None)
+            if lock is not None and hasattr(lock, "_semlock"):
+                expected.add((lock._semlock.name, "semaphore"))
+        flag = getattr(e, "_flag", None)
+        if flag is not None and hasattr(flag, "_semlock"):
+            expected.add((flag._semlock.name, "semaphore"))
+
+        assert expected, (
+            "Test setup broken: forkserver Event exposed no SemLock names."
+        )
+
+        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
+            sc._unregister_ipc_from_child_tracker(e)
+
+        actual = {call.args for call in mock_unreg.call_args_list}
+        missed = expected - actual
+        assert not missed, (
+            f"event SemLocks not unregistered from child tracker: {missed}"
+        )
+
+    def test_swallows_key_error(self):
+        """``resource_tracker.unregister`` raises ``KeyError`` when the name
+        is not tracked in this process. That's fine — nothing to undo —
+        and must not propagate. The writer cannot afford to crash on
+        a cleanup no-op."""
+        shm = MagicMock(spec=["_name", "unlink", "close"])
+        shm._name = "/ckpt_probe_x"
+
+        with patch(
+            "multiprocessing.resource_tracker.unregister",
+            side_effect=KeyError("/ckpt_probe_x"),
+        ):
+            sc._unregister_ipc_from_child_tracker(shm)  # must not raise
+
+    def test_swallows_arbitrary_tracker_errors(self):
+        """The tracker subprocess can also die. Silent degrade — better to
+        return to pre-#768 noise than crash the checkpoint entirely."""
+        shm = MagicMock(spec=["_name", "unlink", "close"])
+        shm._name = "/ckpt_probe_y"
+
+        with patch(
+            "multiprocessing.resource_tracker.unregister",
+            side_effect=RuntimeError("resource_tracker gone"),
+        ):
+            sc._unregister_ipc_from_child_tracker(shm)  # must not raise
+
+    def test_none_argument_is_a_no_op(self):
+        """The writer passes ``stop_event`` which is always non-None in
+        practice, but the helper must tolerate ``None`` in the arg pack
+        so callers don't have to filter."""
+        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
+            sc._unregister_ipc_from_child_tracker(None)
+        mock_unreg.assert_not_called()
+
+    def test_multiple_objects_in_one_call(self):
+        """Callers typically batch buffers + queues + events into one call —
+        each object's names must be unregistered independently."""
+        shm_a = MagicMock(spec=["_name", "unlink", "close"])
+        shm_a._name = "/ckpt_a"
+        shm_b = MagicMock(spec=["_name", "unlink", "close"])
+        shm_b._name = "/ckpt_b"
+
+        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
+            sc._unregister_ipc_from_child_tracker(shm_a, shm_b)
+
+        args = {call.args for call in mock_unreg.call_args_list}
+        assert ("/ckpt_a", "shared_memory") in args
+        assert ("/ckpt_b", "shared_memory") in args
+
+    def test_unknown_object_type_degrades_silently(self):
+        """A future CPython refactor might rename the private ``_semlock`` /
+        ``_rlock`` attrs. The helper must degrade to a no-op silently in
+        that case — returning to pre-#768 noise is preferable to crashing
+        the checkpoint. The failure mode is *silent*, on purpose."""
+        opaque = SimpleNamespace()
+
+        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
+            sc._unregister_ipc_from_child_tracker(opaque)
+        mock_unreg.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+#  StreamingCheckpointing._release_buffer_pool                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestReleaseBufferPoolTolerantOfMissingSegments:
+    """Main's per-``save()`` buffer-pool cleanup must not crash when the
+    writer's ``resource_tracker`` won the race and already unlinked a
+    segment (#768). Defensive backstop for any residual double-unlink race
+    that survives the primary fix — a second unlink of an already-unlinked
+    segment is exactly the desired end state, not a real failure."""
+
+    def test_release_buffer_pool_helper_exists(self):
+        """The cleanup must be factored into a testable helper so its
+        error-tolerance can be verified without spinning up a real
+        writer subprocess."""
+        assert hasattr(sc.StreamingCheckpointing, "_release_buffer_pool"), (
+            "Missing #768 defensive: buffer-pool cleanup must be a "
+            "factored helper so FileNotFoundError from shm.unlink() "
+            "can be tolerated without going through save()."
+        )
+
+    def test_release_pool_swallows_file_not_found(self):
+        """Simulate the writer-tracker-won-race scenario from #768: the
+        second ``unlink()`` hits ``FileNotFoundError`` because the writer's
+        tracker already unlinked the segment. That is *exactly what we
+        wanted*: the segment is gone. Must not propagate — the reporter's
+        stack shows this crashing the owning MPI rank and killing the job."""
+        happy = MagicMock()
+        happy.close = MagicMock()
+        happy.unlink = MagicMock()
+
+        already_unlinked = MagicMock()
+        already_unlinked.close = MagicMock()
+        already_unlinked.unlink = MagicMock(
+            side_effect=FileNotFoundError(
+                2,
+                "No such file or directory",
+                "/ckpt_452136_0_1783755003328000",
+            )
+        )
+
+        # Both buffers processed even though one raised FileNotFoundError.
+        sc.StreamingCheckpointing._release_buffer_pool([happy, already_unlinked])
+
+        happy.close.assert_called_once()
+        happy.unlink.assert_called_once()
+        already_unlinked.close.assert_called_once()
+        already_unlinked.unlink.assert_called_once()
+
+    def test_release_pool_propagates_unrelated_errors(self):
+        """``FileNotFoundError`` is the specific #768 race. Other exceptions
+        (``PermissionError``, ``OSError`` from IO layer) indicate real bugs
+        elsewhere and must NOT be masked by this defensive shim."""
+        bad = MagicMock()
+        bad.close = MagicMock()
+        bad.unlink = MagicMock(side_effect=PermissionError(13, "no perm"))
+
+        with pytest.raises(PermissionError):
+            sc.StreamingCheckpointing._release_buffer_pool([bad])
+
+    def test_release_pool_handles_empty_list(self):
+        """A defensive no-op on an empty pool — reachable if buffer-pool
+        creation failed partway through and we're unwinding."""
+        sc.StreamingCheckpointing._release_buffer_pool([])
+
+    def test_release_pool_continues_past_close_error(self):
+        """``close()`` errors on one buffer must not prevent cleanup of
+        the rest. Segments are independent POSIX names — one bad segment
+        shouldn't strand N-1 others as leaks."""
+        bad_close = MagicMock()
+        bad_close.close = MagicMock(side_effect=OSError("bad close"))
+        bad_close.unlink = MagicMock()
+
+        good = MagicMock()
+        good.close = MagicMock()
+        good.unlink = MagicMock()
+
+        sc.StreamingCheckpointing._release_buffer_pool([bad_close, good])
+
+        # Cleanup continued to the second buffer.
+        good.close.assert_called_once()
+        good.unlink.assert_called_once()
+
+
+# --------------------------------------------------------------------------- #
+#  Writer subprocess wiring                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class TestWriterProcessInvokesUnregister:
+    """The writer subprocess entry point ``_writer_process`` must invoke
+    the resource_tracker workaround for (a) the shared-memory buffers it
+    attaches to by name, and (b) the ``Queue``/``Event`` IPC objects it
+    received via pickle from Main. Verifying the call wiring here so a
+    future refactor of ``_writer_process`` cannot silently regress the
+    #768 fix and let the crash rot back in."""
+
+    def test_writer_process_calls_unregister_helper_for_attached_ipc(self):
+        """After attaching to the SharedMemory buffers and before entering
+        the write loop, the writer must call ``_unregister_ipc_from_child_tracker``
+        with every buffer it attached AND every IPC object it received as
+        args (``buffer_queue``, ``stop_event``, ``stats_queue``). Missing
+        any of them re-opens the #768 race for that primitive."""
+        names = ["/ckpt_probe_a", "/ckpt_probe_b", "/ckpt_probe_c"]
+        fake_shms = []
+        for n in names:
+            m = MagicMock()
+            m._name = n
+            fake_shms.append(m)
+
+        buffer_queue = MagicMock()
+        # Immediate stop — write loop never iterates.
+        buffer_queue.get = MagicMock(return_value=None)
+        stop_event = MagicMock()
+        stats_queue = MagicMock()
+        stats_queue.put = MagicMock()
+        stats_queue.close = MagicMock()
+        stats_queue.join_thread = MagicMock()
+
+        fake_writer = MagicMock()
+        fake_writer.close = MagicMock(return_value={"backend": "test"})
+
+        with patch.object(
+            sc.shared_memory, "SharedMemory", side_effect=fake_shms
+        ), patch.object(
+            sc.StorageWriterFactory, "create", return_value=fake_writer
+        ), patch.object(
+            sc, "_unregister_ipc_from_child_tracker"
+        ) as mock_unreg, patch(
+            "os._exit"
+        ):
+            sc.StreamingCheckpointing._writer_process(
+                names,
+                1024,
+                "/tmp/probe_ckpt",
+                0,  # total_size=0 → write loop skipped
+                buffer_queue,
+                stop_event,
+                stats_queue,
+                "file",
+                False,
+                "none",
+            )
+
+        assert mock_unreg.called, (
+            "Writer subprocess must invoke _unregister_ipc_from_child_tracker "
+            "after attaching to Main's IPC — otherwise the #768 double-unlink "
+            "race is not closed."
+        )
+
+        # Aggregate every positional arg across all calls to the helper.
+        seen = set()
+        for call in mock_unreg.call_args_list:
+            for arg in call.args:
+                seen.add(id(arg))
+
+        for shm in fake_shms:
+            assert id(shm) in seen, (
+                f"writer failed to unregister attached SharedMemory {shm._name} "
+                f"from child resource_tracker"
+            )
+        assert id(buffer_queue) in seen, (
+            "writer failed to unregister buffer_queue's SemLocks — "
+            "leaves the mp.Queue semaphore race path open"
+        )
+        assert id(stats_queue) in seen, (
+            "writer failed to unregister stats_queue's SemLocks — "
+            "leaves the mp.Queue semaphore race path open"
+        )
+        assert id(stop_event) in seen, (
+            "writer failed to unregister stop_event's SemLocks — "
+            "leaves the mp.Event semaphore race path open"
+        )


### PR DESCRIPTION
Fixes #768.

## Summary

- Python 3.12's `multiprocessing.resource_tracker` registers POSIX shared-memory segments and named semaphores in **every** process that touches them via `SharedMemory(name=...)` or `Queue`/`Event` unpickle. The streaming-checkpoint writer subprocess (forkserver, per `save()`) therefore double-registered as owner of Main's IPC; whichever tracker exited first unlinked, and the other raced to `FileNotFoundError` — fatal on `shm.unlink()` in Main's `finally` (killed the owning MPI rank and tore down the whole job on llama3-70b/405b runs), noisy but non-fatal on the `SemLock._rebuild` and `resource_tracker: leaked …` paths.
- Documented pre-3.13 CPython workaround: in the borrowing child, unregister the names from its resource_tracker so single-owner semantics are restored — only Main unlinks at exit. 3.13's `SharedMemory(track=False)` will supersede the shm branch here; SemLock has no equivalent even in 3.13.

## Changes

1. **`_unregister_ipc_from_child_tracker`** — new module-level helper in `mlpstorage_py/checkpointing/streaming_checkpoint.py`. Unregisters `SharedMemory` by `_name` and walks `Queue`/`Event` private SemLock attrs (`_rlock`, `_wlock`, `_sem`, `_notempty._lock`, `_notfull._lock`, `_cond._lock`, `_flag`). Every access `hasattr`-guarded so a future CPython refactor degrades to a silent no-op (pre-#768 noise returns; checkpoint keeps working). Swallows tracker errors (`KeyError` for names not tracked here, `RuntimeError` if the tracker subprocess died).
2. **`StreamingCheckpointing._release_buffer_pool`** — factored buffer-pool cleanup, static method. Defensive `except FileNotFoundError: pass` on `shm.unlink()` as a backstop for any residual race — a second unlink of an already-gone segment is the desired end state, not a real failure. `PermissionError`/`OSError` still propagate. Non-`FileNotFoundError` `close()` errors on one buffer don't strand the rest.
3. **`_writer_process` wiring** — invokes the helper for the attached `SharedMemory` buffers plus the received `buffer_queue`, `stats_queue`, and `stop_event` immediately after buffer attach, before the write loop starts.

## Why all three IPC kinds and not just shm

Reporter's analysis calls out that the `SemLock._rebuild` traceback and "leaked semaphore" warnings share the identical mechanism as the shm crash. Field runs use `ctx.Queue()` and `ctx.Event()` at `streaming_checkpoint.py:369-371`, so those are affected in the same way. Fixing the semaphore side requires reaching into private CPython attrs, which are stable since 3.4 but could silently drift in the future — the `hasattr` guards ensure that drift means quieter benchmark output goes back to the pre-fix state, not a broken checkpoint.

Benchmark submitters have reported the noisy `resource_tracker` / `SemLock._rebuild` output being alarming even when it's non-fatal, so eliminating the noise is a first-class goal alongside fixing the crash.

## Test plan

- [x] `uv run pytest tests/unit/test_streaming_checkpoint_resource_tracker.py -v` — 15 new tests, all pass:
  - Helper: unregisters SharedMemory by name; walks all Queue and Event SemLocks; swallows `KeyError`, arbitrary tracker errors, and unknown object types; batches multiple objects per call
  - `_release_buffer_pool`: swallows `FileNotFoundError`; propagates `PermissionError`; handles empty list; continues past `close()` errors
  - `_writer_process`: verifies wiring — the writer subprocess entry point calls the helper for every attached buffer and every received IPC arg
- [x] `uv run pytest tests/unit/test_streaming_checkpoint_mp_context.py tests/unit/test_streaming_checkpoint_generator_threads.py -q` — sibling streaming-checkpoint tests, no regressions (32 pass)
- [x] `uv run pytest tests/unit -q` — full unit suite, 2729 pass / 1 skip / 0 fail
- [ ] Real-hardware validation on the llama3-70b or llama3-405b object-storage path is deferred: the exact race the fix targets is intermittent at 64-512 ranks and can only be reproduced at that scale. The unit tests lock the workaround at the helper boundary; sign-off from a submission-scale run would confirm the alarming log noise is quiet and the crash no longer surfaces.

## TDD trail

- `6140d93` — RED: 15 failing tests written first
- `b5566d7` — GREEN: implementation added, all 15 pass, no regressions