### PR TITLE
fix(storage#782): exclude write-side teardown from §4.7.1 failover-callout gap

### DIFF
--- a/mlpstorage_py/_invocation.py
+++ b/mlpstorage_py/_invocation.py
@@ -1,14 +1,39 @@
-"""Earliest wall-clock instant of the mlpstorage process.
+"""Wall-clock bookends of the mlpstorage process.
 
-Captured at first import of this module. ``main.py`` imports this before
-any heavier ``mlpstorage_py`` submodule so the timestamp is recorded
-before framework startup (Python imports, MPI spawn, CAP env-validation,
-etc.). ``benchmarks/base.py`` reads the value when populating
-``invocation_start_time`` in the run's metadata; the submission checker
-uses that field as the read-side origin of the §4.7.1 gap check so
-per-invocation framework overhead is not charged against the 30-second
-failover-callout budget.
+``INVOCATION_START`` is captured at first import of this module. ``main.py``
+imports this before any heavier ``mlpstorage_py`` submodule so the timestamp
+is recorded before framework startup (Python imports, MPI spawn, CAP env-
+validation, etc.). ``benchmarks/base.py`` reads the value when populating
+``invocation_start_time`` in the run's metadata; the submission checker uses
+that field as the read-side origin of the §4.7.1 gap check so per-invocation
+framework overhead is not charged against the 30-second failover-callout
+budget.
+
+``INVOCATION_END`` is the symmetric write-side bookend. ``benchmarks/base.py``
+calls :func:`mark_invocation_end` at the top of ``write_metadata()`` — the
+latest moment where the timestamp can still land in the persisted file, and
+the closest we can get to rank 0's actual exit. The value is emitted as
+``invocation_end_time`` in the write-phase metadata; the submission checker
+uses it as the write-side origin of §4.7.1. Symmetric with the read-side
+capture-at-first-import: everything before ``INVOCATION_START`` on the read
+side (framework startup — Python imports, MPI spawn, CAP env-validation) is
+excluded from the callout gap, and everything after ``INVOCATION_END`` on
+the write side (post-benchmark cluster collection, rank-0 teardown
+processing, JSON serialization, interpreter shutdown) is excluded too. See
+mlcommons/storage#782.
 """
 import time
 
 INVOCATION_START: float = time.time()
+INVOCATION_END: float | None = None
+
+
+def mark_invocation_end() -> float:
+    """Record the current wall-clock instant as the invocation-end bookend.
+
+    Idempotent: subsequent calls overwrite the recorded value so the last
+    call before ``write_metadata()`` wins. Returns the recorded value.
+    """
+    global INVOCATION_END
+    INVOCATION_END = time.time()
+    return INVOCATION_END

--- a/mlpstorage_py/benchmarks/base.py
+++ b/mlpstorage_py/benchmarks/base.py
@@ -48,7 +48,8 @@ from typing import Tuple, Dict, Any, List, Optional, Callable, Set, TYPE_CHECKIN
 
 from functools import wraps
 
-from mlpstorage_py._invocation import INVOCATION_START
+from mlpstorage_py import _invocation
+from mlpstorage_py._invocation import INVOCATION_START, mark_invocation_end
 from mlpstorage_py.config import PARAM_VALIDATION, DATETIME_STR, MLPS_DEBUG, EXEC_TYPE
 from mlpstorage_py.errors import ConfigurationError, ErrorCode, FileSystemError
 from mlpstorage_py.run_directory import (
@@ -445,6 +446,16 @@ class Benchmark(BenchmarkInterface, abc.ABC):
         # §4.7.1 gap origin — ISO local naive to match DLIO summary.json's
         # start/end format so _parse_iso_gap can consume both fields uniformly.
         metadata['invocation_start_time'] = datetime.fromtimestamp(INVOCATION_START).isoformat()
+        # §4.7.1 write-side gap origin — captured after _collect_cluster_end()
+        # returns, i.e. the moment the write nodes are actually released.
+        # Symmetric with invocation_start_time on the read side. Absent when
+        # the invocation exited before mark_invocation_end() ran (e.g. crash
+        # during _run); the submission checker falls back to summary.end_time.
+        # See mlcommons/storage#782.
+        if _invocation.INVOCATION_END is not None:
+            metadata['invocation_end_time'] = datetime.fromtimestamp(
+                _invocation.INVOCATION_END
+            ).isoformat()
         metadata['verification'] = self.verification.name if self.verification else None
         metadata['executed_command'] = getattr(self, 'executed_command', None)
         metadata['command_output_files'] = self.command_output_files
@@ -463,6 +474,17 @@ class Benchmark(BenchmarkInterface, abc.ABC):
         Writes metadata to {metadata_file_path}. In verbose/debug mode,
         also prints metadata to stdout.
         """
+        # §4.7.1 write-side bookend — captured here (as late as possible
+        # while still landing in the persisted file) so the recorded
+        # instant reflects the point at which rank 0 is about to exit,
+        # not merely the end of the timed section. Symmetric with the
+        # read-side invocation_start_time capture at first import of
+        # _invocation.py. Per-invocation teardown that follows this
+        # point (JSON serialization, interpreter shutdown, MPI finalize)
+        # is excluded from the failover-callout budget, mirroring the
+        # framework-startup exclusion on the read side. See
+        # mlcommons/storage#782.
+        mark_invocation_end()
         with open(self.metadata_file_path, 'w+') as fd:
             json.dump(self.metadata, fd, indent=2, cls=MLPSJsonEncoder)
 

--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -583,28 +583,40 @@ class CheckpointingCheck(BaseCheck):
         pairs exist.
 
         The gap is measured as
-        ``read.metadata.invocation_start_time − write.summary.end_time`` so
-        that per-invocation framework startup on the read side (Python
-        imports, MPI spawn, CAP env-validation — up to ~50s in the wild) is
-        not charged against the 30-second callout budget. See Rules.md 4.7.1
-        for the semantic and mlpstorage_py/_invocation.py for the capture.
+        ``read.metadata.invocation_start_time − write.metadata.invocation_end_time``.
+        Both bookends are captured by ``mlpstorage_py/_invocation.py``: the
+        read side is snapshotted at first import (before any framework
+        startup — Python imports, MPI spawn, CAP env-validation), and the
+        write side is snapshotted after ``_collect_cluster_end()`` returns
+        (the point at which the write nodes are actually released). Neither
+        per-invocation framework startup on the read side nor post-benchmark
+        cluster collection on the write side is charged against the
+        30-second callout budget. See mlcommons/storage#714 (read side) and
+        #782 (write side).
 
         **Backward compat** — results directories produced by an mlpstorage
-        version predating this rule do not carry ``invocation_start_time``
-        in the read-phase metadata. In that case the check falls back to the
-        legacy origin (``read.summary.start_time`` / ``start``), which
-        conflates the failover callout with per-invocation framework startup
-        and so is not authoritative. To honor the rule that was in force
-        when those results were produced, a gap breach measured against the
-        legacy origin is emitted as a warning (``warn_violation``) rather
-        than a hard failure. The submitter can regenerate with a current
-        mlpstorage to get the honest measurement.
+        version predating either bookend fall back to the corresponding
+        DLIO summary field:
+
+          * missing ``read.metadata.invocation_start_time`` →
+            ``read.summary.start_time`` (predates #714). Downgrades a gap
+            breach to ``warn_violation``.
+          * missing ``write.metadata.invocation_end_time`` →
+            ``write.summary.end_time`` (predates #782). The gap then
+            includes post-benchmark cluster collection, which on large
+            topologies can be tens of seconds; the check emits a normal
+            violation on breach but the submitter should re-run with a
+            current mlpstorage to get the honest measurement.
 
         A negative gap indicates NTP skew between the write and read nodes
-        (the metadata is timestamped on the read-invocation host, the summary
-        on the write-invocation host); it is reported as such rather than as
-        an ordering / causality violation (which is the domain of
+        (the metadata fields are timestamped on their respective invocation
+        hosts); it is reported as such rather than as an ordering /
+        causality violation (which is the domain of
         ``checkpoint_invocation_structure``).
+
+        An INFO line is emitted for every write/read pair with the computed
+        gap and the chosen origin so the measurement is transparent whether
+        the pair passes, warns, or fails.
         """
         valid = True
         if self.mode != "checkpointing":
@@ -613,23 +625,34 @@ class CheckpointingCheck(BaseCheck):
         if not pairs:
             return valid
         for write_entry, read_entry in pairs:
-            write_summary, _, write_ts = write_entry
+            write_summary, write_metadata, write_ts = write_entry
             read_summary, read_metadata, read_ts = read_entry
-            write_end = (write_summary or {}).get("end_time") or (write_summary or {}).get("end")
+            # §4.7.1 write-side origin: prefer invocation_end_time (captured
+            # post-cluster-collection), fall back to summary end_time for
+            # results dirs that predate storage#782.
+            write_end = (write_metadata or {}).get("invocation_end_time")
+            write_origin_label = "write invocation_end"
+            if write_end is None:
+                write_end = (write_summary or {}).get("end_time") or (write_summary or {}).get("end")
+                write_origin_label = "write summary end"
             read_start = (read_metadata or {}).get("invocation_start_time")
-            used_legacy_origin = False
+            read_origin_label = "read invocation_start"
+            used_legacy_read_origin = False
             if read_start is None:
-                # Backward-compat fallback for results dirs that predate the
-                # §4.7.1 fix and don't carry invocation_start_time. Measure
-                # against read.summary.start_time and downgrade any breach
-                # to warn_violation below.
+                # Backward-compat fallback for results dirs that predate
+                # storage#714 and don't carry invocation_start_time.
+                # Measure against read.summary.start_time and downgrade
+                # any breach to warn_violation below.
                 read_start = (read_summary or {}).get("start_time") or (read_summary or {}).get("start")
-                used_legacy_origin = True
+                read_origin_label = "read summary start"
+                used_legacy_read_origin = True
             if write_end is None:
                 self.log_violation(
                     "4.7.1", "checkpointCacheFlushValidation", self.path,
-                    "cannot compute failover-callout gap: missing end_time in "
-                    "write-phase summary.json (write_ts=%s, read_ts=%s)",
+                    "cannot compute failover-callout gap: missing "
+                    "invocation_end_time in write-phase metadata.json and "
+                    "end_time in write-phase summary.json "
+                    "(write_ts=%s, read_ts=%s)",
                     write_ts, read_ts,
                 )
                 valid = False
@@ -654,6 +677,18 @@ class CheckpointingCheck(BaseCheck):
                 )
                 valid = False
                 continue
+            # Transparency: emit an INFO line for every pair with the gap
+            # and the chosen origin, so submitters can see the measurement
+            # regardless of pass/warn/fail. See storage#782.
+            self.log.info(
+                "[4.7.1 checkpointCacheFlushValidation] %s: "
+                "failover-callout gap %.1fs "
+                "(%s=%s, %s=%s, write_ts=%s, read_ts=%s)",
+                self.path, gap_seconds,
+                write_origin_label, write_end,
+                read_origin_label, read_start,
+                write_ts, read_ts,
+            )
             if gap_seconds < 0:
                 # Per Rules.md 4.7.1: negative gap → clock-skew warning, not
                 # a causality violation. Ordering / no-overlap is enforced
@@ -667,7 +702,7 @@ class CheckpointingCheck(BaseCheck):
                 )
                 continue
             if gap_seconds > 30:
-                if used_legacy_origin:
+                if used_legacy_read_origin:
                     # Pre-fix results dir: honor the rule that was in force
                     # when the run was produced by warning rather than
                     # failing. The gap measurement here includes per-
@@ -690,8 +725,10 @@ class CheckpointingCheck(BaseCheck):
                 self.log_violation(
                     "4.7.1", "checkpointCacheFlushValidation", self.path,
                     "failover-callout gap %.1f seconds exceeds 30-second limit "
-                    "(write end=%s, read invocation_start=%s)",
-                    gap_seconds, write_end, read_start,
+                    "(%s=%s, %s=%s)",
+                    gap_seconds,
+                    write_origin_label, write_end,
+                    read_origin_label, read_start,
                 )
                 valid = False
         return valid

--- a/mlpstorage_py/tests/conftest.py
+++ b/mlpstorage_py/tests/conftest.py
@@ -341,21 +341,39 @@ def build_submission(tmp_path, **overrides) -> Path:
       num_checkpoints_read=10`` (read-only) — pairs them per
       ``_pair_checkpoint_runs`` semantics.
     * ``chkpt_cache_flush_gap_seconds`` (int, default 25) — CHKPT-02/04: when
-      ``chkpt_split_mode=True`` AND ``chkpt_summary_timestamps=True``, sets the
-      gap between a write run's ``end`` and the following read run's ``start`` to
-      this many seconds. Also sets the read metadata's ``invocation_start_time``
-      to write ``end`` + this many seconds — since Rules.md §4.7.1 §4.7.1 measures
-      the failover-callout gap from write.summary.end_time to
-      read.metadata.invocation_start_time, this is the value that
-      ``cache_flush_validation`` sees. May be negative to simulate NTP clock skew
-      between the write and read hosts.
+      ``chkpt_split_mode=True`` AND ``chkpt_summary_timestamps=True``, this is
+      the value ``cache_flush_validation`` sees as the failover-callout gap.
+      Rules.md §4.7.1 measures ``read.metadata.invocation_start_time −
+      write.metadata.invocation_end_time``; the fixture sets
+      ``invocation_end_time = summary.end_time + chkpt_write_teardown_seconds``
+      (default 0) and ``invocation_start_time = invocation_end_time +
+      chkpt_cache_flush_gap_seconds``. May be negative to simulate NTP clock
+      skew between the write and read hosts.
+    * ``chkpt_write_teardown_seconds`` (int, default 0) — CHKPT-02 (storage#782):
+      when ``chkpt_split_mode=True`` AND ``chkpt_summary_timestamps=True``,
+      injects a gap between ``write.summary.end_time`` (end of the timed
+      section) and ``write.metadata.invocation_end_time`` (nodes actually
+      released — post cluster collection). Modelling the large-topology case
+      where the write phase's final multi-node collection keeps nodes busy
+      for tens of seconds after the timed section closes. Under the §4.7.1
+      fix in storage#782 the check uses ``invocation_end_time`` as the gap
+      origin, so this value shifts the "legacy" gap seen by pre-fix results
+      dirs (which used ``summary.end_time``) but leaves the "honest"
+      measured gap equal to ``chkpt_cache_flush_gap_seconds``.
     * ``chkpt_omit_invocation_start_time`` (bool, default False) — CHKPT-02:
       when True, do NOT emit ``invocation_start_time`` in read-side metadata
       (simulates a results dir produced by an mlpstorage version predating
-      the §4.7.1 gap-origin fix). Exercises the backward-compat fallback
-      path in ``cache_flush_validation`` — the check falls back to
+      storage#714). Exercises the backward-compat fallback path in
+      ``cache_flush_validation`` — the check falls back to
       ``read.summary.start_time`` and downgrades a 30-second breach from
       hard failure to warning.
+    * ``chkpt_omit_invocation_end_time`` (bool, default False) — CHKPT-02
+      (storage#782): when True, do NOT emit ``invocation_end_time`` in
+      write-side metadata (simulates a results dir produced by an mlpstorage
+      version predating storage#782). Exercises the backward-compat
+      fallback in ``cache_flush_validation`` — the check falls back to
+      ``write.summary.end_time`` and includes any post-benchmark cluster
+      collection in the measured gap.
     * ``chkpt_model`` (str, default "llama3-8b") — CHKPT-01: model directory name
       under ``checkpointing/``.
     * ``chkpt_open_num_processes`` (int | None) — CHKPT-01: when non-None, sets
@@ -433,7 +451,9 @@ def build_submission(tmp_path, **overrides) -> Path:
     chkpt_summary_timestamps = overrides.pop("chkpt_summary_timestamps", False)
     chkpt_split_mode = overrides.pop("chkpt_split_mode", False)
     chkpt_cache_flush_gap_seconds = overrides.pop("chkpt_cache_flush_gap_seconds", 25)
+    chkpt_write_teardown_seconds = overrides.pop("chkpt_write_teardown_seconds", 0)
     chkpt_omit_invocation_start_time = overrides.pop("chkpt_omit_invocation_start_time", False)
+    chkpt_omit_invocation_end_time = overrides.pop("chkpt_omit_invocation_end_time", False)
     chkpt_model = overrides.pop("chkpt_model", "llama3-8b")
     chkpt_open_num_processes = overrides.pop("chkpt_open_num_processes", None)
     chkpt_closed_num_processes = overrides.pop("chkpt_closed_num_processes", None)
@@ -735,12 +755,21 @@ def build_submission(tmp_path, **overrides) -> Path:
                 chkpt_summary = dict(_DEFAULT_SUMMARY)
                 if chkpt_summary_timestamps:
                     if chkpt_split_mode:
+                        # storage#782: read invocation cannot start until the
+                        # write nodes are released — i.e. `gap_seconds` after
+                        # write's ``invocation_end_time``, which is itself
+                        # ``teardown_seconds`` after ``summary.end_time``.
+                        # When teardown=0 (default) this collapses to the
+                        # legacy formula.
+                        _post_write_delta = datetime.timedelta(
+                            seconds=chkpt_write_teardown_seconds
+                            + chkpt_cache_flush_gap_seconds
+                        )
                         if ts in write_timestamps:
                             wi = write_timestamps.index(ts)
                             write_start = _BASE_DT + datetime.timedelta(minutes=10 * wi)
                             write_end = write_start + datetime.timedelta(minutes=5)
-                            # The corresponding read run starts gap_seconds after write_end
-                            read_start = write_end + datetime.timedelta(seconds=chkpt_cache_flush_gap_seconds)
+                            read_start = write_end + _post_write_delta
                             read_end = read_start + datetime.timedelta(minutes=5)
                             chkpt_summary["start"] = write_start.isoformat()
                             chkpt_summary["end"] = write_end.isoformat()
@@ -752,7 +781,7 @@ def build_submission(tmp_path, **overrides) -> Path:
                             # Corresponding write run index is ri
                             write_start = _BASE_DT + datetime.timedelta(minutes=10 * ri)
                             write_end = write_start + datetime.timedelta(minutes=5)
-                            read_start = write_end + datetime.timedelta(seconds=chkpt_cache_flush_gap_seconds)
+                            read_start = write_end + _post_write_delta
                             read_end = read_start + datetime.timedelta(minutes=5)
                             chkpt_summary["start"] = read_start.isoformat()
                             chkpt_summary["end"] = read_end.isoformat()
@@ -800,30 +829,38 @@ def build_submission(tmp_path, **overrides) -> Path:
                         chkpt_meta["args"]["num_checkpoints_read"] = 10
 
                 # §4.7.1: metadata.invocation_start_time is the read-side origin
-                # of the failover-callout gap check (see checkpointing_checks.py
-                # cache_flush_validation). Emit unconditionally to mirror real
-                # mlpstorage runs, except when the test explicitly opts out to
-                # exercise the missing-field branch.
-                if chkpt_summary_timestamps and not (
-                    chkpt_omit_invocation_start_time
-                    and chkpt_split_mode
-                    and ts in read_timestamps
-                ):
+                # and metadata.invocation_end_time is the write-side origin of
+                # the failover-callout gap check (see checkpointing_checks.py
+                # cache_flush_validation). Emit both unconditionally to mirror
+                # real mlpstorage runs, except when the test explicitly opts
+                # out to exercise the missing-field fallback branches.
+                if chkpt_summary_timestamps:
                     if chkpt_split_mode:
                         if ts in write_timestamps:
-                            # Write invocation entered mlpstorage right before write_start.
                             wi = write_timestamps.index(ts)
                             _write_start = _BASE_DT + datetime.timedelta(minutes=10 * wi)
                             chkpt_meta["invocation_start_time"] = _write_start.isoformat()
-                        else:
-                            # Read invocation entered mlpstorage `gap_seconds` after
-                            # the write's summary.end_time — this is what §4.7.1
-                            # measures. Negative gap models NTP clock skew.
+                            # storage#782: write-side bookend — captured
+                            # after post-benchmark cluster collection, so it
+                            # lands ``teardown_seconds`` after summary.end_time.
+                            if not chkpt_omit_invocation_end_time:
+                                _write_end = _write_start + datetime.timedelta(minutes=5)
+                                _inv_end = _write_end + datetime.timedelta(
+                                    seconds=chkpt_write_teardown_seconds
+                                )
+                                chkpt_meta["invocation_end_time"] = _inv_end.isoformat()
+                        elif not chkpt_omit_invocation_start_time:
+                            # Read invocation entered mlpstorage `gap_seconds`
+                            # after write's ``invocation_end_time`` (the
+                            # moment nodes are released), i.e. `teardown +
+                            # gap` after ``summary.end_time``. Negative gap
+                            # models NTP clock skew between hosts.
                             ri = read_timestamps.index(ts)
                             _write_start = _BASE_DT + datetime.timedelta(minutes=10 * ri)
                             _write_end = _write_start + datetime.timedelta(minutes=5)
                             _inv = _write_end + datetime.timedelta(
-                                seconds=chkpt_cache_flush_gap_seconds
+                                seconds=chkpt_write_teardown_seconds
+                                + chkpt_cache_flush_gap_seconds
                             )
                             chkpt_meta["invocation_start_time"] = _inv.isoformat()
                     else:

--- a/mlpstorage_py/tests/test_checkpointing_check_phase2.py
+++ b/mlpstorage_py/tests/test_checkpointing_check_phase2.py
@@ -197,7 +197,7 @@ class TestChkpt02_CacheFlushValidation:
         assert len(mock_logger.errors) >= 1
         assert mock_logger.errors[0].startswith("[4.7.1 checkpointCacheFlushValidation]"), \
             f"Expected [4.7.1 checkpointCacheFlushValidation]; got {mock_logger.errors[0]!r}"
-        assert "missing end_time in write-phase summary.json" in mock_logger.errors[0]
+        assert "end_time in write-phase summary.json" in mock_logger.errors[0]
 
     def test_split_mode_missing_invocation_start_time_falls_back_to_legacy_origin_and_passes(self, tmp_path, mock_logger):
         """Backward-compat: pre-fix results dir (no invocation_start_time) falls back
@@ -258,6 +258,92 @@ class TestChkpt02_CacheFlushValidation:
             "gap is negative" in w and "clock skew" in w
             for w in mock_logger.warnings
         ), f"Expected clock-skew warning; got warnings={mock_logger.warnings!r}"
+
+    def test_split_mode_write_teardown_excluded_from_gap(self, tmp_path, mock_logger):
+        """storage#782: 45s write-side teardown + 25s real gap → check reports 25s and passes.
+
+        Models the issue's exact scenario — the write phase's final multi-node
+        cluster collection keeps nodes busy for tens of seconds after
+        summary.end_time. Because invocation_end_time is written into the
+        write metadata post-collection, the check origin advances to that
+        point and only the true handoff is charged to the budget.
+        """
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(
+            tmp_path,
+            chkpt_split_mode=True,
+            chkpt_summary_timestamps=True,
+            chkpt_write_teardown_seconds=45,   # 45s of post-benchmark cluster collection
+            chkpt_cache_flush_gap_seconds=25,  # 25s real inter-invocation handoff
+        )
+        check = _run_checkpointing_check(root, mock_logger)
+        result = check.cache_flush_validation()
+        assert result is True, (
+            "Expected pass: honest gap is 25s (teardown excluded); "
+            f"got errors={mock_logger.errors!r}"
+        )
+        assert mock_logger.errors == []
+        # INFO line must record the invocation_end origin, not the legacy
+        # summary end, so the measurement is transparent.
+        assert any(
+            "[4.7.1 checkpointCacheFlushValidation]" in m
+            and "write invocation_end=" in m
+            and "gap 25.0s" in m
+            for m in mock_logger.infos
+        ), f"Expected INFO with invocation_end origin; got infos={mock_logger.infos!r}"
+
+    def test_split_mode_missing_invocation_end_time_falls_back_to_summary_end(self, tmp_path, mock_logger):
+        """Backward-compat (storage#782): pre-fix write metadata (no invocation_end_time)
+        falls back to summary.end_time and the whole teardown window is charged
+        to the failover-callout budget — reproducing the original #782 bug on
+        older results dirs.
+
+        45s teardown + 25s real gap ⇒ legacy gap = 70s ⇒ FAIL (matches
+        pre-fix behavior). The INFO line must record the "write summary end"
+        origin so the submitter can see why the gap looks so large.
+        """
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(
+            tmp_path,
+            chkpt_split_mode=True,
+            chkpt_summary_timestamps=True,
+            chkpt_write_teardown_seconds=45,
+            chkpt_cache_flush_gap_seconds=25,
+            chkpt_omit_invocation_end_time=True,   # simulate pre-fix results dir
+        )
+        check = _run_checkpointing_check(root, mock_logger)
+        result = check.cache_flush_validation()
+        assert result is False
+        assert any(
+            e.startswith("[4.7.1 checkpointCacheFlushValidation]")
+            and "exceeds 30-second limit" in e
+            for e in mock_logger.errors
+        ), f"Expected 30-second-limit violation; got errors={mock_logger.errors!r}"
+        # INFO line must record the fallback origin.
+        assert any(
+            "[4.7.1 checkpointCacheFlushValidation]" in m
+            and "write summary end=" in m
+            for m in mock_logger.infos
+        ), f"Expected INFO with summary-end origin; got infos={mock_logger.infos!r}"
+
+    def test_split_mode_info_line_emitted_on_pass(self, tmp_path, mock_logger):
+        """Every write/read pair emits an INFO line, even on the pass path
+        (storage#782 transparency requirement)."""
+        from mlpstorage_py.tests.conftest import build_submission
+        root = build_submission(
+            tmp_path,
+            chkpt_split_mode=True,
+            chkpt_summary_timestamps=True,
+            chkpt_cache_flush_gap_seconds=25,
+        )
+        check = _run_checkpointing_check(root, mock_logger)
+        result = check.cache_flush_validation()
+        assert result is True
+        assert any(
+            "[4.7.1 checkpointCacheFlushValidation]" in m
+            and "gap 25.0s" in m
+            for m in mock_logger.infos
+        ), f"Expected pass-path INFO; got infos={mock_logger.infos!r}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #782. The split-mode failover-callout gap check charged the write phase's post-benchmark work — final multi-node cluster collection, metadata serialization, interpreter shutdown — against the 30-second budget by measuring from `write.summary.end_time` (end of the timed section). On large topologies that teardown can take tens of seconds, causing false failures on legitimate submissions whose real inter-invocation handoff is within budget.

Adds a symmetric write-side bookend to mirror the read-side fix from #714:

- **`_invocation.py`** — new `INVOCATION_END` + `mark_invocation_end()`, symmetric with the existing `INVOCATION_START`.
- **`benchmarks/base.py`** — calls `mark_invocation_end()` at the top of `write_metadata()`, the latest moment where the value can still land in the persisted file. Emits it as `metadata['invocation_end_time']`.
- **Submission checker `cache_flush_validation`** — prefers `write.metadata.invocation_end_time` as the write-side origin, falling back to `write.summary.end_time` for older results dirs (pre-fix behavior). Emits an INFO line per pair with the chosen origin so the measurement is transparent regardless of pass / warn / fail.

Now the two bookends are genuinely symmetric: whatever falls outside `INVOCATION_START` / `INVOCATION_END` is excluded from the gap on both sides — framework startup on the read side, and post-benchmark cluster collection, rank-0 teardown, JSON serialization, and interpreter shutdown on the write side.

## Worked example (from #782)

| Quantity | Value |
| --- | --- |
| `write.summary.end_time` (timed section ends) | `2026-07-13T06:36:25` |
| `write.metadata.invocation_end_time` (nodes released, rank 0 exiting) | `2026-07-13T06:37:03` |
| `read.metadata.invocation_start_time` | `2026-07-13T06:37:29` |
| gap charged **before** fix (`read_start − summary_end`) | **64.4s → FAIL** |
| gap charged **after** fix (`read_start − invocation_end`) | **~27s → PASS** |

## Test plan

- [x] `mlpstorage_py/tests` — 850 passed (includes 3 new §4.7.1 tests)
- [x] `tests/` — 2907 passed, 1 skipped, 13 deselected
- [x] `vdb_benchmark/tests` — 174 passed
- [x] `kv_cache_benchmark/tests` — 238 passed
- [ ] Reviewer sanity-check on a real split-mode submission whose failure motivated the issue

## New tests

- `test_split_mode_write_teardown_excluded_from_gap` — issue #782 scenario: 45s teardown + 25s real gap ⇒ PASS.
- `test_split_mode_missing_invocation_end_time_falls_back_to_summary_end` — pre-#782 results dirs still measure against `summary.end_time` (unchanged behavior).
- `test_split_mode_info_line_emitted_on_pass` — INFO transparency line is emitted on every pair.