### PR TITLE
fix(storage#772): probe --results-dir for shared-FS visibility (CAP-02b)

### DIFF
--- a/mlpstorage_py/benchmarks/base.py
+++ b/mlpstorage_py/benchmarks/base.py
@@ -67,6 +67,7 @@ from mlpstorage_py.cluster_collector import (
     TimeSeriesCollector,
     MultiHostTimeSeriesCollector,
     run_shared_fs_probe,
+    run_results_dir_shared_probe,
 )
 from mlpstorage_py.benchmarks.fs_separation_probe import probe_fs_separation
 from mlpstorage_py.progress import create_stage_progress, progress_context
@@ -1056,6 +1057,29 @@ class Benchmark(BenchmarkInterface, abc.ABC):
                 mpi_bin=getattr(self.args, 'mpi_bin', None),
                 allow_run_as_root=getattr(self.args, 'allow_run_as_root', False),
                 ssh_username=getattr(self.args, 'ssh_username', None),
+            )
+        # ------------------------------------------------------------------
+        # CAP-02b: --results-dir shared-FS probe (storage#772).
+        # ------------------------------------------------------------------
+        # CAP-02 covers --data-dir. --results-dir has the same
+        # shared-FS requirement (rank 0 writes summary.json/output.json,
+        # each rank writes its own dlio.log) but was previously only
+        # probed for kvcache (issue #521). Storage#772's reporter ran 51
+        # workers with a per-host-local --results-dir; each host wrote
+        # dlio.log to its own copy, only rank 0 wrote summary.json to
+        # its own copy, and the launcher's timestamp leaf came out empty.
+        # Reuses the same --skip-validation opt-out as CAP-02; no new
+        # flag needed (see storage#772 discussion for the opt-out
+        # rationale re: Argonne's srun/PALS auto-skip).
+        if not getattr(self.args, 'skip_validation', False):
+            hosts = getattr(self.args, 'hosts', None) or []
+            run_results_dir_shared_probe(
+                results_dir=self.run_result_output,
+                hosts=hosts,
+                run_uuid=self._run_uuid,
+                logger=self.logger,
+                mpi_bin=getattr(self.args, 'mpi_bin', None),
+                allow_run_as_root=getattr(self.args, 'allow_run_as_root', False),
             )
         # ------------------------------------------------------------------
         # Slice 5 / CAP-03: FS-separation probe (issue #601).

--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, asdict
@@ -3921,6 +3922,214 @@ def run_shared_fs_probe(destination, hosts, run_uuid, logger,
         msg,
         path=destination,
         operation="cap02-shared-fs-probe",
+        code=ErrorCode.FS_INVALID_STRUCTURE,
+    )
+
+
+# =============================================================================
+# CAP-02b Results-Dir Shared-Filesystem Probe (storage#772)
+# =============================================================================
+#
+# Sibling of CAP-02: verifies that ``--results-dir`` — not just
+# ``--data-dir`` — is visible at the same path on every host in ``--hosts``.
+# storage#772 reporter's failure mode: DLIO writes ``summary.json`` on rank
+# 0's local FS and ``dlio.log`` on each rank's local FS. When
+# ``--results-dir`` is per-host local storage, those artifacts scatter,
+# ``mlpstorage validate`` sees empty run/timestamp/ leaves on the launcher,
+# and the operator wastes cluster time discovering the misconfiguration.
+#
+# Pattern lifted from ``KVCacheBenchmark._probe_results_dir_shared`` (issue
+# #521). Inline ``python -c "..."`` payload — no SCP staging — so we
+# introduce no new SSH surface beyond what CAP-02 already needs for the
+# launcher bootstrap. Argonne's srun/PALS-launcher path keeps working
+# unchanged because the payload goes through the caller's ``mpi_bin``, not
+# through a dedicated SSH connection.
+#
+# Opt-out: callers respect the same ``--skip-validation`` blanket flag that
+# gates CAP-02. No dedicated ``--skip-results-dir`` flag: the SSH-preflight
+# auto-skip (``_launcher_bypasses_ssh``) is orthogonal because this probe
+# does not do a dedicated SSH reachability test.
+
+
+def run_results_dir_shared_probe(results_dir, hosts, run_uuid, logger,
+                                 mpi_bin=None, allow_run_as_root=False,
+                                 timeout_seconds=60):
+    """Verify --results-dir is visible at the same path on every host.
+
+    Contract (storage#772):
+
+    * **Silent no-op** when ``hosts`` is None/empty/single or resolves to
+      all-localhost. No subprocess is spawned, no ``.fs_probe/`` scratch
+      dir is created, and only a debug-level log is emitted. Callers
+      still invoke the helper unconditionally so the short-circuit lives
+      in one place.
+    * **Shared FS (success)**: each rank drops a sentinel
+      ``{probe_id}__rank<r>__<host>.ok`` under
+      ``<results_dir>/.fs_probe/``. If the launcher sees a sentinel from
+      every unique host, the probe returns ``None`` and removes
+      ``.fs_probe/`` so the timestamp leaf stays clean for the
+      submission checker's directory-contents rules.
+    * **Non-shared FS (failure)**: at least one host wrote its sentinel
+      to its OWN local ``results_dir`` (invisible to the launcher).
+      Raise :class:`FileSystemError` with ``ErrorCode.FS_INVALID_STRUCTURE``
+      and a diagnostic that names the missing hosts and the shared-FS
+      remedy. ``.fs_probe/`` is preserved so the operator can diagnose.
+
+    Args:
+        results_dir: Absolute path of the run's results leaf
+            (``Benchmark.run_result_output``).
+        hosts: The ``--hosts`` list. ``host:N`` slot suffixes are
+            stripped; ``None`` and empty list trigger the silent no-op.
+        run_uuid: The per-Benchmark ``self._run_uuid``. Its first 12
+            hex characters are used as the sentinel probe_id so
+            concurrent runs against the same results tree cannot collide
+            (Pitfall 7 style).
+        logger: Project logger.
+        mpi_bin: MPI binary to invoke (``mpirun`` / ``mpiexec`` / ``srun``).
+            Defaults to :data:`MPIRUN`.
+        allow_run_as_root: If True, append ``--allow-run-as-root`` (Open
+            MPI convention).
+        timeout_seconds: Wall-clock upper bound on the mpirun subprocess.
+
+    Raises:
+        FileSystemError: On non-shared FS detection OR on a non-zero
+            launcher exit code (the latter surfaces mpirun bootstrap
+            errors like bad ``--hosts`` without silently pretending the
+            probe passed).
+    """
+    # Filter to unique hosts, stripping :N slot suffixes so
+    # ``--hosts h1:4 h2:4`` probes 2 hosts, not 8.
+    unique_hosts: List[str] = []
+    seen = set()
+    for raw in hosts or []:
+        hostname = raw.split(":")[0] if ":" in raw else raw
+        if hostname and hostname not in seen:
+            seen.add(hostname)
+            unique_hosts.append(hostname)
+
+    if len(unique_hosts) <= 1:
+        logger.debug("CAP-02b (results-dir) skipped: single-host run")
+        return None
+    if all(_is_localhost(h) for h in unique_hosts):
+        logger.debug("CAP-02b (results-dir) skipped: all-localhost run")
+        return None
+
+    if mpi_bin is None:
+        mpi_bin = MPIRUN
+
+    # Use first 12 hex of the caller's run_uuid so the sentinel name is
+    # bound to this Benchmark instance (concurrent-run collision guard).
+    probe_id = (run_uuid or "")[:12]
+    if len(probe_id) < 12 or not all(c in "0123456789abcdef" for c in probe_id):
+        probe_id = uuid.uuid4().hex[:12]
+
+    probe_dir = Path(results_dir) / ".fs_probe"
+    probe_dir.mkdir(parents=True, exist_ok=True)
+
+    # Inline payload — no staged script file. Each rank:
+    #   1. Re-creates the probe dir on its local view (mkdir exist_ok so a
+    #      rank whose --results-dir was never created still runs).
+    #   2. Writes a sentinel file naming its rank and hostname.
+    # Shared FS: all N sentinels land in the launcher-visible probe_dir.
+    # Split FS: each rank's sentinel lands on its own local filesystem, so
+    # the launcher sees at most its own.
+    inline = (
+        "import os,socket,pathlib;"
+        f"d=pathlib.Path({str(probe_dir)!r});"
+        "d.mkdir(parents=True,exist_ok=True);"
+        "r=os.environ.get('OMPI_COMM_WORLD_RANK',os.environ.get('PMI_RANK','x'));"
+        "h=socket.gethostname();"
+        f"(d/('{probe_id}__rank'+r+'__'+h+'.ok')).write_text(h)"
+    )
+
+    probe_hosts_arg = ",".join(f"{h}:1" for h in unique_hosts)
+    prefix = (
+        f"{mpi_bin} -n {len(unique_hosts)} -host {probe_hosts_arg} "
+        f"--map-by node --bind-to none"
+    )
+    if allow_run_as_root:
+        prefix += " --allow-run-as-root"
+
+    import shlex as _shlex
+    cmd = f"{prefix} {sys.executable} -c {_shlex.quote(inline)}"
+
+    logger.status(
+        f"Probing --results-dir visibility across {len(unique_hosts)} host(s) "
+        f"(CAP-02b, storage#772)..."
+    )
+
+    try:
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise FileSystemError(
+            (
+                f"CAP-02b: --results-dir shared-FS probe timed out after "
+                f"{timeout_seconds}s across hosts {sorted(unique_hosts)}. "
+                f"Verify --hosts reachability and --mpi-bin choice."
+            ),
+            path=results_dir,
+            operation="cap02b-results-dir-probe",
+            code=ErrorCode.FS_INVALID_STRUCTURE,
+        ) from e
+
+    if result.returncode != 0:
+        # Launcher bootstrap error — do NOT silently pretend the probe
+        # passed just because probe_dir is empty. Surface rc + stderr.
+        msg = (
+            f"CAP-02b: --results-dir shared-FS probe launcher exited "
+            f"with returncode={result.returncode}. "
+            f"stderr: {(result.stderr or '').strip()}"
+        )
+        logger.error(msg)
+        raise FileSystemError(
+            msg,
+            path=results_dir,
+            operation="cap02b-results-dir-probe",
+            code=ErrorCode.FS_INVALID_STRUCTURE,
+        )
+
+    found_hosts: set = set()
+    for marker in probe_dir.glob(f"{probe_id}__rank*__*.ok"):
+        try:
+            found_hosts.add(marker.read_text().strip())
+        except OSError:
+            continue
+
+    if len(found_hosts) >= len(unique_hosts):
+        # Shared FS — clean up so the timestamp leaf stays lean.
+        try:
+            shutil.rmtree(probe_dir)
+        except OSError as cleanup_err:
+            logger.warning(
+                "CAP-02b: could not remove probe dir %s: %s",
+                probe_dir, cleanup_err,
+            )
+        return None
+
+    missing = sorted(set(unique_hosts) - found_hosts)
+    msg = (
+        f"--results-dir is not visible on every host listed in --hosts.\n"
+        f"  Probed {len(unique_hosts)} host(s): {sorted(unique_hosts)}\n"
+        f"  Only {len(found_hosts)} host(s) landed a sentinel into "
+        f"{results_dir}: {sorted(found_hosts)}\n"
+        f"  Missing sentinels for: {missing}\n"
+        f"MLPerf training / checkpointing require --results-dir to be on a "
+        f"shared filesystem (NFS / Lustre / GPFS) mounted at the same path "
+        f"on every host in --hosts. DLIO writes summary.json / output.json "
+        f"on rank 0 and dlio.log on each rank; if --results-dir is per-host "
+        f"local storage those artifacts scatter and mlpstorage validate "
+        f"reports the run leaf as empty (storage#772). Mount a shared "
+        f"filesystem at {results_dir!r} on every host and re-run, or run "
+        f"on a single host."
+    )
+    logger.error(msg)
+    raise FileSystemError(
+        msg,
+        path=results_dir,
+        operation="cap02b-results-dir-probe",
         code=ErrorCode.FS_INVALID_STRUCTURE,
     )
 

--- a/tests/integration/test_systemname_yaml_end_to_end.py
+++ b/tests/integration/test_systemname_yaml_end_to_end.py
@@ -1727,14 +1727,21 @@ class TestPhase5Cap02:
 
     def test_multi_host_cardinality_1_succeeds_silently(self, tmp_path):
         """Multi-host cardinality 1: launcher returns None (success); the
-        benchmark proceeds to _run normally. No logger.error/warning."""
+        benchmark proceeds to _run normally. No logger.error/warning.
+
+        storage#772: CAP-02b (results-dir shared-FS probe) also fires from
+        _pre_execution_gate; patch it alongside CAP-02 so the fake host1/
+        host2 don't trigger a real mpirun/ssh attempt.
+        """
         hosts = [_make_host(hostname=f"h{i}") for i in range(2)]
         bm = _make_benchmark_with_local_destination(
             tmp_path, hosts, hosts_arg=['host1', 'host2'])
         logger = MagicMock()
         bm.logger = logger
         with patch('mlpstorage_py.benchmarks.base.run_shared_fs_probe',
-                   return_value=None) as mock_probe:
+                   return_value=None) as mock_probe, \
+             patch('mlpstorage_py.benchmarks.base.run_results_dir_shared_probe',
+                   return_value=None):
             rc = bm.run()
         assert rc == 0
         assert mock_probe.called
@@ -1805,7 +1812,9 @@ class TestPhase5Cap02:
 
     def test_cap02_fires_after_cap01_in_pre_execution_gate_ordering(self, tmp_path):
         """Gate-order lock: in _pre_execution_gate, check_capacity_4field is
-        called BEFORE run_shared_fs_probe. Slice 3 + Slice 4 ordering."""
+        called BEFORE run_shared_fs_probe, which in turn precedes
+        run_results_dir_shared_probe (CAP-02b, storage#772).
+        Slice 3 + Slice 4 + Slice 4b ordering."""
         hosts = [_make_host(hostname=f"h{i}") for i in range(2)]
         bm = _make_benchmark(tmp_path, hosts)
         bm.args.hosts = ['host1', 'host2']
@@ -1817,15 +1826,19 @@ class TestPhase5Cap02:
             call_order.append('cap01')
         def cap02_se(*a, **kw):
             call_order.append('cap02')
+        def cap02b_se(*a, **kw):
+            call_order.append('cap02b')
 
         with patch('mlpstorage_py.benchmarks.base.check_capacity_4field',
                    side_effect=cap01_se), \
              patch('mlpstorage_py.benchmarks.base.run_shared_fs_probe',
-                   side_effect=cap02_se):
+                   side_effect=cap02_se), \
+             patch('mlpstorage_py.benchmarks.base.run_results_dir_shared_probe',
+                   side_effect=cap02b_se):
             bm.run()
 
-        assert call_order == ['cap01', 'cap02'], (
-            f"Expected CAP-01 BEFORE CAP-02, got: {call_order}"
+        assert call_order == ['cap01', 'cap02', 'cap02b'], (
+            f"Expected CAP-01 → CAP-02 → CAP-02b, got: {call_order}"
         )
 
     def test_cap02_fires_before_write_systemname_yaml(self, tmp_path):

--- a/tests/unit/test_capacity_gate.py
+++ b/tests/unit/test_capacity_gate.py
@@ -153,14 +153,23 @@ def _make_mock_benchmark(destination, required_bytes, logger=None):
     We provide an empty hosts list by default so the probe takes its
     SC#8 single-host no-op short-circuit; tests that care about the
     CAP-02 path can override args.hosts and patch run_shared_fs_probe.
+
+    storage#772 (CAP-02b wiring) note: _pre_execution_gate additionally
+    reads self.run_result_output to invoke run_results_dir_shared_probe.
+    The empty hosts list above also silences CAP-02b; we set
+    args.skip_validation to False (the production default) so the
+    CAP-02b block executes and reaches its own short-circuit rather than
+    being suppressed by the opt-out flag.
     """
     bm = MagicMock(spec=Benchmark)
     bm._capacity_gate_destination = MagicMock(return_value=destination)
     bm.required_bytes_for_capacity_gate = MagicMock(return_value=required_bytes)
     bm.logger = logger or MagicMock()
     bm.args = SimpleNamespace(hosts=[], mpi_bin=None,
-                              allow_run_as_root=False, ssh_username=None)
+                              allow_run_as_root=False, ssh_username=None,
+                              skip_validation=False)
     bm._run_uuid = "test-uuid-mock"
+    bm.run_result_output = "/tmp/mlps-cap-test-placeholder"
     # Bind the real method to the mock so it actually executes.
     bm._pre_execution_gate = Benchmark._pre_execution_gate.__get__(bm, MagicMock)
     return bm

--- a/tests/unit/test_pre_execution_gate_results_dir.py
+++ b/tests/unit/test_pre_execution_gate_results_dir.py
@@ -1,0 +1,171 @@
+"""Unit tests for ``Benchmark._pre_execution_gate`` results-dir shared-FS
+probe wiring (storage#772).
+
+This module locks the *call-site* contract for lifting kvcache's inline
+shared-results-dir probe into ``Benchmark._pre_execution_gate``:
+
+- Runs AFTER CAP-02 (data-dir shared-FS probe) and BEFORE CAP-03
+  (FS-separation probe). Ordering matters because CAP-02 is the closest
+  sibling contract; if CAP-02 already established that data-dir is
+  shared, we still need to independently verify results-dir.
+- Passes ``self.run_result_output`` as the probe destination (the
+  timestamp leaf that will hold ``dlio.log`` / ``summary.json`` /
+  ``dlio_config/``).
+- Respects the same ``--skip-validation`` blanket opt-out that CAP-02
+  respects. Storage#772 opt-out discussion: no new ``--skip-results-dir``
+  flag is added, and the SSH-preflight auto-skip
+  (``_launcher_bypasses_ssh``) does NOT apply here because the probe
+  does not do a dedicated SSH reachability test — the launcher bootstrap
+  itself is what talks (or doesn't talk) to SSH, and that's already
+  handled by the caller's ``mpi_bin`` choice.
+- A ``FileSystemError`` from the probe propagates unchanged so
+  ``Benchmark.run()`` aborts before ``write_systemname_yaml``.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub heavy deps that mlpstorage_py.benchmarks.base transitively pulls in.
+import importlib.util as _ilu
+for _dep in ("pyarrow", "pyarrow.ipc", "psutil"):
+    if _dep in sys.modules:
+        continue
+    try:
+        _spec = _ilu.find_spec(_dep)
+    except (ModuleNotFoundError, ValueError):
+        _spec = None
+    if _spec is None:
+        sys.modules[_dep] = MagicMock()
+
+from mlpstorage_py.benchmarks.base import Benchmark
+from mlpstorage_py.errors import ErrorCode, FileSystemError
+
+
+def _make_mock_benchmark(destination, required_bytes, hosts, tmp_path,
+                         skip_validation=False):
+    """Bare Benchmark-like object exposing only the surface
+    ``_pre_execution_gate`` touches. Mirrors the fixture in
+    ``tests/unit/test_capacity_gate.py:_make_mock_benchmark`` but
+    parameterizes hosts + skip_validation for the results-dir probe path.
+    """
+    bm = MagicMock(spec=Benchmark)
+    bm._capacity_gate_destination = MagicMock(return_value=destination)
+    bm.required_bytes_for_capacity_gate = MagicMock(return_value=required_bytes)
+    bm.logger = MagicMock()
+    bm.args = SimpleNamespace(
+        hosts=hosts,
+        mpi_bin=None,
+        allow_run_as_root=False,
+        ssh_username=None,
+        skip_validation=skip_validation,
+        skip_fs_separation_gate=False,
+    )
+    bm._run_uuid = "test-uuid-mock"
+    bm.run_result_output = str(tmp_path)
+    bm._run_fs_separation_probe = MagicMock()  # CAP-03 stubbed
+    bm._pre_execution_gate = Benchmark._pre_execution_gate.__get__(bm, MagicMock)
+    return bm
+
+
+class TestResultsDirProbeCalled:
+    """Positive path: probe fires with the correct arguments."""
+
+    def test_probe_called_with_run_result_output(self, tmp_path):
+        bm = _make_mock_benchmark(str(tmp_path), 1,
+                                  hosts=["h1", "h2"], tmp_path=tmp_path)
+        with patch(
+            "mlpstorage_py.benchmarks.base.check_capacity_4field"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_results_dir_shared_probe"
+        ) as mock_probe:
+            bm._pre_execution_gate()
+
+        mock_probe.assert_called_once()
+        _, kwargs = mock_probe.call_args
+        assert kwargs["results_dir"] == str(tmp_path)
+        assert kwargs["hosts"] == ["h1", "h2"]
+        assert kwargs["run_uuid"] == "test-uuid-mock"
+
+
+class TestResultsDirProbeSkip:
+    """Blanket opt-out: --skip-validation must suppress the probe."""
+
+    def test_skip_validation_suppresses_probe(self, tmp_path):
+        bm = _make_mock_benchmark(
+            str(tmp_path), 1, hosts=["h1", "h2"], tmp_path=tmp_path,
+            skip_validation=True,
+        )
+        with patch(
+            "mlpstorage_py.benchmarks.base.check_capacity_4field"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_results_dir_shared_probe"
+        ) as mock_probe:
+            bm._pre_execution_gate()
+        mock_probe.assert_not_called()
+
+
+class TestResultsDirProbeOrdering:
+    """CAP-02 (data-dir) → CAP-02b (results-dir) → CAP-03 (FS-separation)."""
+
+    def test_probe_runs_after_cap02_and_before_cap03(self, tmp_path):
+        order = []
+        bm = _make_mock_benchmark(str(tmp_path), 1,
+                                  hosts=["h1", "h2"], tmp_path=tmp_path)
+        bm._run_fs_separation_probe = MagicMock(
+            side_effect=lambda: order.append("cap03")
+        )
+
+        def _cap02(*a, **kw):
+            order.append("cap02")
+
+        def _cap02b(*a, **kw):
+            order.append("cap02b")
+
+        with patch(
+            "mlpstorage_py.benchmarks.base.check_capacity_4field"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_shared_fs_probe",
+            side_effect=_cap02,
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_results_dir_shared_probe",
+            side_effect=_cap02b,
+        ):
+            bm._pre_execution_gate()
+
+        assert order == ["cap02", "cap02b", "cap03"], order
+
+
+class TestResultsDirProbeFailurePropagates:
+    """A probe FileSystemError must escape _pre_execution_gate so
+    Benchmark.run() aborts before write_systemname_yaml."""
+
+    def test_probe_error_propagates(self, tmp_path):
+        bm = _make_mock_benchmark(str(tmp_path), 1,
+                                  hosts=["h1", "h2"], tmp_path=tmp_path)
+        with patch(
+            "mlpstorage_py.benchmarks.base.check_capacity_4field"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_results_dir_shared_probe",
+            side_effect=FileSystemError(
+                "results-dir is not shared",
+                path=str(tmp_path),
+                operation="cap02b-results-dir-probe",
+                code=ErrorCode.FS_INVALID_STRUCTURE,
+            ),
+        ):
+            with pytest.raises(FileSystemError) as excinfo:
+                bm._pre_execution_gate()
+        assert excinfo.value.code == ErrorCode.FS_INVALID_STRUCTURE
+        # CAP-03 must NOT have been consulted after the CAP-02b failure.
+        bm._run_fs_separation_probe.assert_not_called()

--- a/tests/unit/test_results_dir_shared_probe.py
+++ b/tests/unit/test_results_dir_shared_probe.py
@@ -1,0 +1,361 @@
+"""Unit tests for the results-dir shared-filesystem probe (storage#772).
+
+Storage#772 background: a submitter reported that ``mlpstorage validate``
+kept complaining about missing ``dlio.log`` / ``summary.json`` /
+``dlio_config/`` in every run/timestamp leaf. The submitter's follow-up
+comments showed the artifacts DO exist — but they're scattered across
+per-host local ``retinanet_results/`` directories on 51 worker hosts.
+``dlio.log`` lands on every rank's local FS; ``summary.json`` lands only
+on rank-0's local FS; the launcher (command host) never sees any of
+them. Root cause: ``--results-dir`` was NOT on a shared filesystem.
+
+CAP-02 probes ``--data-dir`` for the same misconfiguration but does not
+cover ``--results-dir``. ``kvcache._probe_results_dir_shared`` implements
+the equivalent for kvcache (issue #521). This module lifts kvcache's
+inline-payload pattern into a module-level helper in
+``mlpstorage_py.cluster_collector`` so training and checkpointing can
+share it via ``Benchmark._pre_execution_gate``.
+
+Contract locks:
+
+- Single-host / all-localhost / empty ``hosts`` → silent no-op. NO
+  subprocess invocation, no ``.fs_probe/`` sentinel dir left behind on
+  the launcher, no logger.error / logger.info.
+- Multi-host + all-hosts-write-sentinel → return cleanly with the
+  probe dir removed (results directory stays clean for the submission
+  checker).
+- Multi-host + at least one host missing a sentinel → raise
+  ``FileSystemError`` with:
+  * the probed hostnames in the diagnostic
+  * an explicit ``NFS / Lustre / GPFS`` shared-FS hint
+  * the phrase ``results-dir`` (so the operator distinguishes this from
+    CAP-02's data-dir diagnostic)
+  * ``ErrorCode.FS_INVALID_STRUCTURE`` (matches CAP-02's failure code)
+- ``:slot`` suffixes in ``hosts`` are stripped before probing (``h1:4
+  h2:4`` → 2 unique hosts, not 8).
+- Payload is inline (``python -c "..."``) so no SCP staging step is
+  needed — Argonne's srun/PALS launchers keep working with no new
+  SSH surface. See the discussion at storage#772 for why we do NOT
+  add a dedicated ``--skip-results-dir-check`` flag: the existing
+  ``--skip-validation`` opt-out (which also gates CAP-02) is
+  sufficient, and the SSH-preflight auto-skip
+  (``_launcher_bypasses_ssh``) does not apply here because the probe
+  never does a dedicated SSH reachability test.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub heavy deps that mlpstorage_py.cluster_collector transitively pulls
+# in on some dev environments. Matches the pattern in
+# tests/unit/test_shared_fs_probe.py and tests/unit/test_benchmarks_kvcache.py.
+import importlib.util as _ilu
+for _dep in ("pyarrow", "pyarrow.ipc", "psutil"):
+    if _ilu.find_spec(_dep) is None and _dep not in sys.modules:
+        sys.modules[_dep] = MagicMock()
+
+from mlpstorage_py.cluster_collector import run_results_dir_shared_probe
+from mlpstorage_py.errors import ErrorCode, FileSystemError
+
+
+# ---------------------------------------------------------------------------
+# Helper: simulate a subprocess.run(...) call that drops sentinels for a
+# given subset of the probed hosts (the "shared filesystem" view from the
+# launcher's side).
+# ---------------------------------------------------------------------------
+
+
+def _fake_subprocess_run_landing_sentinels(results_dir, host_ranks):
+    """Return a fake ``subprocess.run`` side-effect that lands one sentinel
+    per (rank, host) in ``host_ranks`` inside the launcher-visible probe dir.
+
+    ``host_ranks`` is an iterable of ``(rank:int, host:str)`` tuples. The
+    inline payload embeds the probe id as a literal quoted string in the
+    argv; we recover it from ``cmd`` via a regex.
+    """
+    import re
+    from pathlib import Path
+
+    def _side_effect(cmd, **kwargs):
+        probe_dir = Path(results_dir) / ".fs_probe"
+        m = re.search(r"([0-9a-f]{12})__rank", cmd if isinstance(cmd, str) else " ".join(cmd))
+        assert m is not None, f"probe_id not found in cmd: {cmd!r}"
+        probe_id = m.group(1)
+        probe_dir.mkdir(parents=True, exist_ok=True)
+        for rank, host in host_ranks:
+            (probe_dir / f"{probe_id}__rank{rank}__{host}.ok").write_text(host)
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    return _side_effect
+
+
+# ---------------------------------------------------------------------------
+# TestNoOpShortCircuit — single-host / localhost-only / empty hosts
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpShortCircuit:
+    """Contract: no probe when the run cannot exhibit the bug."""
+
+    def test_empty_hosts_is_noop(self, tmp_path):
+        logger = MagicMock()
+        with patch("mlpstorage_py.cluster_collector.subprocess.run") as p_sub:
+            result = run_results_dir_shared_probe(
+                results_dir=str(tmp_path),
+                hosts=[],
+                run_uuid="abc",
+                logger=logger,
+            )
+        assert result is None
+        p_sub.assert_not_called()
+        # No .fs_probe/ dir must be left behind.
+        assert not (tmp_path / ".fs_probe").exists()
+        logger.error.assert_not_called()
+
+    def test_none_hosts_is_noop(self, tmp_path):
+        logger = MagicMock()
+        with patch("mlpstorage_py.cluster_collector.subprocess.run") as p_sub:
+            result = run_results_dir_shared_probe(
+                results_dir=str(tmp_path),
+                hosts=None,
+                run_uuid="abc",
+                logger=logger,
+            )
+        assert result is None
+        p_sub.assert_not_called()
+        assert not (tmp_path / ".fs_probe").exists()
+
+    def test_single_host_is_noop(self, tmp_path):
+        logger = MagicMock()
+        with patch("mlpstorage_py.cluster_collector.subprocess.run") as p_sub:
+            result = run_results_dir_shared_probe(
+                results_dir=str(tmp_path),
+                hosts=["h1"],
+                run_uuid="abc",
+                logger=logger,
+            )
+        assert result is None
+        p_sub.assert_not_called()
+        assert not (tmp_path / ".fs_probe").exists()
+
+    def test_all_localhost_is_noop(self, tmp_path):
+        """A run whose --hosts are all localhost aliases cannot scatter."""
+        logger = MagicMock()
+        with patch("mlpstorage_py.cluster_collector.subprocess.run") as p_sub:
+            result = run_results_dir_shared_probe(
+                results_dir=str(tmp_path),
+                hosts=["localhost", "127.0.0.1", "localhost"],
+                run_uuid="abc",
+                logger=logger,
+            )
+        assert result is None
+        p_sub.assert_not_called()
+        assert not (tmp_path / ".fs_probe").exists()
+
+
+# ---------------------------------------------------------------------------
+# TestSuccessPath — all hosts write sentinels
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessPath:
+    def test_all_hosts_sentinel_returns_none_and_cleans_up(self, tmp_path):
+        """Shared FS: every host lands a sentinel. Probe returns cleanly
+        and removes the .fs_probe/ scratch dir so the timestamp leaf stays
+        clean for submission_checker."""
+        logger = MagicMock()
+        hosts = ["h1", "h2", "h3"]
+        with patch(
+            "mlpstorage_py.cluster_collector.subprocess.run",
+            side_effect=_fake_subprocess_run_landing_sentinels(
+                str(tmp_path), [(i, h) for i, h in enumerate(hosts)],
+            ),
+        ):
+            result = run_results_dir_shared_probe(
+                results_dir=str(tmp_path),
+                hosts=hosts,
+                run_uuid="abc",
+                logger=logger,
+            )
+        assert result is None
+        # Cleanup: probe dir removed.
+        assert not (tmp_path / ".fs_probe").exists()
+        logger.error.assert_not_called()
+
+    def test_strips_slot_suffixes(self, tmp_path):
+        """--hosts 'h1:4 h2:4' should probe 2 unique hosts, not 8."""
+        logger = MagicMock()
+        captured = {}
+
+        def _side_effect(cmd, **kwargs):
+            captured["cmd"] = cmd if isinstance(cmd, str) else " ".join(cmd)
+            # Land one sentinel per unique host.
+            return _fake_subprocess_run_landing_sentinels(
+                str(tmp_path), [(0, "h1"), (1, "h2")],
+            )(cmd, **kwargs)
+
+        with patch(
+            "mlpstorage_py.cluster_collector.subprocess.run",
+            side_effect=_side_effect,
+        ):
+            run_results_dir_shared_probe(
+                results_dir=str(tmp_path),
+                hosts=["h1:4", "h2:4"],
+                run_uuid="abc",
+                logger=logger,
+            )
+        assert "-n 2 " in captured["cmd"]
+        # Host arg must pin one rank per unique host.
+        assert "h1:1" in captured["cmd"] and "h2:1" in captured["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# TestFailurePath — at least one host missing a sentinel
+# ---------------------------------------------------------------------------
+
+
+class TestFailurePath:
+    def test_missing_sentinels_raises_filesystem_error(self, tmp_path):
+        """Non-shared FS: only rank-0 lands a sentinel. Fail loudly."""
+        logger = MagicMock()
+        hosts = ["h1", "h2", "h3"]
+        with patch(
+            "mlpstorage_py.cluster_collector.subprocess.run",
+            side_effect=_fake_subprocess_run_landing_sentinels(
+                str(tmp_path), [(0, "h1")],
+            ),
+        ):
+            with pytest.raises(FileSystemError) as excinfo:
+                run_results_dir_shared_probe(
+                    results_dir=str(tmp_path),
+                    hosts=hosts,
+                    run_uuid="abc",
+                    logger=logger,
+                )
+        msg = str(excinfo.value)
+        # Diagnostic must name --results-dir explicitly so the operator
+        # distinguishes this from CAP-02's --data-dir failure mode.
+        assert "results-dir" in msg or "--results-dir" in msg
+        # Point at the shared-FS remedy.
+        assert "NFS" in msg or "Lustre" in msg or "GPFS" in msg
+        # Name the hosts that did NOT land a sentinel.
+        assert "h2" in msg and "h3" in msg
+        # Error code matches CAP-02's failure surface.
+        assert excinfo.value.code == ErrorCode.FS_INVALID_STRUCTURE
+
+    def test_missing_sentinels_preserves_probe_dir_for_debugging(self, tmp_path):
+        """On failure, leave .fs_probe/ behind so the operator can inspect
+        which host's sentinel is missing."""
+        logger = MagicMock()
+        with patch(
+            "mlpstorage_py.cluster_collector.subprocess.run",
+            side_effect=_fake_subprocess_run_landing_sentinels(
+                str(tmp_path), [(0, "h1")],
+            ),
+        ):
+            with pytest.raises(FileSystemError):
+                run_results_dir_shared_probe(
+                    results_dir=str(tmp_path),
+                    hosts=["h1", "h2", "h3"],
+                    run_uuid="abc",
+                    logger=logger,
+                )
+        # Preserved.
+        assert (tmp_path / ".fs_probe").exists()
+
+    def test_subprocess_nonzero_rc_raises_filesystem_error(self, tmp_path):
+        """If the launcher itself fails (mpi bootstrap error / bad --hosts),
+        raise a FileSystemError with a bootstrap-specific hint rather than
+        silently succeeding on an empty probe dir."""
+        logger = MagicMock()
+
+        def _side_effect(cmd, **kwargs):
+            # No sentinels written; launcher reports a non-zero rc.
+            return MagicMock(returncode=1, stdout="", stderr="mpirun: bootstrap failed")
+
+        with patch(
+            "mlpstorage_py.cluster_collector.subprocess.run",
+            side_effect=_side_effect,
+        ):
+            with pytest.raises(FileSystemError) as excinfo:
+                run_results_dir_shared_probe(
+                    results_dir=str(tmp_path),
+                    hosts=["h1", "h2"],
+                    run_uuid="abc",
+                    logger=logger,
+                )
+        msg = str(excinfo.value)
+        # Should surface the launcher's rc AND its stderr so the operator
+        # can distinguish "shared-FS failure" from "launcher bootstrap failed".
+        assert "bootstrap failed" in msg or "rc=1" in msg or "returncode" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestPayloadShape — command construction lock
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadShape:
+    def test_uses_configured_mpi_bin(self, tmp_path):
+        """A caller that passes ``mpi_bin='srun'`` (Slurm) must see srun in
+        the invocation, not the default mpirun. Storage#772 discussion: the
+        launcher choice is what determines whether the probe bootstraps
+        over SSH (plain mpirun) or via the batch daemon
+        (srun/PALS mpiexec). We use the caller's launcher verbatim."""
+        logger = MagicMock()
+        captured = {}
+
+        def _side_effect(cmd, **kwargs):
+            captured["cmd"] = cmd if isinstance(cmd, str) else " ".join(cmd)
+            # Land sentinels for both hosts so the probe succeeds.
+            return _fake_subprocess_run_landing_sentinels(
+                str(tmp_path), [(0, "h1"), (1, "h2")],
+            )(cmd, **kwargs)
+
+        with patch(
+            "mlpstorage_py.cluster_collector.subprocess.run",
+            side_effect=_side_effect,
+        ):
+            run_results_dir_shared_probe(
+                results_dir=str(tmp_path),
+                hosts=["h1", "h2"],
+                run_uuid="abc",
+                logger=logger,
+                mpi_bin="srun",
+            )
+        assert captured["cmd"].startswith("srun ") or " srun " in captured["cmd"]
+
+    def test_payload_is_inline_python_no_scp_staging(self, tmp_path):
+        """The probe payload must be an inline ``python -c '...'`` argument.
+        Argonne (per storage#772 opt-out discussion) may run on a cluster
+        where SSH-based script staging is unavailable; an inline payload
+        avoids introducing any new SCP surface beyond what CAP-02 already
+        does."""
+        logger = MagicMock()
+        captured = {}
+
+        def _side_effect(cmd, **kwargs):
+            captured["cmd"] = cmd if isinstance(cmd, str) else " ".join(cmd)
+            return _fake_subprocess_run_landing_sentinels(
+                str(tmp_path), [(0, "h1"), (1, "h2")],
+            )(cmd, **kwargs)
+
+        with patch(
+            "mlpstorage_py.cluster_collector.subprocess.run",
+            side_effect=_side_effect,
+        ):
+            run_results_dir_shared_probe(
+                results_dir=str(tmp_path),
+                hosts=["h1", "h2"],
+                run_uuid="abc",
+                logger=logger,
+            )
+        # Inline python -c payload — NOT a staged script path.
+        assert " -c " in captured["cmd"]
+        # No SCP invocation in the command.
+        assert "scp " not in captured["cmd"]

--- a/tests/unit/test_shared_fs_probe.py
+++ b/tests/unit/test_shared_fs_probe.py
@@ -1357,6 +1357,12 @@ class TestSkipValidationBypassesCap02:
         bench._capacity_gate_destination = lambda: str(tmp_path)
         bench.required_bytes_for_capacity_gate = lambda: 1
         bench._run_uuid = "test-uuid"
+        # CAP-02b (storage#772) also fires from _pre_execution_gate. It
+        # reads self.run_result_output. These CAP-02 tests set hosts to
+        # a 2-host list — patch the CAP-02b helper in each test that
+        # needs to exercise a non-single-host path; the placeholder path
+        # below just satisfies the attribute lookup.
+        bench.run_result_output = str(tmp_path / "run-result-placeholder")
         # CAP-03 (issue #601) also fires from _pre_execution_gate. These
         # tests target CAP-02 only; return None from _fs_separation_paths
         # to take the A8 skip branch (no local FS to probe).
@@ -1370,7 +1376,9 @@ class TestSkipValidationBypassesCap02:
             "mlpstorage_py.benchmarks.base.check_capacity_4field"
         ), patch(
             "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
-        ) as mock_probe:
+        ) as mock_probe, patch(
+            "mlpstorage_py.benchmarks.base.run_results_dir_shared_probe"
+        ):
             bench._pre_execution_gate()
         mock_probe.assert_not_called()
 
@@ -1381,6 +1389,8 @@ class TestSkipValidationBypassesCap02:
             "mlpstorage_py.benchmarks.base.check_capacity_4field"
         ) as mock_cap01, patch(
             "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_results_dir_shared_probe"
         ):
             bench._pre_execution_gate()
         mock_cap01.assert_called_once()
@@ -1392,7 +1402,9 @@ class TestSkipValidationBypassesCap02:
             "mlpstorage_py.benchmarks.base.check_capacity_4field"
         ), patch(
             "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
-        ) as mock_probe:
+        ) as mock_probe, patch(
+            "mlpstorage_py.benchmarks.base.run_results_dir_shared_probe"
+        ):
             bench._pre_execution_gate()
         mock_probe.assert_called_once()
 
@@ -1404,6 +1416,8 @@ class TestSkipValidationBypassesCap02:
             "mlpstorage_py.benchmarks.base.check_capacity_4field"
         ), patch(
             "mlpstorage_py.benchmarks.base.run_shared_fs_probe"
+        ), patch(
+            "mlpstorage_py.benchmarks.base.run_results_dir_shared_probe"
         ):
             bench._pre_execution_gate()
         assert bench.logger.warning.called, (


### PR DESCRIPTION
## Summary

Closes #772.

CAP-02 verifies `--data-dir` is on a shared filesystem across every host in `--hosts`, but `--results-dir` was never probed. #772's reporter ran 51 workers with a per-host-local `--results-dir`; DLIO's per-rank `<rank>_output.json` / `<rank>_per_epoch_stats.json` and rank-0's `summary.json` landed on each rank's local FS, and `dlio.log` (opened `mode=\"a\"` from every rank) scattered similarly. The launcher's timestamp leaf came out empty, `mlpstorage validate` reported every DLIO artifact as missing, and the operator burned six full runs across the fleet before noticing.

## Why DLIO's layout works on a shared FS (and only on a shared FS)

- `summary.json` — **rank-0 only** write.
- `<rank>_output.json`, `<rank>_per_epoch_stats.json` — every rank writes, filename prefixed with `my_rank` (see `dlio_benchmark/utils/statscounter.py:498-512`).
- `dlio.log` — every rank opens `mode=\"a\"`; POSIX guarantees `write(2)` up to `PIPE_BUF` is atomic, so line-level appends from all ranks merge cleanly (`utils/config.py:411-420`).

None of that protects an operator whose `--results-dir` is per-host local storage — each rank's write hits its own private mount and the launcher sees nothing.

## The fix

Add CAP-02b: an inline-payload sibling of CAP-02 that drops a sentinel per unique host into `<results_dir>/.fs_probe/`, then verifies the launcher sees a sentinel from every host. Pattern lifted from `KVCacheBenchmark._probe_results_dir_shared` (issue #521); no new SCP staging surface is added, so Argonne's srun/PALS-launcher path (`_launcher_bypasses_ssh`, #740) keeps working via the existing `mpi_bin` bootstrap. Same `--skip-validation` blanket opt-out as CAP-02; **no dedicated `--skip-results-dir` flag** — the SSH-preflight auto-skip is orthogonal because this probe does no dedicated SSH reachability test.

## Changes

- `mlpstorage_py/cluster_collector.py` — new module-level `run_results_dir_shared_probe(results_dir, hosts, run_uuid, logger, mpi_bin=None, allow_run_as_root=False, timeout_seconds=60)`. Silent no-op on empty/single/all-localhost hosts. On success cleans up `.fs_probe/` so the timestamp leaf stays lean for the submission checker. On failure raises `FileSystemError(FS_INVALID_STRUCTURE)` naming the missing hostnames and pointing at the shared-FS remedy; preserves `.fs_probe/` for post-mortem inspection.
- `mlpstorage_py/benchmarks/base.py` — invoke the helper from `_pre_execution_gate` between CAP-02 (data-dir) and CAP-03 (FS-separation), gated by `--skip-validation`.
- `tests/unit/test_results_dir_shared_probe.py` — 11 RED-first tests for the helper (no-op paths, success + cleanup, slot-suffix stripping, missing-sentinel failure + preserved probe dir, launcher rc≠0, `mpi_bin` respect, inline-payload lock).
- `tests/unit/test_pre_execution_gate_results_dir.py` — 4 wiring tests (probe called with `run_result_output`, `--skip-validation` suppresses, ordering CAP-02 → CAP-02b → CAP-03, error propagation halts before CAP-03).
- `tests/unit/test_capacity_gate.py`, `tests/unit/test_shared_fs_probe.py` — minimal fixture updates for the new `run_result_output` attribute read; existing CAP-01 / CAP-02 tests keep passing unchanged.

## Not addressed (deliberately)

- **Diagnostic tightening in `mlpstorage validate`** — the reporter's original noise (duplicate 2.1.14/2.1.15 and 2.1.19/2.1.20 \"dlio_config not found\" lines, the loader's WARNING preceding the same ERROR) is real but out of scope. This PR closes the pre-execution gap; a follow-up can dedupe the validate output on top of that.
- **Refactoring kvcache's `_probe_results_dir_shared` onto the new shared helper** — same-shape sibling but different call site (inside `_execute_run`, not `_pre_execution_gate`). Bundling would enlarge the blast radius without shipping value for #772; left as a candidate for a later consolidation pass.

## Test plan

- [x] `uv run pytest tests/unit mlpstorage_py/tests` — 3588 passed, 1 skipped, 0 failed.
- [x] New helper tests: 11 passed.
- [x] New wiring tests: 4 passed.
- [x] Existing CAP-01 (`test_capacity_gate.py`), CAP-02 (`test_shared_fs_probe.py`), CAP-03 (`test_issue601_fs_separation_probe.py`) suites — all green.
- [ ] Manual smoke test on a two-node cluster with a per-host-local `--results-dir` — expect immediate `FileSystemError` naming the missing host.
- [ ] Manual smoke test on the same cluster with a shared `--results-dir` (NFS) — expect silent pass and `.fs_probe/` removed after the probe.