### PR TITLE
fix(storage#777): skip child tracker REGISTER instead of immediate-UNREGISTER

### DIFF
--- a/mlpstorage_py/checkpointing/streaming_checkpoint.py
+++ b/mlpstorage_py/checkpointing/streaming_checkpoint.py
@@ -7,6 +7,7 @@ by isolating data generation from storage operations using shared memory buffers
 import os
 import time
 import multiprocessing as mp
+from contextlib import contextmanager
 
 
 # Per-node MPI rank count, used to size the dgen-py generator's thread pool.
@@ -172,77 +173,73 @@ from typing import Optional, Dict, Any
 from .storage_writers import StorageWriterFactory
 
 
-# Issue #768: pre-3.13 CPython resource_tracker double-unlink workaround.
+# Issue #768 / #777: pre-3.13 CPython resource_tracker double-unlink workaround.
 #
-# multiprocessing.resource_tracker registers POSIX shared-memory segments and
-# named semaphores in every process that touches them via
-# SharedMemory(name=...) attach or Queue/Event pickle-unpickle. When the
-# streaming-checkpoint writer subprocess (spawned per save() on the forkserver
-# path for #642 safety) exits, its tracker races Main's to unlink the same
-# names — one wins, the other raises FileNotFoundError. On the shm side that
-# crashed Main's finally block, killing the owning MPI rank; on the semaphore
-# side it produced alarming SemLock._rebuild and "leaked" warnings that
-# spooked benchmark submitters even though nothing was actually lost.
+# The tracker daemon's cache is a `set`; REGISTER = idempotent add,
+# UNREGISTER = set.remove (KeyError on absent). SharedMemory(name=...) attach
+# unconditionally sends REGISTER to the tracker, so a writer subprocess that
+# borrows Main-owned buffers ends up double-registered. Without any
+# workaround, the tracker at exit unlinks whatever's left in cache and races
+# Main's own shm.unlink() — one wins, the other raises FileNotFoundError
+# and (on the shm side) killed the owning MPI rank in Main's finally block
+# (#768).
 #
-# The documented CPython workaround for 3.12 is: in the borrowing child,
-# unregister the names from ITS tracker so single-owner semantics are
-# restored — only Main's tracker unlinks at exit. 3.13 adds a public
-# SharedMemory(..., track=False) that supersedes the shm branch below;
-# SemLock has no equivalent even in 3.13, so the semaphore branch stays
-# until we can drop 3.12.
+# The initial #768 fix used the "immediate unregister in child" community
+# pattern (register then unregister right after attach). That pattern is
+# correct only when the parent NEVER explicitly calls shm.unlink() /
+# SemLock finalizer itself — because SharedMemory.unlink() and
+# SemLock._cleanup both end in resource_tracker.unregister() on the same
+# name. Our parent DOES call shm.unlink() per save() cycle (a fresh pool
+# per save() means the previous pool must be released or /dev/shm leaks
+# gigabytes per checkpoint), and Main's SemLock Finalize inevitably fires
+# on Queue/Event GC. The child's immediate UNREGISTER empties the set
+# entry; Main's later UNREGISTER then hits set.remove on an absent name
+# -> KeyError storm at 64 ranks x N save() calls (#777). On the semaphore
+# side the same race + SemLock._cleanup's own sem_unlink produced a
+# 700+/run "sem_unlink -> FileNotFoundError" cascade, correlated with a
+# cluster-wide livelock right after checkpoint 1.
 #
-# Only removes the child's cleanup callback for the given POSIX name; does
-# not close fds, detach shared state, or alter runtime behavior of the IPC
-# object. Every access is hasattr-guarded so a future CPython refactor of
-# the private ``_semlock`` / ``_rlock`` / ``_flag`` attrs degrades to a
-# silent no-op (returning to pre-#768 noise) rather than crashing the
-# checkpoint.
-def _unregister_ipc_from_child_tracker(*ipc_objs):
-    """Undo the child process's redundant resource_tracker registration of
-    parent-owned SharedMemory / Queue / Event primitives (issue #768)."""
+# The correct shape for our lifecycle is the OTHER well-known variant:
+# skip registration in the child entirely, so the tracker cache holds
+# exactly one entry (Main's) and Main's later unlink -> unregister finds
+# it and removes it cleanly. Functionally equivalent to Python 3.13's
+# SharedMemory(track=False).
+#
+# We only do this for shared_memory. SemLock's __setstate__ registers with
+# the tracker BEFORE our target function runs (it happens during pickle
+# unpickling in the forkserver bootstrap), so a context-manager scope
+# can't catch it. That's OK: pre-#768 semaphore behavior was "alarming
+# SemLock._rebuild warnings but functionally correct" — strictly better
+# than the KeyError + double-sem_unlink cascade #777 reports.
+@contextmanager
+def _child_skips_shm_registration():
+    """Suppress ``resource_tracker.register`` for ``shared_memory`` within
+    the block.
+
+    Used in the writer subprocess so ``SharedMemory(name=...)`` attach
+    does NOT double-register Main-owned buffer names in the tracker
+    daemon's cache. See the module comment above for why this is the
+    correct pattern for our lifecycle and why the "immediate unregister
+    after attach" variant (initial #768 fix) is not.
+
+    Only the ``register`` shim is installed — ``unregister`` is left
+    alone, so the child cannot accidentally send an UNREGISTER for a
+    name it never REGISTERed. The patch is scoped to the ``with`` block
+    and restored in ``finally`` even on exception.
+    """
     from multiprocessing import resource_tracker
+    orig_register = resource_tracker.register
 
-    def _try(name, kind):
-        try:
-            resource_tracker.unregister(name, kind)
-        except Exception:
-            # KeyError = not tracked here (nothing to undo); anything else =
-            # tracker down / private-attr drift. Silent degrade is the goal.
-            pass
+    def _register_skip_shm(name, rtype):
+        if rtype == "shared_memory":
+            return
+        return orig_register(name, rtype)
 
-    def _semlock_name(obj):
-        sl = getattr(obj, "_semlock", None)
-        return getattr(sl, "name", None) if sl is not None else None
-
-    for obj in ipc_objs:
-        if obj is None:
-            continue
-
-        # SharedMemory: single named POSIX segment. Detect by the pair of
-        # attrs SharedMemory uniquely provides — a bare object with a _name
-        # attribute would false-positive here otherwise.
-        name = getattr(obj, "_name", None)
-        if name and hasattr(obj, "unlink") and hasattr(obj, "close"):
-            _try(name, "shared_memory")
-            continue
-
-        # mp.Queue and mp.Event both carry SemLock-backed primitives. The
-        # attribute layout is undocumented but stable in CPython since 3.4;
-        # enumerate the known slots and hasattr-guard each.
-        for attr in ("_rlock", "_wlock", "_sem", "_flag"):
-            v = getattr(obj, attr, None)
-            if v is not None:
-                sem_name = _semlock_name(v)
-                if sem_name:
-                    _try(sem_name, "semaphore")
-        for attr in ("_notempty", "_notfull", "_cond"):
-            cond = getattr(obj, attr, None)
-            if cond is not None:
-                lock = getattr(cond, "_lock", None)
-                if lock is not None:
-                    sem_name = _semlock_name(lock)
-                    if sem_name:
-                        _try(sem_name, "semaphore")
+    resource_tracker.register = _register_skip_shm
+    try:
+        yield
+    finally:
+        resource_tracker.register = orig_register
 
 # Try to import dgen-py for high-performance data generation
 try:
@@ -625,21 +622,23 @@ class StreamingCheckpointing:
         print(f"[Writer] DEBUG: AWS_ACCESS_KEY_ID = {aws_key[:4] if aws_key != 'NOT SET' else 'NOT SET'}***")
         print(f"[Writer] DEBUG: AWS_ENDPOINT_URL = {aws_endpoint}")
         
-        # Attach to shared memory buffers
+        # Attach to shared memory buffers.
+        #
+        # #768/#777: suppress this child's tracker REGISTER for each
+        # SharedMemory attach. Main owns these segments and will call
+        # shm.unlink() itself per save() cycle; if we let the child ALSO
+        # register with the tracker daemon, either the tracker unlinks at
+        # exit and races Main's unlink -> FileNotFoundError (#768), or we
+        # "immediate unregister" and Main's later unregister trips
+        # KeyError on an already-empty set (#777). Skipping the register
+        # entirely leaves the daemon holding exactly one entry (Main's),
+        # so Main's unlink -> unregister finds and removes it cleanly.
+        # Equivalent to SharedMemory(track=False) which lands in 3.13.
         buffers = []
-        for name in buffer_names:
-            shm = shared_memory.SharedMemory(name=name)
-            buffers.append(shm)
-
-        # #768: undo this subprocess's redundant resource_tracker registration
-        # of the SharedMemory segments we just attached to AND the Queue/Event
-        # IPC objects Main passed in as args. Both would otherwise be
-        # unlinked twice at process exit — once here, once in Main — with
-        # whichever tracker lost the race crashing with FileNotFoundError.
-        # Only Main owns these; only Main should unlink.
-        _unregister_ipc_from_child_tracker(
-            *buffers, buffer_queue, stats_queue, stop_event
-        )
+        with _child_skips_shm_registration():
+            for name in buffer_names:
+                shm = shared_memory.SharedMemory(name=name)
+                buffers.append(shm)
 
         print(f"[Writer] Attached to {len(buffers)} buffers ({chunk_size / (1024**2):.0f} MB each)")
         

--- a/tests/unit/test_streaming_checkpoint_resource_tracker.py
+++ b/tests/unit/test_streaming_checkpoint_resource_tracker.py
@@ -1,33 +1,36 @@
-"""Tests for streaming-checkpoint IPC resource_tracker safety (issue #768).
+"""Tests for streaming-checkpoint IPC resource_tracker safety (issues #768, #777).
 
-Python 3.12's ``multiprocessing.resource_tracker`` registers POSIX
-shared-memory segments and named semaphores in **every** process that
-touches them via ``SharedMemory(name=...)`` attach or ``Queue``/``Event``
-pickle-unpickle. Whichever process's tracker fires first at shutdown
-unlinks the underlying name; the second tracker races to
-``FileNotFoundError``.
+The tracker daemon's cache is a ``set``: ``REGISTER`` = idempotent add,
+``UNREGISTER`` = ``set.remove`` (raises ``KeyError`` if absent).
+``SharedMemory(name=...)`` attach always sends REGISTER to the tracker, so a
+writer subprocess that borrows Main-owned buffers ends up double-registered.
+Without a workaround, the tracker daemon unlinks its cache at exit and races
+Main's own ``shm.unlink()`` -> ``FileNotFoundError`` (the #768 fatal crash).
 
-On the streaming-checkpoint object-storage path (writer subprocess spawned
-per ``save()`` on the ``forkserver`` context) that raced double-unlink
-surfaces as:
+#768's initial fix used the "immediate unregister in child" community pattern
+(register then unregister after attach). That pattern is correct only when
+the parent never explicitly unlinks the resource itself. Our
+``_release_buffer_pool`` DOES call ``shm.unlink()`` per save() cycle (a
+fresh pool per save() would otherwise leak ``/dev/shm``), and
+``SharedMemory.unlink()`` unconditionally calls
+``resource_tracker.unregister()``. Child immediate-unregister empties the
+cache entry; Main's later unregister then hits ``set.remove`` on absent -> a
+per-run KeyError storm at 64 ranks x N save() calls (#777), plus a
+correlated 700+ ``sem_unlink -> FileNotFoundError`` cascade and cluster-wide
+livelock right after checkpoint 1.
 
-* fatal ``shm.unlink() -> FileNotFoundError`` in Main's ``finally`` block,
-  killing the owning MPI rank and tearing down the whole job
-* non-fatal ``SemLock._rebuild -> FileNotFoundError`` noise from
-  ``forkserver``-spawned worker startups
-* ``resource_tracker: leaked semaphore/shared_memory`` warnings at exit
-  that are alarming for submitters even though they indicate no data loss
-
-Fix (documented CPython pre-3.13 workaround): in the writer subprocess,
-unregister the borrowed names from ITS ``resource_tracker`` so only Main
-ever unlinks. Plus a defensive ``FileNotFoundError`` swallow in Main's
-buffer-pool cleanup for any residual race.
+Fix (#777): swap the "immediate unregister" for the OTHER well-known
+variant: skip the child's REGISTER in the first place, via a scoped
+monkey-patch of ``resource_tracker.register`` that no-ops for
+``shared_memory`` inside the attach block. Tracker cache holds exactly one
+entry (Main's); Main's later ``unlink -> unregister`` finds and removes it
+cleanly. Semaphore branch is dropped entirely — pre-#768 semaphore behavior
+was noisy but functional, strictly better than the storm the immediate-
+unregister variant caused.
 """
 
 from __future__ import annotations
 
-import multiprocessing as mp
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,158 +39,140 @@ from mlpstorage_py.checkpointing import streaming_checkpoint as sc
 
 
 # --------------------------------------------------------------------------- #
-#  _unregister_ipc_from_child_tracker                                         #
+#  _child_skips_shm_registration                                              #
 # --------------------------------------------------------------------------- #
 
 
-class TestUnregisterIpcFromChildTracker:
-    """The writer subprocess must unregister borrowed IPC names from its
-    own ``resource_tracker`` so only Main's tracker unlinks them at exit
-    (#768). The helper is the single injection point for that workaround."""
+class TestChildSkipsShmRegistration:
+    """The writer subprocess must prevent tracker REGISTER for the
+    SharedMemory buffers it attaches to. Skipping the REGISTER (rather
+    than issuing an UNREGISTER after the fact) is the only pattern
+    compatible with Main's per-``save()`` explicit ``shm.unlink()`` —
+    an ``unlink()`` internally calls ``resource_tracker.unregister()``
+    and would trip ``KeyError`` on an already-empty cache entry (#777)."""
 
-    def test_helper_exists(self):
+    def test_context_manager_exists(self):
         """The workaround entry point must be importable from the module."""
-        assert hasattr(sc, "_unregister_ipc_from_child_tracker"), (
-            "Missing #768 fix: writer subprocess needs a helper to "
-            "unregister resource_tracker's redundant ownership of "
-            "Main-owned SharedMemory/Queue/Event names."
+        assert hasattr(sc, "_child_skips_shm_registration"), (
+            "Missing #777 fix: writer subprocess needs a scoped patch of "
+            "resource_tracker.register to skip shared_memory REGISTER at "
+            "child attach time. Without it, either the double-unlink race "
+            "returns (#768) or child-side immediate UNREGISTER races Main's "
+            "later unregister -> KeyError storm (#777)."
         )
 
-    def test_unregisters_shared_memory_by_name(self):
-        """SharedMemory carries a single POSIX name; the helper unregisters
-        it as kind ``shared_memory`` so the writer's tracker won't unlink it
-        on process exit — leaving that job to Main, the actual owner."""
-        shm = MagicMock(spec=["_name", "unlink", "close"])
-        shm._name = "/ckpt_probe_0"
+    def test_shm_register_is_a_noop_within_block(self):
+        """Inside the block, calling ``resource_tracker.register`` for
+        ``shared_memory`` must NOT reach the real tracker — that's the
+        entire point. The daemon's cache stays holding only Main's entry."""
+        from multiprocessing import resource_tracker
 
-        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
-            sc._unregister_ipc_from_child_tracker(shm)
+        real_register_calls = []
 
-        mock_unreg.assert_called_once_with("/ckpt_probe_0", "shared_memory")
+        def _tracking_register(name, rtype):
+            real_register_calls.append((name, rtype))
 
-    def test_unregisters_all_queue_semlocks(self):
-        """A ``forkserver``-context Queue carries several SemLock-backed
-        primitives (``_rlock``, ``_wlock``, ``_sem``, ``_notempty._lock``,
-        and — for bounded queues — ``_notfull._lock``). Every one of them
-        gets registered in the child's tracker at unpickle time; each must
-        be unregistered here or the SemLock double-unlink race remains."""
-        ctx = mp.get_context("forkserver")
-        q = ctx.Queue(maxsize=4)
+        with patch.object(resource_tracker, "register", _tracking_register):
+            with sc._child_skips_shm_registration():
+                resource_tracker.register("/ckpt_X", "shared_memory")
+                resource_tracker.register("/ckpt_Y", "shared_memory")
 
-        expected = set()
-        for attr in ("_rlock", "_wlock", "_sem"):
-            v = getattr(q, attr, None)
-            if v is not None and hasattr(v, "_semlock"):
-                expected.add((v._semlock.name, "semaphore"))
-        for attr in ("_notempty", "_notfull"):
-            cond = getattr(q, attr, None)
-            if cond is not None:
-                lock = getattr(cond, "_lock", None)
-                if lock is not None and hasattr(lock, "_semlock"):
-                    expected.add((lock._semlock.name, "semaphore"))
-
-        assert expected, (
-            "Test setup broken: forkserver Queue exposed no SemLock names."
+        assert real_register_calls == [], (
+            "shared_memory REGISTER must not reach the tracker inside the "
+            "block; got calls: {!r}".format(real_register_calls)
         )
 
-        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
-            sc._unregister_ipc_from_child_tracker(q)
+    def test_semaphore_register_still_forwarded(self):
+        """SemLock ``__setstate__`` registers semaphores with the tracker
+        during pickle unpickling (before our target function even runs, so
+        we can't scope-patch it anyway). Inside our block, non-shm
+        REGISTER calls must pass through so we don't break unrelated
+        tracker semantics."""
+        from multiprocessing import resource_tracker
 
-        actual = {call.args for call in mock_unreg.call_args_list}
-        missed = expected - actual
-        assert not missed, (
-            f"queue SemLocks not unregistered from child tracker: {missed}"
+        forwarded = []
+
+        def _tracking_register(name, rtype):
+            forwarded.append((name, rtype))
+
+        with patch.object(resource_tracker, "register", _tracking_register):
+            with sc._child_skips_shm_registration():
+                resource_tracker.register("/sem_A", "semaphore")
+
+        assert forwarded == [("/sem_A", "semaphore")], (
+            "non-shared_memory REGISTER must pass through the shim; "
+            "got: {!r}".format(forwarded)
         )
 
-    def test_unregisters_event_semlocks(self):
-        """An ``Event`` carries an internal ``_cond._lock._semlock`` (the
-        condition-variable lock) and ``_flag._semlock`` (the BoundedSemaphore
-        backing the set/unset flag). Both must be unregistered."""
-        ctx = mp.get_context("forkserver")
-        e = ctx.Event()
+    def test_register_restored_after_block(self):
+        """The patch must be scoped to the ``with`` block. After exit,
+        subsequent ``shared_memory`` REGISTER calls must reach the tracker
+        again — long-lived subprocesses that create their OWN SharedMemory
+        later must not be silently untracked."""
+        from multiprocessing import resource_tracker
 
-        expected = set()
-        cond = getattr(e, "_cond", None)
-        if cond is not None:
-            lock = getattr(cond, "_lock", None)
-            if lock is not None and hasattr(lock, "_semlock"):
-                expected.add((lock._semlock.name, "semaphore"))
-        flag = getattr(e, "_flag", None)
-        if flag is not None and hasattr(flag, "_semlock"):
-            expected.add((flag._semlock.name, "semaphore"))
+        after_block_calls = []
 
-        assert expected, (
-            "Test setup broken: forkserver Event exposed no SemLock names."
+        def _tracking_register(name, rtype):
+            after_block_calls.append((name, rtype))
+
+        with patch.object(resource_tracker, "register", _tracking_register):
+            with sc._child_skips_shm_registration():
+                pass  # patched inside
+            # Outside the block: patch reverted, real tracker gets the call
+            resource_tracker.register("/ckpt_Z", "shared_memory")
+
+        assert after_block_calls == [("/ckpt_Z", "shared_memory")], (
+            "resource_tracker.register must be restored on block exit; "
+            "post-block call log: {!r}".format(after_block_calls)
         )
 
-        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
-            sc._unregister_ipc_from_child_tracker(e)
+    def test_register_restored_on_exception(self):
+        """The patch must be reverted even if the body raises. A failed
+        SharedMemory attach inside the block must not leave the child's
+        tracker.register permanently no-op'd."""
+        from multiprocessing import resource_tracker
 
-        actual = {call.args for call in mock_unreg.call_args_list}
-        missed = expected - actual
-        assert not missed, (
-            f"event SemLocks not unregistered from child tracker: {missed}"
+        after_block_calls = []
+
+        def _tracking_register(name, rtype):
+            after_block_calls.append((name, rtype))
+
+        with patch.object(resource_tracker, "register", _tracking_register):
+            with pytest.raises(RuntimeError):
+                with sc._child_skips_shm_registration():
+                    raise RuntimeError("attach failed")
+
+            resource_tracker.register("/ckpt_after_error", "shared_memory")
+
+        assert after_block_calls == [("/ckpt_after_error", "shared_memory")], (
+            "resource_tracker.register must be restored via finally even "
+            "on exception; post-exception call log: {!r}".format(
+                after_block_calls
+            )
         )
 
-    def test_swallows_key_error(self):
-        """``resource_tracker.unregister`` raises ``KeyError`` when the name
-        is not tracked in this process. That's fine — nothing to undo —
-        and must not propagate. The writer cannot afford to crash on
-        a cleanup no-op."""
-        shm = MagicMock(spec=["_name", "unlink", "close"])
-        shm._name = "/ckpt_probe_x"
+    def test_shim_does_not_call_unregister(self):
+        """Regression guard for #777: the shim must NOT send UNREGISTER
+        for anything. The whole point of switching from "immediate
+        unregister" to "skip register" is that the child never issues an
+        UNREGISTER that could race Main's later unregister on the same
+        name."""
+        from multiprocessing import resource_tracker
 
-        with patch(
-            "multiprocessing.resource_tracker.unregister",
-            side_effect=KeyError("/ckpt_probe_x"),
-        ):
-            sc._unregister_ipc_from_child_tracker(shm)  # must not raise
+        unregister_calls = []
 
-    def test_swallows_arbitrary_tracker_errors(self):
-        """The tracker subprocess can also die. Silent degrade — better to
-        return to pre-#768 noise than crash the checkpoint entirely."""
-        shm = MagicMock(spec=["_name", "unlink", "close"])
-        shm._name = "/ckpt_probe_y"
+        def _tracking_unregister(name, rtype):
+            unregister_calls.append((name, rtype))
 
-        with patch(
-            "multiprocessing.resource_tracker.unregister",
-            side_effect=RuntimeError("resource_tracker gone"),
-        ):
-            sc._unregister_ipc_from_child_tracker(shm)  # must not raise
+        with patch.object(resource_tracker, "unregister", _tracking_unregister):
+            with sc._child_skips_shm_registration():
+                pass
 
-    def test_none_argument_is_a_no_op(self):
-        """The writer passes ``stop_event`` which is always non-None in
-        practice, but the helper must tolerate ``None`` in the arg pack
-        so callers don't have to filter."""
-        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
-            sc._unregister_ipc_from_child_tracker(None)
-        mock_unreg.assert_not_called()
-
-    def test_multiple_objects_in_one_call(self):
-        """Callers typically batch buffers + queues + events into one call —
-        each object's names must be unregistered independently."""
-        shm_a = MagicMock(spec=["_name", "unlink", "close"])
-        shm_a._name = "/ckpt_a"
-        shm_b = MagicMock(spec=["_name", "unlink", "close"])
-        shm_b._name = "/ckpt_b"
-
-        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
-            sc._unregister_ipc_from_child_tracker(shm_a, shm_b)
-
-        args = {call.args for call in mock_unreg.call_args_list}
-        assert ("/ckpt_a", "shared_memory") in args
-        assert ("/ckpt_b", "shared_memory") in args
-
-    def test_unknown_object_type_degrades_silently(self):
-        """A future CPython refactor might rename the private ``_semlock`` /
-        ``_rlock`` attrs. The helper must degrade to a no-op silently in
-        that case — returning to pre-#768 noise is preferable to crashing
-        the checkpoint. The failure mode is *silent*, on purpose."""
-        opaque = SimpleNamespace()
-
-        with patch("multiprocessing.resource_tracker.unregister") as mock_unreg:
-            sc._unregister_ipc_from_child_tracker(opaque)
-        mock_unreg.assert_not_called()
+        assert unregister_calls == [], (
+            "The #777 fix relies on the child NEVER sending UNREGISTER; "
+            "got unexpected unregister calls: {!r}".format(unregister_calls)
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -196,16 +181,16 @@ class TestUnregisterIpcFromChildTracker:
 
 
 class TestReleaseBufferPoolTolerantOfMissingSegments:
-    """Main's per-``save()`` buffer-pool cleanup must not crash when the
-    writer's ``resource_tracker`` won the race and already unlinked a
-    segment (#768). Defensive backstop for any residual double-unlink race
-    that survives the primary fix — a second unlink of an already-unlinked
-    segment is exactly the desired end state, not a real failure."""
+    """Main's per-``save()`` buffer-pool cleanup must not crash when a
+    residual race leaves a segment already unlinked (#768 defensive
+    backstop). The #777 fix makes this path clean in the common case,
+    but this shim stays as insurance against any edge case that survives
+    it — a second unlink of an already-unlinked segment is exactly the
+    desired end state, not a real failure."""
 
     def test_release_buffer_pool_helper_exists(self):
-        """The cleanup must be factored into a testable helper so its
-        error-tolerance can be verified without spinning up a real
-        writer subprocess."""
+        """The cleanup must be a testable helper so its error-tolerance
+        can be verified without spinning up a real writer subprocess."""
         assert hasattr(sc.StreamingCheckpointing, "_release_buffer_pool"), (
             "Missing #768 defensive: buffer-pool cleanup must be a "
             "factored helper so FileNotFoundError from shm.unlink() "
@@ -213,11 +198,11 @@ class TestReleaseBufferPoolTolerantOfMissingSegments:
         )
 
     def test_release_pool_swallows_file_not_found(self):
-        """Simulate the writer-tracker-won-race scenario from #768: the
-        second ``unlink()`` hits ``FileNotFoundError`` because the writer's
-        tracker already unlinked the segment. That is *exactly what we
-        wanted*: the segment is gone. Must not propagate — the reporter's
-        stack shows this crashing the owning MPI rank and killing the job."""
+        """Simulate the writer-tracker-won-race scenario: the second
+        ``unlink()`` hits ``FileNotFoundError`` because someone else
+        already unlinked the segment. Must not propagate — the reporter's
+        stack in #768 showed this crashing the owning MPI rank and
+        killing the job."""
         happy = MagicMock()
         happy.close = MagicMock()
         happy.unlink = MagicMock()
@@ -280,20 +265,19 @@ class TestReleaseBufferPoolTolerantOfMissingSegments:
 # --------------------------------------------------------------------------- #
 
 
-class TestWriterProcessInvokesUnregister:
-    """The writer subprocess entry point ``_writer_process`` must invoke
-    the resource_tracker workaround for (a) the shared-memory buffers it
-    attaches to by name, and (b) the ``Queue``/``Event`` IPC objects it
-    received via pickle from Main. Verifying the call wiring here so a
-    future refactor of ``_writer_process`` cannot silently regress the
-    #768 fix and let the crash rot back in."""
+class TestWriterProcessAttachesUnderShimContext:
+    """The writer subprocess must attach its SharedMemory buffers inside
+    the ``_child_skips_shm_registration`` context so no shared_memory
+    REGISTER escapes to the tracker daemon. Verifying the wiring here so
+    a future refactor of ``_writer_process`` cannot silently regress the
+    fix and let the double-unlink (#768) or KeyError-storm (#777)
+    scenarios rot back in."""
 
-    def test_writer_process_calls_unregister_helper_for_attached_ipc(self):
-        """After attaching to the SharedMemory buffers and before entering
-        the write loop, the writer must call ``_unregister_ipc_from_child_tracker``
-        with every buffer it attached AND every IPC object it received as
-        args (``buffer_queue``, ``stop_event``, ``stats_queue``). Missing
-        any of them re-opens the #768 race for that primitive."""
+    def test_writer_process_attaches_shms_under_shim(self):
+        """Every ``SharedMemory(name=...)`` attach must happen while the
+        ``_child_skips_shm_registration`` context is active. Attaching
+        outside the shim would restore the double-registration that #768
+        and #777 both trace back to."""
         names = ["/ckpt_probe_a", "/ckpt_probe_b", "/ckpt_probe_c"]
         fake_shms = []
         for n in names:
@@ -302,8 +286,7 @@ class TestWriterProcessInvokesUnregister:
             fake_shms.append(m)
 
         buffer_queue = MagicMock()
-        # Immediate stop — write loop never iterates.
-        buffer_queue.get = MagicMock(return_value=None)
+        buffer_queue.get = MagicMock(return_value=None)  # skip write loop
         stop_event = MagicMock()
         stats_queue = MagicMock()
         stats_queue.put = MagicMock()
@@ -313,20 +296,42 @@ class TestWriterProcessInvokesUnregister:
         fake_writer = MagicMock()
         fake_writer.close = MagicMock(return_value={"backend": "test"})
 
+        # State captured by the shim probes: True/False for whether the
+        # shim was active at each SharedMemory call site, and the order
+        # of enter/exit vs. attach calls.
+        shim_active = {"value": False}
+        event_log = []
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _probe_shim():
+            shim_active["value"] = True
+            event_log.append("shim_enter")
+            try:
+                yield
+            finally:
+                event_log.append("shim_exit")
+                shim_active["value"] = False
+
+        attach_iter = iter(fake_shms)
+
+        def _probe_shared_memory(name=None, **kwargs):
+            event_log.append(("attach", name, shim_active["value"]))
+            return next(attach_iter)
+
         with patch.object(
-            sc.shared_memory, "SharedMemory", side_effect=fake_shms
+            sc, "_child_skips_shm_registration", _probe_shim
+        ), patch.object(
+            sc.shared_memory, "SharedMemory", side_effect=_probe_shared_memory
         ), patch.object(
             sc.StorageWriterFactory, "create", return_value=fake_writer
-        ), patch.object(
-            sc, "_unregister_ipc_from_child_tracker"
-        ) as mock_unreg, patch(
-            "os._exit"
-        ):
+        ), patch("os._exit"):
             sc.StreamingCheckpointing._writer_process(
                 names,
                 1024,
                 "/tmp/probe_ckpt",
-                0,  # total_size=0 → write loop skipped
+                0,  # total_size=0 -> write loop skipped
                 buffer_queue,
                 stop_event,
                 stats_queue,
@@ -335,32 +340,30 @@ class TestWriterProcessInvokesUnregister:
                 "none",
             )
 
-        assert mock_unreg.called, (
-            "Writer subprocess must invoke _unregister_ipc_from_child_tracker "
-            "after attaching to Main's IPC — otherwise the #768 double-unlink "
-            "race is not closed."
-        )
-
-        # Aggregate every positional arg across all calls to the helper.
-        seen = set()
-        for call in mock_unreg.call_args_list:
-            for arg in call.args:
-                seen.add(id(arg))
-
-        for shm in fake_shms:
-            assert id(shm) in seen, (
-                f"writer failed to unregister attached SharedMemory {shm._name} "
-                f"from child resource_tracker"
+        # Every attach happened with shim_active=True.
+        attach_events = [e for e in event_log if isinstance(e, tuple)]
+        assert attach_events, "writer did not attach any SharedMemory buffers"
+        for _tag, name, active in attach_events:
+            assert active, (
+                f"SharedMemory attach for {name!r} happened OUTSIDE the "
+                "_child_skips_shm_registration shim — this reintroduces the "
+                "double-registration that #768/#777 trace back to."
             )
-        assert id(buffer_queue) in seen, (
-            "writer failed to unregister buffer_queue's SemLocks — "
-            "leaves the mp.Queue semaphore race path open"
+
+        # And the shim opened before the first attach and closed after the
+        # last one — the shim must WRAP the entire attach loop, not open/
+        # close per attach.
+        assert event_log[0] == "shim_enter", (
+            "shim must be entered before the first SharedMemory attach; "
+            "event log: {!r}".format(event_log)
         )
-        assert id(stats_queue) in seen, (
-            "writer failed to unregister stats_queue's SemLocks — "
-            "leaves the mp.Queue semaphore race path open"
+        assert "shim_exit" in event_log, "shim never exited"
+        last_attach_idx = max(
+            i for i, e in enumerate(event_log) if isinstance(e, tuple)
         )
-        assert id(stop_event) in seen, (
-            "writer failed to unregister stop_event's SemLocks — "
-            "leaves the mp.Event semaphore race path open"
+        first_exit_idx = event_log.index("shim_exit")
+        assert last_attach_idx < first_exit_idx, (
+            "shim exited before the last attach; event log: {!r}".format(
+                event_log
+            )
         )


### PR DESCRIPTION
Closes #777.

## Summary

- #768 replaced a fatal `shm.unlink() -> FileNotFoundError` with the "immediate unregister in child" community pattern. That pattern is only safe when the parent never explicitly unlinks the resource itself — which we do, per `save()` cycle, in `_release_buffer_pool` (a fresh pool per save() means the previous one must be released or `/dev/shm` leaks gigabytes per checkpoint). And Main's `SemLock` Finalize inevitably fires on `Queue`/`Event` GC, calling `sem_unlink` + `resource_tracker.unregister` on names the child already unregistered. Result at 64 ranks × N save() calls: a per-run KeyError storm (`cache[rtype].remove(name)` on empty set), a 700+ `sem_unlink -> FileNotFoundError` cascade, and a correlated cluster-wide livelock right after checkpoint 1.
- Switch to the other well-known variant: **skip the child's REGISTER in the first place**, via a scoped monkey-patch of `resource_tracker.register` that no-ops for `shared_memory` inside the `SharedMemory(name=...)` attach block. Tracker cache holds exactly one entry (Main's); Main's later `unlink -> unregister` finds and removes it cleanly. Functionally equivalent to Python 3.13's `SharedMemory(track=False)`.
- Semaphore branch is dropped entirely. `SemLock.__setstate__` registers with the tracker before our target function runs (during forkserver bootstrap unpickle), so a scoped patch cannot cover it. Pre-#768 semaphore behavior was "alarming `SemLock._rebuild` warnings but functionally correct" — strictly better than the KeyError + double-`sem_unlink` cascade the immediate-unregister variant caused. The child never calls `sem_unlink` (exit via `os._exit()` bypasses Finalizers); Main's Finalize fires normally and cleans up.
- `_release_buffer_pool`'s defensive `FileNotFoundError` swallow is kept as a backstop.
- Tests rewritten to verify the new contract: the shim no-ops shm register within the block, forwards semaphore register through, restores register on both success and exception, never calls unregister (regression guard for #777), and `_writer_process` runs its entire attach loop inside the shim.

## Load-bearing assumptions (Python 3.12)

- `SharedMemory.__init__` calls `resource_tracker.register` via module-attribute lookup at the end of `__init__` (verified in `/usr/lib/python3.12/multiprocessing/shared_memory.py:120`).
- `SemLock.__setstate__` does NOT register a `util.Finalize` (verified in `/usr/lib/python3.12/multiprocessing/synchronize.py:113` — Finalize is only in `__init__`), so children unpickled from Main never `sem_unlink` at exit.

If either invariant changes in a future CPython patch release, the fix would need revisiting. The test suite would catch (1) since `test_shm_register_is_a_noop_within_block` mirrors what `SharedMemory` does.

## Test plan

- [x] `uv run pytest tests` — 2907 passed, 1 skipped, 13 deselected
- [x] `uv run pytest mlpstorage_py/tests` — 844 passed
- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed, 2 deselected
- [x] `uv run pytest vdb_benchmark/tests` — 174 passed
- [ ] **@bissantz**: please re-run the llama3-70b / 64-rank / 8-node campaign that reproduced #777 and confirm (a) KeyError count on `resource_tracker.py:239` drops to 0, (b) `sem_unlink -> FileNotFoundError` count drops meaningfully (some `SemLock._rebuild` residue may remain — that's a distinct pre-#768 race, not addressed here), (c) no livelock after checkpoint 1. I have not been able to independently reproduce the livelock on our hardware, so this fix removes the two correlated stressors but I can't claim it eliminates the livelock without your scale-test confirmation.