### PR TITLE
Fix checkpoint flush budget calculation

### DIFF
--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -7,6 +7,7 @@ from ..loader import SubmissionLogs
 from ..rule_registry import rule
 from .helpers import (
     _check_filesystem_separation,
+    _oldest_final_collection_timestamp,
     _pair_checkpoint_runs,
     _parse_iso_gap,
     read_fs_separation_sidecar,
@@ -601,12 +602,15 @@ class CheckpointingCheck(BaseCheck):
           * missing ``read.metadata.invocation_start_time`` →
             ``read.summary.start_time`` (predates #714). Downgrades a gap
             breach to ``warn_violation``.
-          * missing ``write.metadata.invocation_end_time`` →
-            ``write.summary.end_time`` (predates #782). The gap then
-            includes post-benchmark cluster collection, which on large
-            topologies can be tens of seconds; the check emits a normal
-            violation on breach but the submitter should re-run with a
-            current mlpstorage to get the honest measurement.
+          * missing ``write.metadata.invocation_end_time`` → the earliest
+            post-benchmark ``collection_timestamp`` in the write-phase
+            metadata, when present (a best-effort proxy for node release on
+            results dirs that predate #782 but do record per-node collection
+            timestamps); otherwise ``write.summary.end_time`` (predates both
+            fixes). Either fallback may still include some post-benchmark
+            cluster collection, so the check emits a normal violation on
+            breach but the submitter should re-run with a current mlpstorage
+            to get the honest measurement.
 
         A negative gap indicates NTP skew between the write and read nodes
         (the metadata fields are timestamped on their respective invocation
@@ -627,14 +631,32 @@ class CheckpointingCheck(BaseCheck):
         for write_entry, read_entry in pairs:
             write_summary, write_metadata, write_ts = write_entry
             read_summary, read_metadata, read_ts = read_entry
-            # §4.7.1 write-side origin: prefer invocation_end_time (captured
-            # post-cluster-collection), fall back to summary end_time for
-            # results dirs that predate storage#782.
+            # §4.7.1 write-side origin selection (highest priority first):
+            #   1. write.metadata.invocation_end_time — the authoritative
+            #      write-side bookend captured after _collect_cluster_end()
+            #      returns (storage#782). Excludes post-benchmark teardown.
+            #   2. earliest post-benchmark collection_timestamp in the
+            #      write-phase metadata — a best-effort origin for results
+            #      dirs that predate the invocation_end_time bookend but do
+            #      record per-node collection timestamps. The final cluster
+            #      collection runs after the timed section and occupies the
+            #      write nodes, so its earliest timestamp is a closer proxy
+            #      for node release than the raw summary end.
+            #   3. write.summary.end_time — the timed-section end (pre-fix
+            #      fallback; charges post-benchmark collection to the gap).
             write_end = (write_metadata or {}).get("invocation_end_time")
             write_origin_label = "write invocation_end"
             if write_end is None:
-                write_end = (write_summary or {}).get("end_time") or (write_summary or {}).get("end")
-                write_origin_label = "write summary end"
+                summary_end = (write_summary or {}).get("end_time") or (write_summary or {}).get("end")
+                final_collection_end = _oldest_final_collection_timestamp(
+                    write_metadata, summary_end
+                )
+                if final_collection_end is not None:
+                    write_end = final_collection_end
+                    write_origin_label = "write final-collection timestamp"
+                else:
+                    write_end = summary_end
+                    write_origin_label = "write summary end"
             read_start = (read_metadata or {}).get("invocation_start_time")
             read_origin_label = "read invocation_start"
             used_legacy_read_origin = False
@@ -653,16 +675,6 @@ class CheckpointingCheck(BaseCheck):
                     "invocation_end_time in write-phase metadata.json and "
                     "end_time in write-phase summary.json "
                     "(write_ts=%s, read_ts=%s)",
-                    write_ts, read_ts,
-                )
-                valid = False
-                continue
-            if read_start is None:
-                self.log_violation(
-                    "4.7.1", "checkpointCacheFlushValidation", self.path,
-                    "cannot compute failover-callout gap: read-phase metadata "
-                    "has no invocation_start_time and read-phase summary.json "
-                    "has no start_time/start (write_ts=%s, read_ts=%s)",
                     write_ts, read_ts,
                 )
                 valid = False

--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -7,7 +7,7 @@ from ..loader import SubmissionLogs
 from ..rule_registry import rule
 from .helpers import (
     _check_filesystem_separation,
-    _oldest_final_collection_timestamp,
+    _latest_final_collection_timestamp,
     _pair_checkpoint_runs,
     _parse_iso_gap,
     read_fs_separation_sidecar,
@@ -602,15 +602,17 @@ class CheckpointingCheck(BaseCheck):
           * missing ``read.metadata.invocation_start_time`` →
             ``read.summary.start_time`` (predates #714). Downgrades a gap
             breach to ``warn_violation``.
-          * missing ``write.metadata.invocation_end_time`` → the earliest
+          * missing ``write.metadata.invocation_end_time`` → the latest
             post-benchmark ``collection_timestamp`` in the write-phase
-            metadata, when present (a best-effort proxy for node release on
-            results dirs that predate #782 but do record per-node collection
-            timestamps); otherwise ``write.summary.end_time`` (predates both
-            fixes). Either fallback may still include some post-benchmark
-            cluster collection, so the check emits a normal violation on
-            breach but the submitter should re-run with a current mlpstorage
-            to get the honest measurement.
+            metadata, when present (the last node to finish the final cluster
+            collection marks the end of write-phase teardown — a best-effort
+            proxy for node release on results dirs that predate #782 but do
+            record per-node collection timestamps); otherwise
+            ``write.summary.end_time`` (predates both fixes). The summary-end
+            fallback still includes the full post-benchmark collection window
+            in the gap, so the check emits a normal violation on breach but
+            the submitter should re-run with a current mlpstorage to get the
+            honest measurement.
 
         A negative gap indicates NTP skew between the write and read nodes
         (the metadata fields are timestamped on their respective invocation
@@ -635,20 +637,21 @@ class CheckpointingCheck(BaseCheck):
             #   1. write.metadata.invocation_end_time — the authoritative
             #      write-side bookend captured after _collect_cluster_end()
             #      returns (storage#782). Excludes post-benchmark teardown.
-            #   2. earliest post-benchmark collection_timestamp in the
+            #   2. latest post-benchmark collection_timestamp in the
             #      write-phase metadata — a best-effort origin for results
             #      dirs that predate the invocation_end_time bookend but do
-            #      record per-node collection timestamps. The final cluster
-            #      collection runs after the timed section and occupies the
-            #      write nodes, so its earliest timestamp is a closer proxy
-            #      for node release than the raw summary end.
+            #      record per-node collection timestamps. The write nodes are
+            #      only released once the last node finishes the final
+            #      cluster collection, so the latest such timestamp marks the
+            #      end of write-phase teardown and is a close proxy for the
+            #      invocation_end_time bookend.
             #   3. write.summary.end_time — the timed-section end (pre-fix
             #      fallback; charges post-benchmark collection to the gap).
             write_end = (write_metadata or {}).get("invocation_end_time")
             write_origin_label = "write invocation_end"
             if write_end is None:
                 summary_end = (write_summary or {}).get("end_time") or (write_summary or {}).get("end")
-                final_collection_end = _oldest_final_collection_timestamp(
+                final_collection_end = _latest_final_collection_timestamp(
                     write_metadata, summary_end
                 )
                 if final_collection_end is not None:

--- a/mlpstorage_py/submission_checker/checks/helpers.py
+++ b/mlpstorage_py/submission_checker/checks/helpers.py
@@ -440,3 +440,89 @@ def _parse_iso_gap(start_str: str, end_str: str) -> float:
     start = _parse(start_str)
     end = _parse(end_str)
     return (end - start).total_seconds()
+
+
+# ---------------------------------------------------------------------------
+# _oldest_final_collection_timestamp
+# ---------------------------------------------------------------------------
+
+def _normalize_collection_iso(s: str) -> str:
+    """Normalise an ISO timestamp for naive parsing on Python 3.10+.
+
+    Collection timestamps are emitted with a trailing ``Z`` (UTC designator),
+    e.g. ``"2026-07-13T06:37:03Z"``; benchmark ``summary.json`` timestamps are
+    naive (no offset). Both are wall-clock instants recorded on the same
+    (write-invocation) host, so the ``Z`` is stripped and the values are
+    compared naively. A space separator is normalised to ``T`` as well.
+    """
+    s = s.strip()
+    if s.endswith("Z"):
+        s = s[:-1]
+    return s.replace(" ", "T")
+
+
+def _iter_collection_timestamps(obj):
+    """Yield every ``collection_timestamp`` string found in a nested metadata
+    structure (dicts/lists), recursing into all containers."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if key == "collection_timestamp" and isinstance(value, str):
+                yield value
+            else:
+                yield from _iter_collection_timestamps(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _iter_collection_timestamps(item)
+
+
+def _oldest_final_collection_timestamp(metadata, after_iso: str):
+    """Return the oldest post-benchmark ``collection_timestamp`` in ``metadata``.
+
+    The write invocation performs a final, multi-node data collection AFTER the
+    checkpoint benchmark's timed section ends (e.g. the ``end`` cluster
+    snapshot). That collection occupies the write nodes and delays the read
+    invocation from launching, so it should not be charged against the
+    §4.7.1 30-second failover-callout budget — mirroring the read-side
+    framework-startup exclusion (#696/#714).
+
+    This returns the *earliest* ``collection_timestamp`` in ``metadata`` that
+    occurs at or after ``after_iso`` (the write benchmark's summary end),
+    normalised to a naive ISO string, or ``None`` when the metadata carries no
+    post-benchmark collection timestamp. Start-of-run collection timestamps
+    (before ``after_iso``) are ignored so the failover-callout origin is never
+    moved *earlier* than the summary end.
+
+    Choosing the oldest (earliest) post-benchmark timestamp is deliberately
+    conservative: it credits the write phase for its final-collection window
+    while still charging as much of the inter-phase gap to the write side as
+    the evidence allows.
+
+    Args:
+        metadata: The write-phase ``metadata.json`` dict (may be ``None``).
+        after_iso: The write benchmark's ``summary.json`` end timestamp.
+
+    Returns:
+        The oldest qualifying collection timestamp as a naive ISO string, or
+        ``None``.
+    """
+    if not isinstance(metadata, dict) or not after_iso:
+        return None
+    try:
+        after = datetime.datetime.fromisoformat(_normalize_collection_iso(after_iso))
+    except (ValueError, TypeError):
+        return None
+
+    best_str = None
+    best_dt = None
+    for raw in _iter_collection_timestamps(metadata):
+        normalized = _normalize_collection_iso(raw)
+        try:
+            candidate = datetime.datetime.fromisoformat(normalized)
+        except (ValueError, TypeError):
+            continue
+        if candidate < after:
+            continue
+        if best_dt is None or candidate < best_dt:
+            best_dt = candidate
+            best_str = normalized
+    return best_str

--- a/mlpstorage_py/submission_checker/checks/helpers.py
+++ b/mlpstorage_py/submission_checker/checks/helpers.py
@@ -443,7 +443,7 @@ def _parse_iso_gap(start_str: str, end_str: str) -> float:
 
 
 # ---------------------------------------------------------------------------
-# _oldest_final_collection_timestamp
+# _latest_final_collection_timestamp
 # ---------------------------------------------------------------------------
 
 def _normalize_collection_iso(s: str) -> str:
@@ -475,8 +475,8 @@ def _iter_collection_timestamps(obj):
             yield from _iter_collection_timestamps(item)
 
 
-def _oldest_final_collection_timestamp(metadata, after_iso: str):
-    """Return the oldest post-benchmark ``collection_timestamp`` in ``metadata``.
+def _latest_final_collection_timestamp(metadata, after_iso: str):
+    """Return the latest post-benchmark ``collection_timestamp`` in ``metadata``.
 
     The write invocation performs a final, multi-node data collection AFTER the
     checkpoint benchmark's timed section ends (e.g. the ``end`` cluster
@@ -485,24 +485,25 @@ def _oldest_final_collection_timestamp(metadata, after_iso: str):
     §4.7.1 30-second failover-callout budget — mirroring the read-side
     framework-startup exclusion (#696/#714).
 
-    This returns the *earliest* ``collection_timestamp`` in ``metadata`` that
-    occurs at or after ``after_iso`` (the write benchmark's summary end),
-    normalised to a naive ISO string, or ``None`` when the metadata carries no
-    post-benchmark collection timestamp. Start-of-run collection timestamps
-    (before ``after_iso``) are ignored so the failover-callout origin is never
-    moved *earlier* than the summary end.
+    The write nodes are only released once the *last* node finishes the final
+    collection, so this returns the *latest* ``collection_timestamp`` in
+    ``metadata`` that occurs at or after ``after_iso`` (the write benchmark's
+    summary end), normalised to a naive ISO string, or ``None`` when the
+    metadata carries no post-benchmark collection timestamp. Start-of-run
+    collection timestamps (before ``after_iso``) are ignored so the
+    failover-callout origin is never moved *earlier* than the summary end.
 
-    Choosing the oldest (earliest) post-benchmark timestamp is deliberately
-    conservative: it credits the write phase for its final-collection window
-    while still charging as much of the inter-phase gap to the write side as
-    the evidence allows.
+    Choosing the latest post-benchmark timestamp marks the true end of the
+    write phase's teardown (the moment the nodes are actually released),
+    excluding that teardown window from the inter-phase gap — the same intent
+    as the ``invocation_end_time`` bookend this fallback stands in for.
 
     Args:
         metadata: The write-phase ``metadata.json`` dict (may be ``None``).
         after_iso: The write benchmark's ``summary.json`` end timestamp.
 
     Returns:
-        The oldest qualifying collection timestamp as a naive ISO string, or
+        The latest qualifying collection timestamp as a naive ISO string, or
         ``None``.
     """
     if not isinstance(metadata, dict) or not after_iso:
@@ -522,7 +523,7 @@ def _oldest_final_collection_timestamp(metadata, after_iso: str):
             continue
         if candidate < after:
             continue
-        if best_dt is None or candidate < best_dt:
+        if best_dt is None or candidate > best_dt:
             best_dt = candidate
             best_str = normalized
     return best_str

--- a/mlpstorage_py/tests/conftest.py
+++ b/mlpstorage_py/tests/conftest.py
@@ -374,6 +374,16 @@ def build_submission(tmp_path, **overrides) -> Path:
       fallback in ``cache_flush_validation`` — the check falls back to
       ``write.summary.end_time`` and includes any post-benchmark cluster
       collection in the measured gap.
+    * ``chkpt_write_collection_offsets`` (list[int] | None, default None) —
+      CHKPT-02: when ``chkpt_split_mode=True``, inject one nested
+      ``collection_timestamp`` into each WRITE-phase metadata.json per offset,
+      each computed as write ``end_time`` + offset seconds (offsets may be
+      negative to model a pre-benchmark, start-of-run collection). Exercises
+      the final-collection gap-origin path in ``cache_flush_validation``: the
+      earliest post-benchmark ``collection_timestamp`` (offset >= 0) becomes
+      the gap origin, while pre-benchmark timestamps (offset < 0) are ignored.
+      Timestamps are emitted with a trailing ``Z`` to also exercise the
+      ``_normalize_collection_iso`` UTC-designator stripping.
     * ``chkpt_model`` (str, default "llama3-8b") — CHKPT-01: model directory name
       under ``checkpointing/``.
     * ``chkpt_open_num_processes`` (int | None) — CHKPT-01: when non-None, sets
@@ -454,6 +464,7 @@ def build_submission(tmp_path, **overrides) -> Path:
     chkpt_write_teardown_seconds = overrides.pop("chkpt_write_teardown_seconds", 0)
     chkpt_omit_invocation_start_time = overrides.pop("chkpt_omit_invocation_start_time", False)
     chkpt_omit_invocation_end_time = overrides.pop("chkpt_omit_invocation_end_time", False)
+    chkpt_write_collection_offsets = overrides.pop("chkpt_write_collection_offsets", None)
     chkpt_model = overrides.pop("chkpt_model", "llama3-8b")
     chkpt_open_num_processes = overrides.pop("chkpt_open_num_processes", None)
     chkpt_closed_num_processes = overrides.pop("chkpt_closed_num_processes", None)
@@ -824,6 +835,29 @@ def build_submission(tmp_path, **overrides) -> Path:
                     if ts in write_timestamps:
                         chkpt_meta["args"]["num_checkpoints_write"] = 10
                         chkpt_meta["args"]["num_checkpoints_read"] = 0
+
+                        # §4.7.1 final-collection gap origin: inject nested
+                        # collection_timestamp(s) into the WRITE metadata. The
+                        # write invocation performs a post-benchmark multi-node
+                        # collection after end_time; the earliest such timestamp
+                        # (offset >= 0) is the gap origin, pre-benchmark ones
+                        # (offset < 0) are ignored. Emitted with a trailing "Z"
+                        # to also exercise _normalize_collection_iso.
+                        if chkpt_write_collection_offsets:
+                            wi = write_timestamps.index(ts)
+                            _w_start = _BASE_DT + datetime.timedelta(minutes=10 * wi)
+                            _w_end = _w_start + datetime.timedelta(minutes=5)
+                            chkpt_meta["cluster_information"] = {
+                                "collections": [
+                                    {
+                                        "collection_timestamp": (
+                                            _w_end
+                                            + datetime.timedelta(seconds=off)
+                                        ).isoformat() + "Z"
+                                    }
+                                    for off in chkpt_write_collection_offsets
+                                ]
+                            }
                     else:
                         chkpt_meta["args"]["num_checkpoints_write"] = 0
                         chkpt_meta["args"]["num_checkpoints_read"] = 10

--- a/mlpstorage_py/tests/conftest.py
+++ b/mlpstorage_py/tests/conftest.py
@@ -380,10 +380,11 @@ def build_submission(tmp_path, **overrides) -> Path:
       each computed as write ``end_time`` + offset seconds (offsets may be
       negative to model a pre-benchmark, start-of-run collection). Exercises
       the final-collection gap-origin path in ``cache_flush_validation``: the
-      earliest post-benchmark ``collection_timestamp`` (offset >= 0) becomes
-      the gap origin, while pre-benchmark timestamps (offset < 0) are ignored.
-      Timestamps are emitted with a trailing ``Z`` to also exercise the
-      ``_normalize_collection_iso`` UTC-designator stripping.
+      latest post-benchmark ``collection_timestamp`` (offset >= 0) becomes
+      the gap origin (the last node released), while pre-benchmark timestamps
+      (offset < 0) are ignored. Timestamps are emitted with a trailing ``Z``
+      to also exercise the ``_normalize_collection_iso`` UTC-designator
+      stripping.
     * ``chkpt_model`` (str, default "llama3-8b") — CHKPT-01: model directory name
       under ``checkpointing/``.
     * ``chkpt_open_num_processes`` (int | None) — CHKPT-01: when non-None, sets
@@ -839,10 +840,11 @@ def build_submission(tmp_path, **overrides) -> Path:
                         # §4.7.1 final-collection gap origin: inject nested
                         # collection_timestamp(s) into the WRITE metadata. The
                         # write invocation performs a post-benchmark multi-node
-                        # collection after end_time; the earliest such timestamp
-                        # (offset >= 0) is the gap origin, pre-benchmark ones
-                        # (offset < 0) are ignored. Emitted with a trailing "Z"
-                        # to also exercise _normalize_collection_iso.
+                        # collection after end_time; the latest such timestamp
+                        # (offset >= 0, the last node released) is the gap
+                        # origin, pre-benchmark ones (offset < 0) are ignored.
+                        # Emitted with a trailing "Z" to also exercise
+                        # _normalize_collection_iso.
                         if chkpt_write_collection_offsets:
                             wi = write_timestamps.index(ts)
                             _w_start = _BASE_DT + datetime.timedelta(minutes=10 * wi)

--- a/mlpstorage_py/tests/test_checkpointing_check_phase2.py
+++ b/mlpstorage_py/tests/test_checkpointing_check_phase2.py
@@ -348,10 +348,12 @@ class TestChkpt02_CacheFlushValidation:
     def test_split_mode_final_collection_timestamp_becomes_gap_origin(self, tmp_path, mock_logger):
         """§4.7.1 collection_timestamp fallback (used ONLY when invocation_end_time
         is absent): a 60s raw gap (write.summary.end_time → read.invocation_start_time)
-        would FAIL, but a post-benchmark collection_timestamp at end_time+40s moves
-        the origin so the charged gap is 60-40 = 20s and the pair PASSES. A
-        pre-benchmark collection at end_time-120s must be ignored (else the origin
-        would move earlier and the gap would balloon to 180s).
+        would FAIL, but the write nodes are only released once the LAST node finishes
+        the final collection. With post-benchmark collections at end_time+10s and
+        end_time+40s, the latest (+40s) becomes the origin so the charged gap is
+        60-40 = 20s and the pair PASSES. Taking the earliest (+10s) instead would
+        leave a 50s gap and wrongly FAIL. A pre-benchmark collection at end_time-120s
+        must be ignored (else the origin would move earlier and the gap balloons).
 
         invocation_end_time is omitted so the collection_timestamp path is
         exercised; when present it takes priority over collection_timestamp.
@@ -365,20 +367,22 @@ class TestChkpt02_CacheFlushValidation:
             # No invocation_end_time bookend → exercise the collection_timestamp
             # fallback (invocation_end_time otherwise takes priority).
             chkpt_omit_invocation_end_time=True,
-            # -120s = start-of-run collection (ignored); +40s = post-benchmark
-            # final collection (becomes the gap origin).
-            chkpt_write_collection_offsets=[-120, 40],
+            # -120s = start-of-run collection (ignored); +10s and +40s = the
+            # per-node post-benchmark final collection. The LATEST (+40s), when
+            # the last node is released, becomes the gap origin.
+            chkpt_write_collection_offsets=[-120, 10, 40],
         )
         check = _run_checkpointing_check(root, mock_logger)
         result = check.cache_flush_validation()
         assert result is True, (
-            "post-benchmark collection_timestamp should move the gap origin so "
-            "the charged gap (20s) is within the 30s limit"
+            "the latest post-benchmark collection_timestamp (+40s) should move "
+            "the gap origin so the charged gap (20s) is within the 30s limit"
         )
         assert mock_logger.errors == []
         # The INFO line must report the final-collection origin and the reduced
-        # 20.0s gap — proving the collection_timestamp (not summary end) was used
-        # and that the pre-benchmark timestamp was ignored (else gap would be 180s).
+        # 20.0s gap — proving the LATEST collection_timestamp (+40s, not the +10s
+        # earliest and not summary end) was used, and the pre-benchmark timestamp
+        # was ignored.
         assert any(
             "failover-callout gap 20.0s" in i
             and "write final-collection timestamp" in i

--- a/mlpstorage_py/tests/test_checkpointing_check_phase2.py
+++ b/mlpstorage_py/tests/test_checkpointing_check_phase2.py
@@ -293,10 +293,10 @@ class TestChkpt02_CacheFlushValidation:
         ), f"Expected INFO with invocation_end origin; got infos={mock_logger.infos!r}"
 
     def test_split_mode_missing_invocation_end_time_falls_back_to_summary_end(self, tmp_path, mock_logger):
-        """Backward-compat (storage#782): pre-fix write metadata (no invocation_end_time)
-        falls back to summary.end_time and the whole teardown window is charged
-        to the failover-callout budget — reproducing the original #782 bug on
-        older results dirs.
+        """Backward-compat (storage#782): pre-fix write metadata (no invocation_end_time
+        and no collection_timestamp) falls back to summary.end_time and the whole
+        teardown window is charged to the failover-callout budget — reproducing
+        the original #782 bug on older results dirs.
 
         45s teardown + 25s real gap ⇒ legacy gap = 70s ⇒ FAIL (matches
         pre-fix behavior). The INFO line must record the "write summary end"
@@ -344,6 +344,96 @@ class TestChkpt02_CacheFlushValidation:
             and "gap 25.0s" in m
             for m in mock_logger.infos
         ), f"Expected pass-path INFO; got infos={mock_logger.infos!r}"
+
+    def test_split_mode_final_collection_timestamp_becomes_gap_origin(self, tmp_path, mock_logger):
+        """§4.7.1 collection_timestamp fallback (used ONLY when invocation_end_time
+        is absent): a 60s raw gap (write.summary.end_time → read.invocation_start_time)
+        would FAIL, but a post-benchmark collection_timestamp at end_time+40s moves
+        the origin so the charged gap is 60-40 = 20s and the pair PASSES. A
+        pre-benchmark collection at end_time-120s must be ignored (else the origin
+        would move earlier and the gap would balloon to 180s).
+
+        invocation_end_time is omitted so the collection_timestamp path is
+        exercised; when present it takes priority over collection_timestamp.
+        """
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(
+            tmp_path,
+            chkpt_split_mode=True,
+            chkpt_summary_timestamps=True,
+            chkpt_cache_flush_gap_seconds=60,
+            # No invocation_end_time bookend → exercise the collection_timestamp
+            # fallback (invocation_end_time otherwise takes priority).
+            chkpt_omit_invocation_end_time=True,
+            # -120s = start-of-run collection (ignored); +40s = post-benchmark
+            # final collection (becomes the gap origin).
+            chkpt_write_collection_offsets=[-120, 40],
+        )
+        check = _run_checkpointing_check(root, mock_logger)
+        result = check.cache_flush_validation()
+        assert result is True, (
+            "post-benchmark collection_timestamp should move the gap origin so "
+            "the charged gap (20s) is within the 30s limit"
+        )
+        assert mock_logger.errors == []
+        # The INFO line must report the final-collection origin and the reduced
+        # 20.0s gap — proving the collection_timestamp (not summary end) was used
+        # and that the pre-benchmark timestamp was ignored (else gap would be 180s).
+        assert any(
+            "failover-callout gap 20.0s" in i
+            and "write final-collection timestamp" in i
+            for i in mock_logger.infos
+        ), f"Expected final-collection-origin INFO with 20.0s gap; got infos={mock_logger.infos!r}"
+
+    def test_split_mode_invocation_end_time_takes_priority_over_collection(self, tmp_path, mock_logger):
+        """When BOTH invocation_end_time and a post-benchmark collection_timestamp
+        are present, invocation_end_time wins. 45s teardown + 25s real gap: the
+        invocation_end bookend yields the honest 25s gap (PASS), even though a
+        collection_timestamp at end_time+5s is also present."""
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(
+            tmp_path,
+            chkpt_split_mode=True,
+            chkpt_summary_timestamps=True,
+            chkpt_write_teardown_seconds=45,
+            chkpt_cache_flush_gap_seconds=25,
+            chkpt_write_collection_offsets=[5],  # present but must be ignored
+        )
+        check = _run_checkpointing_check(root, mock_logger)
+        result = check.cache_flush_validation()
+        assert result is True, f"got errors={mock_logger.errors!r}"
+        assert mock_logger.errors == []
+        assert any(
+            "[4.7.1 checkpointCacheFlushValidation]" in m
+            and "write invocation_end=" in m
+            and "gap 25.0s" in m
+            for m in mock_logger.infos
+        ), f"Expected invocation_end origin to win; got infos={mock_logger.infos!r}"
+
+    def test_split_mode_pre_benchmark_collection_only_falls_back_to_summary_end(self, tmp_path, mock_logger):
+        """Only a pre-benchmark (start-of-run) collection_timestamp is present
+        (offset < 0), and no invocation_end_time bookend. It must be ignored, so
+        the gap origin falls back to write.summary.end_time and the charged gap
+        equals the raw 25s gap."""
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(
+            tmp_path,
+            chkpt_split_mode=True,
+            chkpt_summary_timestamps=True,
+            chkpt_cache_flush_gap_seconds=25,
+            chkpt_omit_invocation_end_time=True,
+            chkpt_write_collection_offsets=[-90],  # pre-benchmark only → ignored
+        )
+        check = _run_checkpointing_check(root, mock_logger)
+        result = check.cache_flush_validation()
+        assert result is True
+        assert mock_logger.errors == []
+        # Origin falls back to summary end; charged gap is the raw 25.0s.
+        assert any(
+            "failover-callout gap 25.0s" in i
+            and "write summary end" in i
+            for i in mock_logger.infos
+        ), f"Expected summary-end-origin INFO with 25.0s gap; got infos={mock_logger.infos!r}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request updates the checkpoint cache flush validation logic to more accurately account for final, post-benchmark data collections that occur after the main timed section. #782  The goal is to ensure that the measured gap between write and read phases does not unfairly penalize teams for legitimate post-benchmark activities. The main changes are the introduction of helper functions to locate and normalize collection timestamps, and the adjustment of the gap calculation to use the earliest qualifying post-benchmark collection timestamp when available.

**Checkpoint gap calculation improvements:**

* Added a new helper function `_oldest_final_collection_timestamp` to find the earliest post-benchmark `collection_timestamp` in write-phase metadata, ensuring the failover-callout gap is measured fairly.
* Modified `cache_flush_validation` to use the post-benchmark collection timestamp as the gap origin when available, and updated log messages to clarify which timestamp is used. [[1]](diffhunk://#diff-38ec20461200130fca257ee40a5beba92f4c628dc94b82d310fd7f641c7dc415L616-R617) [[2]](diffhunk://#diff-38ec20461200130fca257ee40a5beba92f4c628dc94b82d310fd7f641c7dc415R638-R653) [[3]](diffhunk://#diff-38ec20461200130fca257ee40a5beba92f4c628dc94b82d310fd7f641c7dc415R674-R679) [[4]](diffhunk://#diff-38ec20461200130fca257ee40a5beba92f4c628dc94b82d310fd7f641c7dc415L693-R717)
* Imported `_oldest_final_collection_timestamp` into `checkpointing_checks.py` for use in the validation logic.

**Helper utilities:**

* Introduced `_normalize_collection_iso` to standardize timestamp formats for comparison, and `_iter_collection_timestamps` to recursively find all `collection_timestamp` values in nested metadata structures. #