### PR TITLE
fix(storage#779): emit 3.4.2 / 4.4.2 / 5.4.2 same-filesystem finding at WARN

### DIFF
--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -1019,11 +1019,10 @@ class CheckpointingCheck(BaseCheck):
             sidecar = read_fs_separation_sidecar(run_dir)
             if sidecar is not None:
                 if sidecar.get("same_filesystem"):
-                    self.log_violation(
+                    self.warn_violation(
                         "4.4.2", "checkpointFilesystemCheck", logfile_path,
                         "checkpoint_folder and results_dir are on the same filesystem",
                     )
-                    valid = False
                 continue
             args = metadata.get("args", {})
             # For checkpointing, checkpoint_folder is the "data path" analog (RESEARCH.md).
@@ -1044,11 +1043,8 @@ class CheckpointingCheck(BaseCheck):
                 valid = False
                 continue
             if not ok:
-                # df WAS found (e.g. submitter manually injected it), so this
-                # is a real same-mount finding and remains an error.
-                self.log_violation(
+                self.warn_violation(
                     "4.4.2", "checkpointFilesystemCheck", logfile_path,
                     "checkpoint_folder and results_dir are on the same filesystem",
                 )
-                valid = False
         return valid

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -941,11 +941,10 @@ class TrainingCheck(BaseCheck):
             sidecar = read_fs_separation_sidecar(run_dir)
             if sidecar is not None:
                 if sidecar.get("same_filesystem"):
-                    self.log_violation(
+                    self.warn_violation(
                         "3.4.2", "trainingMlpstorageFilesystemCheck", logfile_path,
                         "data_dir and results_dir are on the same filesystem",
                     )
-                    valid = False
                 continue
             args = metadata.get("args", {})
             ok, df_found = _check_filesystem_separation(args, logfile_path)
@@ -961,11 +960,8 @@ class TrainingCheck(BaseCheck):
                 valid = False
                 continue
             if not ok:
-                # df WAS found (e.g. submitter manually injected it), so this
-                # is a real same-mount finding and remains an error.
-                self.log_violation(
+                self.warn_violation(
                     "3.4.2", "trainingMlpstorageFilesystemCheck", logfile_path,
                     "data_dir and results_dir are on the same filesystem",
                 )
-                valid = False
         return valid

--- a/mlpstorage_py/submission_checker/checks/vdb_checks.py
+++ b/mlpstorage_py/submission_checker/checks/vdb_checks.py
@@ -648,12 +648,11 @@ class VdbCheck(BaseCheck):
             sidecar = read_fs_separation_sidecar(run_dir)
             if sidecar is not None:
                 if sidecar.get("same_filesystem"):
-                    self.log_violation(
+                    self.warn_violation(
                         "5.4.2", "vdbFilesystemCheck", logfile_path,
                         "vdbFilesystemCheck: vdb data path and results_dir are on the "
                         "same filesystem",
                     )
-                    valid = False
                 continue
             # _check_filesystem_separation looks up "data_dir" or
             # "checkpoint_folder"; for vdb the analog is storage_root. Synthesize
@@ -672,12 +671,11 @@ class VdbCheck(BaseCheck):
                 valid = False
                 continue
             if not ok:
-                self.log_violation(
+                self.warn_violation(
                     "5.4.2", "vdbFilesystemCheck", logfile_path,
                     "vdbFilesystemCheck: vdb data path and results_dir are on the "
                     "same filesystem",
                 )
-                valid = False
 
         if not any_run:
             self._vdb_loader_gap_warning("5.4.2", "vdbFilesystemCheck")

--- a/mlpstorage_py/tests/test_checkpointing_check_phase2.py
+++ b/mlpstorage_py/tests/test_checkpointing_check_phase2.py
@@ -675,11 +675,12 @@ class TestChkpt06_CheckpointFilesystemCheck:
         )
         check = _run_checkpointing_check(root, mock_logger)
         result = check.checkpoint_filesystem_check()
-        assert result is False
-        assert len(mock_logger.errors) >= 1
-        assert mock_logger.errors[0].startswith("[4.4.2 checkpointFilesystemCheck]"), \
-            f"Expected [4.4.2 checkpointFilesystemCheck]; got {mock_logger.errors[0]!r}"
-        assert "same filesystem" in mock_logger.errors[0]
+        assert result is True
+        assert mock_logger.errors == []
+        assert len(mock_logger.warnings) >= 1
+        assert mock_logger.warnings[0].startswith("[4.4.2 checkpointFilesystemCheck]"), \
+            f"Expected [4.4.2 checkpointFilesystemCheck]; got {mock_logger.warnings[0]!r}"
+        assert "same filesystem" in mock_logger.warnings[0]
 
     def test_df_not_found_emits_4_4_2_missing(self, tmp_path, mock_logger):
         """No sidecar AND no df logfile → hard [4.4.2] violation (D-B8, #601).
@@ -809,10 +810,11 @@ class TestQual02RuleIdPrefix:
         check()   # run all check methods
 
         prefix = f"[{rule_id} {rule_name}]"
-        assert any(m.startswith(prefix) for m in mock_logger.errors), \
+        records = mock_logger.errors + mock_logger.warnings
+        assert any(m.startswith(prefix) for m in records), \
             (
-                f"Expected at least one error starting with {prefix!r}; "
-                f"got errors: {mock_logger.errors}"
+                f"Expected at least one record starting with {prefix!r}; "
+                f"got errors: {mock_logger.errors}; warnings: {mock_logger.warnings}"
             )
 
 

--- a/mlpstorage_py/tests/test_issue601_validator_reads_sidecar.py
+++ b/mlpstorage_py/tests/test_issue601_validator_reads_sidecar.py
@@ -262,8 +262,9 @@ class TestRule3_4_2_TrainingSidecar:
 
         result = check.mlpstorage_filesystem_check()
 
-        assert result is False, "3.4.2 must fire 'same filesystem' from sidecar"
-        violations = [str(c) for c in check.log.error.call_args_list]
+        assert result is True
+        assert check.log.error.call_args_list == []
+        violations = [str(c) for c in check.log.warning.call_args_list]
         assert any("same filesystem" in v for v in violations), violations
 
     def test_no_sidecar_no_df_fires_db8(self, tmp_path):
@@ -315,8 +316,9 @@ class TestRule4_4_2_CheckpointingSidecar:
 
         result = check.checkpoint_filesystem_check()
 
-        assert result is False
-        violations = [str(c) for c in check.log.error.call_args_list]
+        assert result is True
+        assert check.log.error.call_args_list == []
+        violations = [str(c) for c in check.log.warning.call_args_list]
         assert any("same filesystem" in v for v in violations), violations
 
 
@@ -347,6 +349,7 @@ class TestRule5_4_2_VdbSidecar:
 
         result = check.vdb_filesystem_check()
 
-        assert result is False
-        violations = [str(c) for c in check.log.error.call_args_list]
+        assert result is True
+        assert check.log.error.call_args_list == []
+        violations = [str(c) for c in check.log.warning.call_args_list]
         assert any("same filesystem" in v for v in violations), violations

--- a/mlpstorage_py/tests/test_training_check_phase2.py
+++ b/mlpstorage_py/tests/test_training_check_phase2.py
@@ -172,12 +172,13 @@ class TestTrain02_MlpstorageFilesystemCheck:
         )
         check = _run_training_check(root, mock_logger)
         result = check.mlpstorage_filesystem_check()
-        assert result is False
-        assert len(mock_logger.errors) >= 1
-        assert mock_logger.errors[0].startswith("[3.4.2 trainingMlpstorageFilesystemCheck]"), \
-            f"Expected prefix [3.4.2 trainingMlpstorageFilesystemCheck]; got {mock_logger.errors[0]!r}"
-        assert "same filesystem" in mock_logger.errors[0], \
-            f"Expected 'same filesystem' in error; got {mock_logger.errors[0]!r}"
+        assert result is True
+        assert mock_logger.errors == []
+        assert len(mock_logger.warnings) >= 1
+        assert mock_logger.warnings[0].startswith("[3.4.2 trainingMlpstorageFilesystemCheck]"), \
+            f"Expected prefix [3.4.2 trainingMlpstorageFilesystemCheck]; got {mock_logger.warnings[0]!r}"
+        assert "same filesystem" in mock_logger.warnings[0], \
+            f"Expected 'same filesystem' in warning; got {mock_logger.warnings[0]!r}"
 
     def test_df_not_found_emits_3_4_2_missing(self, tmp_path, mock_logger):
         """No sidecar AND no df logfile → hard [3.4.2] violation (D-B8, #601).

--- a/mlpstorage_py/tests/test_vdb_checks.py
+++ b/mlpstorage_py/tests/test_vdb_checks.py
@@ -644,9 +644,10 @@ class Test_5_4_2_VdbFilesystemCheck:
         check = _make_vdb_check(
             leaf, "closed", mock_logger, run_files=run_files,
         )
-        assert check.vdb_filesystem_check() is False
-        viol = _violations(mock_logger, "5.4.2", "vdbFilesystemCheck")
-        assert any("same filesystem" in v for v in viol), viol
+        assert check.vdb_filesystem_check() is True
+        assert _violations(mock_logger, "5.4.2", "vdbFilesystemCheck") == []
+        warn = _warnings(mock_logger, "5.4.2", "vdbFilesystemCheck")
+        assert any("same filesystem" in v for v in warn), warn
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Downgrades the shared-`<data-dir>`/`<results-dir>` finding from ERROR to WARN in `TrainingCheck` (3.4.2), `CheckpointingCheck` (4.4.2), and `VdbCheck` (5.4.2). Message text and `[rule_id rule_name]` prefix are unchanged; only the log level and the pass/fail contribution flip.
- The D-B8 evidence-gap path (no CAP-03 sidecar **and** no df block) still fires as a hard ERROR under the same rule ID — a submission with no fs-separation telemetry at all continues to fail validation.
- Tests updated to assert the same-mount findings now land on the WARN channel and the check returns `valid=True`. The Phase 2 `TestQual02RuleIdPrefix` D-05 invariant assertion is widened from `mock_logger.errors` to `errors + warnings` so the rule-prefix format check still covers 4.4.2 regardless of severity.

## Test plan
- [x] `uv run pytest tests` — 2909 passed, 1 skipped
- [x] `uv run pytest mlpstorage_py/tests` — 853 passed
- [x] `uv run pytest vdb_benchmark/tests` — 174 passed
- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed

Closes #779.