### PR TITLE
fix(#778): refuse --results-dir nested inside source_root

### DIFF
--- a/mlpstorage_py/submission_checker/tools/code_image.py
+++ b/mlpstorage_py/submission_checker/tools/code_image.py
@@ -1018,6 +1018,28 @@ def capture_or_verify_code_image(args, env, log):
                        f"or point --results-dir at an existing directory",
             code=ErrorCode.CONFIG_INVALID_VALUE,
         )
+    # Issue #778: refuse when results_dir is inside source_root. The pool tmp
+    # lives under org_root = <results_dir>/<orgname>/, so _atomic_capture's
+    # shutil.copytree(source_root, tmp) walks its own destination, copies
+    # itself into itself, and blows out with ENAMETOOLONG. Even without the
+    # recursion, compute_code_tree_md5(source_root) would fold prior-run
+    # outputs and the .mlps-code-image pointer written by the current run
+    # into the source hash, so verify_source_against_image would silently
+    # fail on the next invocation. Refusing here fixes both.
+    source_root = find_source_root()
+    resolved_source = source_root.resolve()
+    resolved_results = results_dir.resolve()
+    if resolved_results == resolved_source or resolved_results.is_relative_to(resolved_source):
+        raise ConfigurationError(
+            f"--results-dir {str(results_dir)!r} lives inside the mlpstorage "
+            f"source tree at {str(source_root)!r} (issue #778); the code-image "
+            f"capture would recursively copy its own destination and fail with "
+            f"ENAMETOOLONG",
+            parameter="--results-dir",
+            suggestion="Point --results-dir at a path OUTSIDE the mlpstorage "
+                       "checkout (e.g., /var/tmp/mlps-results, $HOME/mlps-results)",
+            code=ErrorCode.CONFIG_INVALID_VALUE,
+        )
     # 6. Phase 6 pool + pointer flow (D-63..D-67, CAPVER-01/02/03, POOL-01..04,
     # PTR-01, UX-01). Mode-agnostic org_root per D-64: pool images live under
     # <results_dir>/<orgname>/code-<hash8>/, shared across closed and open.
@@ -1038,7 +1060,7 @@ def capture_or_verify_code_image(args, env, log):
         )
 
     # 6b. Hash the live source tree exactly once (CAPVER-01 predicate).
-    source_root = find_source_root()
+    # source_root was resolved above for the #778 nested-results guard.
     live_hash = compute_code_tree_md5(str(source_root), log)
     if live_hash is None:
         # source_root exists (find_source_root would have raised

--- a/mlpstorage_py/tests/test_capture_or_verify_code_image.py
+++ b/mlpstorage_py/tests/test_capture_or_verify_code_image.py
@@ -219,6 +219,91 @@ class TestPathTraversalGuard:
 
 
 # ---------------------------------------------------------------------------
+# Issue #778: refuse results-dir nested inside the mlpstorage source tree.
+#
+# Without this guard, _atomic_capture's shutil.copytree walks source_root,
+# descends into the results-dir subtree (which is not in MD5_EXCLUDE_PREFIXES),
+# and copies its own destination into itself. Path length grows unbounded
+# until the OS returns ENAMETOOLONG — the exact traceback in Issue #778.
+# ---------------------------------------------------------------------------
+
+class TestResultsDirInsideSourceRoot:
+    """Issue #778: refuse when --results-dir lives inside source_root."""
+
+    def test_results_dir_inside_source_root_raises_configuration_error(
+        self, tmp_path, log, monkeypatch,
+    ):
+        # Fake source root with a pyproject.toml; results_dir nested underneath.
+        src = tmp_path / "src_root"
+        src.mkdir()
+        (src / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.0.1'\n")
+        monkeypatch.setattr(
+            "mlpstorage_py.submission_checker.tools.code_image.find_source_root",
+            lambda: src,
+        )
+
+        results_dir = src / "mlps-results" / "unet3d"
+        results_dir.mkdir(parents=True)
+
+        args = _make_args(
+            mode="closed", command="datagen",
+            results_dir=results_dir, orgname="local",
+        )
+        with pytest.raises(ConfigurationError) as exc_info:
+            capture_or_verify_code_image(args, {}, log)
+
+        msg = str(exc_info.value)
+        assert "778" in msg, msg
+        assert exc_info.value.parameter == "--results-dir"
+        assert exc_info.value.code == ErrorCode.CONFIG_INVALID_VALUE
+
+    def test_results_dir_equal_to_source_root_raises(
+        self, tmp_path, log, monkeypatch,
+    ):
+        # Edge case: --results-dir set to the source root itself.
+        src = tmp_path / "src_root"
+        src.mkdir()
+        (src / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.0.1'\n")
+        monkeypatch.setattr(
+            "mlpstorage_py.submission_checker.tools.code_image.find_source_root",
+            lambda: src,
+        )
+
+        args = _make_args(
+            mode="closed", command="datagen",
+            results_dir=src, orgname="local",
+        )
+        with pytest.raises(ConfigurationError) as exc_info:
+            capture_or_verify_code_image(args, {}, log)
+        assert "778" in str(exc_info.value)
+
+    def test_results_dir_sibling_of_source_root_is_allowed(
+        self, tmp_path, log, monkeypatch,
+    ):
+        # Sanity: a results_dir OUTSIDE source_root must NOT trip the #778 guard.
+        src = tmp_path / "src_root"
+        src.mkdir()
+        (src / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.0.1'\n")
+        (src / "mlpstorage_py").mkdir()
+        (src / "mlpstorage_py" / "__init__.py").write_text("__version__='0.0.1'\n")
+        monkeypatch.setattr(
+            "mlpstorage_py.submission_checker.tools.code_image.find_source_root",
+            lambda: src,
+        )
+
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+
+        args = _make_args(
+            mode="closed", command="datagen",
+            results_dir=results_dir, orgname="local",
+        )
+        # Must not raise the #778 ConfigurationError. It may still succeed
+        # (returning a Path) — the point is that we do NOT reject a valid layout.
+        capture_or_verify_code_image(args, {}, log)
+
+
+# ---------------------------------------------------------------------------
 # Capture / verify behavioral tests moved to Plan 06-02:
 #
 # The pre-Phase-6 legacy `code/` tree-shape assertions (`TestCapturePath`) and


### PR DESCRIPTION
## Summary

Fixes #778. When ``--results-dir`` lives inside the mlpstorage source tree, ``capture_or_verify_code_image`` now refuses the configuration up front with a ``ConfigurationError`` (``--results-dir``, ``CONFIG_INVALID_VALUE``) instead of blowing up mid-copy with ``[Errno 36] File name too long``.

## Root cause

- ``find_source_root()`` walks up from the installed module to ``pyproject.toml``.
- The reporter's checkout sits at ``/config/home/ubuntu/storage/`` and their ``--results-dir`` was ``/config/home/ubuntu/storage/mlps-results/unet3d`` — inside the source tree.
- ``_atomic_capture`` calls ``shutil.copytree(source_root, tmp)`` where ``tmp`` = ``<results_dir>/<orgname>/.code-<hash8>.tmp.<pid>/``. ``ignore_logic`` excludes ``.git``, ``__pycache__``, ``tests/``, etc., but has no notion of the copy destination, so the walker descends into ``mlps-results/.../.code-*.tmp.*/`` — the directory it is currently writing into — and recurses until the path length exceeds ``NAME_MAX``. That is the exact ``.code-*.tmp.*/mlps-results/unet3d/local/.code-*.tmp.*/...`` chain in the issue traceback.

Even without the recursion, ``compute_code_tree_md5(source_root)`` would fold prior-run outputs and the ``.mlps-code-image`` pointer written by the current run into the source hash, so ``verify_source_against_image`` would silently fail on the next invocation. Refusing at the entry point fixes both.

## Change

- ``capture_or_verify_code_image``: after resolving ``results_dir``, resolve ``source_root`` and raise ``ConfigurationError`` (parameter ``--results-dir``, code ``CONFIG_INVALID_VALUE``, message names issue #778) when ``results_dir`` equals or is nested under ``source_root``. Suggestion points the user at a path outside the checkout.
- Reuse the already-resolved ``source_root`` at the CAPVER-01 hash step (drop the duplicate ``find_source_root()`` call).

## Tests

New class ``TestResultsDirInsideSourceRoot`` in ``mlpstorage_py/tests/test_capture_or_verify_code_image.py``:
- Nested ``results_dir`` raises ``ConfigurationError`` (RED without the fix reproduces the exact ``.code-*.tmp.*`` recursion + ``shutil.Error``).
- ``results_dir`` equal to ``source_root`` raises.
- ``results_dir`` outside ``source_root`` proceeds normally (regression guard).

## Test plan

- [x] RED test reproduces Issue #778 traceback locally
- [x] GREEN with the fix (3/3 new tests pass; 123/123 code-image-related tests pass)
- [x] Full CI matrix run locally in parallel — all four suites green:
  - ``mlpstorage_py/tests`` — 847 passed
  - ``tests/`` — 2910 passed, 1 skipped, 13 deselected
  - ``vdb_benchmark/tests`` — 174 passed
  - ``kv_cache_benchmark/tests`` — 238 passed, 2 deselected
- [ ] Reporter re-runs the failing command with a ``--results-dir`` outside the checkout and confirms the ``ConfigurationError`` (or reports back)