### PR TITLE
fix(storage#785): datasize sizes against max(declared, measured) memory

### DIFF
--- a/mlpstorage_py/rules/utils.py
+++ b/mlpstorage_py/rules/utils.py
@@ -46,6 +46,43 @@ def _check_safe_path_component(name: str, value: str) -> None:
         )
 
 
+def _reconcile_declared_and_measured(declared_total_bytes, cluster_information, logger):
+    """Return the larger of the CLI-declared budget and the measured cluster
+    memory when both are available (storage#785).
+
+    ``submission_checker`` rule 3.1.2 (trainingRecalculateDatasetSize)
+    computes the 5×memory requirement from the ``host_memory_GB`` array in
+    ``summary.json`` — i.e. the actual ``/proc/meminfo`` values MPI-collected
+    at run time — and the in-process ``check_num_files_train`` runs the
+    same math against ``cluster_information.total_memory_bytes``. If
+    ``datasize`` recommends against a smaller CLI-declared budget only,
+    the resulting dataset undersizes both checks: the reporter's run
+    failed with ``expected >= 1071000, actual 714000`` because their
+    machines had substantially more RAM than the declared
+    ``--client-host-memory-in-gb`` budget.
+
+    When measured < declared (e.g. an operator sizing against a reserved
+    budget larger than what MPI observed under cgroup limits), the
+    declared basis wins — that keeps the recommendation conservative for
+    both rule 3.1.2 (which will accept any file count ≥ 5× measured) and
+    forward-looking runs on unrestricted hardware.
+    """
+    if cluster_information is None:
+        return declared_total_bytes
+    measured = getattr(cluster_information, 'total_memory_bytes', 0) or 0
+    if measured <= declared_total_bytes:
+        return declared_total_bytes
+    logger.warning(
+        f"Measured cluster memory ({measured / (1024**3):.1f}GiB) exceeds "
+        f"the declared --client-host-memory-in-gb budget "
+        f"({declared_total_bytes / (1024**3):.1f}GiB); sizing against the "
+        f"measured value so the recommendation matches run-time "
+        f"check_num_files_train and submission_checker rule 3.1.2. See "
+        f"storage#785."
+    )
+    return measured
+
+
 def calculate_training_data_size(args, cluster_information, dataset_params, reader_params, logger,
                                  num_processes=None) -> Tuple[int, int, int]:
     """
@@ -102,12 +139,16 @@ def calculate_training_data_size(args, cluster_information, dataset_params, read
         per_host_memory_in_bytes = args.client_host_memory_in_gb * 1024 * 1024 * 1024
         num_hosts = args.num_client_hosts
         total_mem_bytes = per_host_memory_in_bytes * num_hosts
+        total_mem_bytes = _reconcile_declared_and_measured(
+            total_mem_bytes, cluster_information, logger)
         num_processes = args.num_processes
     elif hasattr(args, 'clienthost_host_memory_in_gb') and args.clienthost_host_memory_in_gb and \
          not (hasattr(args, 'num_client_hosts') and args.num_client_hosts):
         per_host_memory_in_bytes = args.clienthost_host_memory_in_gb * 1024 * 1024 * 1024
         num_hosts = len(args.hosts)
         total_mem_bytes = per_host_memory_in_bytes * num_hosts
+        total_mem_bytes = _reconcile_declared_and_measured(
+            total_mem_bytes, cluster_information, logger)
         num_processes = args.num_processes
     else:
         raise ValueError('Either args or cluster_information is required')

--- a/tests/unit/test_rules_calculations.py
+++ b/tests/unit/test_rules_calculations.py
@@ -205,6 +205,128 @@ class TestCalculateTrainingDataSize:
                 logger=mock_logger,
             )
 
+    def test_datasize_uses_measured_when_it_exceeds_declared_budget(
+            self, mock_logger, sample_reader_params):
+        """storage#785: datasize must recommend against the LARGER of the
+        CLI-declared --client-host-memory-in-gb budget and the actually
+        measured cluster memory. submission_checker rule 3.1.2 aggregates
+        host_memory_GB from summary.json (the /proc/meminfo values
+        MPI-collected at run time), so if we recommend against a smaller
+        declared budget only, datasize can undersize a run that will then
+        fail the run-time check_num_files_train and, later, rule 3.1.2.
+
+        Reporter (issue #785): declared 189 GiB/host * 51 hosts but real
+        hosts have significantly more RAM. Datasize returned 714,000 files
+        (500-step rule against the declared budget) while the run-time
+        check demanded ~1,071,000. Taking max(declared, measured) at
+        datasize time closes the gap so datasize, run-time check, and
+        submission_checker all agree.
+        """
+        # unet3d-sized records so 500-step (28,000) dominates over the
+        # 5x-declared-memory rule with a modest budget — this mirrors the
+        # reporter's shape.
+        unet3d_dataset_params = {
+            'num_samples_per_file': 1,
+            'record_length_bytes': 146_600_628,
+        }
+
+        mock_args = MagicMock()
+        mock_args.client_host_memory_in_gb = 100  # declared per-host GiB
+        mock_args.num_client_hosts = 4
+        mock_args.num_processes = 8
+
+        # Measured cluster memory ~10x the declared budget — e.g. hosts are
+        # 1 TiB machines but the operator scoped the storage budget to 100
+        # GiB/host. Rule 3.1.2 uses the measured value, so datasize must
+        # match.
+        one_tib_bytes = 1024 * 1024 * 1024 * 1024
+        measured_hosts = [
+            HostInfo(hostname=f'h{i}',
+                     memory=HostMemoryInfo.from_total_mem_int(one_tib_bytes))
+            for i in range(4)
+        ]
+        measured_cluster = ClusterInformation(measured_hosts, mock_logger)
+
+        num_files_declared_only, _, _ = calculate_training_data_size(
+            args=mock_args,
+            cluster_information=None,
+            dataset_params=unet3d_dataset_params,
+            reader_params=sample_reader_params,
+            logger=mock_logger,
+        )
+
+        num_files_measured_higher, _, _ = calculate_training_data_size(
+            args=mock_args,
+            cluster_information=measured_cluster,
+            dataset_params=unet3d_dataset_params,
+            reader_params=sample_reader_params,
+            logger=mock_logger,
+        )
+
+        # Sanity: with unet3d record_length and 4x100 GiB declared, the
+        # 5x-memory rule computes ~14,650 files while 500-step's floor is
+        # 500*8*7=28,000, so declared-only returns 28,000. With 4 TiB
+        # measured, the 5x rule dominates and returns ~150k.
+        assert num_files_declared_only == 28000, (
+            f"Precondition failed: declared-only should equal the 500-step "
+            f"floor of 28,000, got {num_files_declared_only}"
+        )
+        assert num_files_measured_higher > num_files_declared_only * 5, (
+            f"When measured cluster memory (~4 TiB) exceeds the declared "
+            f"budget (~400 GiB), datasize must size against the measured "
+            f"value (rule 3.1.2's basis) instead of the smaller declared "
+            f"budget. Got {num_files_measured_higher} vs "
+            f"{num_files_declared_only} — declared value silently wins, "
+            f"which is the storage#785 bug."
+        )
+
+    def test_datasize_keeps_declared_when_it_exceeds_measured(
+            self, mock_logger, sample_dataset_params, sample_reader_params):
+        """Guard against over-correction: when the CLI-declared budget is
+        LARGER than measured (e.g. operator has provisioned more RAM in
+        reserve, or MPI collection under-counted), datasize must still
+        honor the declared value — rule 3.1.2 will accept any file count
+        >= 5x measured, and the declared-larger recommendation stays
+        conservative for both."""
+        mock_args = MagicMock()
+        mock_args.client_host_memory_in_gb = 1024  # declared per-host GiB
+        mock_args.num_client_hosts = 4
+        mock_args.num_processes = 8
+
+        # Measured much smaller than declared (e.g. shrunk under cgroup).
+        small_bytes = 8 * 1024 * 1024 * 1024  # 8 GiB per host
+        measured_hosts = [
+            HostInfo(hostname=f'h{i}',
+                     memory=HostMemoryInfo.from_total_mem_int(small_bytes))
+            for i in range(4)
+        ]
+        measured_cluster = ClusterInformation(measured_hosts, mock_logger)
+
+        num_files_with_small_measured, _, _ = calculate_training_data_size(
+            args=mock_args,
+            cluster_information=measured_cluster,
+            dataset_params=sample_dataset_params,
+            reader_params=sample_reader_params,
+            logger=mock_logger,
+        )
+
+        num_files_declared_only, _, _ = calculate_training_data_size(
+            args=mock_args,
+            cluster_information=None,
+            dataset_params=sample_dataset_params,
+            reader_params=sample_reader_params,
+            logger=mock_logger,
+        )
+
+        # max(declared, measured) with declared > measured should equal the
+        # declared-only result.
+        assert num_files_with_small_measured == num_files_declared_only, (
+            f"When declared budget ({1024*4} GiB) exceeds measured "
+            f"({8*4} GiB), datasize must keep the declared basis; "
+            f"got {num_files_with_small_measured} vs "
+            f"{num_files_declared_only}"
+        )
+
 
 class TestGenerateOutputLocation:
     """Tests for generate_output_location function.


### PR DESCRIPTION
## Summary

- Fixes #785 — `mlpstorage closed training unet3d datasize` under-recommends `num_files_train` when hosts have more RAM than the CLI-declared `--client-host-memory-in-gb` budget, causing the follow-on run to fail `check_num_files_train`.
- Root cause: `calculate_training_data_size` used only the declared budget for the 5×memory rule, while `check_num_files_train` (via `cluster_information.total_memory_bytes` from MPI-collected `/proc/meminfo`) and `submission_checker` rule 3.1.2 (via `host_memory_GB` in `summary.json`) both use the actual measured host RAM. Datasize, run-check, and submission-check disagreed.
- Fix: new `_reconcile_declared_and_measured` helper takes `max(declared, measured)` when both are available in `mlpstorage_py/rules/utils.py`. Emits a WARNING when measured overrides declared so the operator sees why the recommendation grew.
- Guard against over-correction: when measured ≤ declared (cgroup-shrunk hosts, MPI undercount, reserved budget), the declared basis is preserved.
- Reporter (`lou-lydiksen-purestorage`) scenario: declared 189 GiB/host × 51 hosts → datasize returned 714,000 files (500-step against declared); run demanded ≥ 1,071,000. After the fix, datasize sizes against the measured cluster memory that the run-time and submission checks already enforce.

## Test plan

- [x] RED test committed first (`test_datasize_uses_measured_when_it_exceeds_declared_budget`), turns GREEN after the fix.
- [x] Regression guard (`test_datasize_keeps_declared_when_it_exceeds_measured`) — the declared-larger case still returns the declared basis.
- [x] `tests/unit` — 2745 passed, 1 skipped (no other test disturbed).
- [x] `mlpstorage_py/tests` — 847 passed.
- [ ] Reporter reruns their `mlpstorage closed training unet3d datasize` on the failing 51-host cluster and confirms the recommendation matches what `check_num_files_train` / `submission_checker` 3.1.2 subsequently accept.