### PR TITLE
Fix(vdb_benchmark#625): planted query mode and tie-aware epsilon recall

### DIFF
--- a/vdb_benchmark/README.md
+++ b/vdb_benchmark/README.md
@@ -51,6 +51,9 @@ The `mlpstorage` path is recommended for standard benchmark workflows.
 - [8. End-to-End Examples](#8-end-to-end-examples)
 - [9. Enhanced Benchmark Full Reference](#9-enhanced-benchmark-full-reference)
 - [10. Metrics and Measurement](#10-metrics-and-measurement)
+  - [Recall Measurement](#recall-measurement)
+  - [Query Modes and Recall Semantics (Issue #625)](#query-modes-and-recall-semantics-issue-625)
+  - [Guidance for Submitters: Comparability and Reruns](#guidance-for-submitters-comparability-and-reruns)
 - [11. Testing and Validation](#11-testing-and-validation)
 - [12. Troubleshooting](#12-troubleshooting)
 - [13. Contributing](#13-contributing)
@@ -661,6 +664,29 @@ uv run enhanced-bench \
 ```
 
 See [Section 9](#9-enhanced-benchmark-full-reference) for full parameter reference and execution paths.
+
+#### Optional: planted queries and tie-aware recall
+
+Both `simple_bench.py` and `enhanced_bench.py` accept three optional flags
+that improve recall measurement on synthetic datasets (see
+[Query Modes and Recall Semantics](#query-modes-and-recall-semantics-issue-625)):
+
+```bash
+uv run vdbbench \
+  --host 127.0.0.1 \
+  --port 19530 \
+  --collection-name mlps_1m_1536dim_uniform_diskann \
+  --processes 4 \
+  --batch-size 10 \
+  --runtime 120 \
+  --query-mode planted \
+  --query-noise 0.05 \
+  --recall-epsilon 1e-4 \
+  --output-dir /tmp/vdbbench_results
+```
+
+Defaults (`--query-mode independent`, `--recall-epsilon 0`) reproduce the
+historical behavior exactly.
 
 ---
 
@@ -1608,6 +1634,9 @@ python vdbbench/enhanced_bench.py \
 | `--search-ef` | `200` | Search parameter override |
 | `--num-query-vectors` | `1000` | Pre-generated query vectors for recall |
 | `--recall-k` | `--search-limit` | k for recall@k |
+| `--query-mode` | `independent` | `independent` or `planted` — see [Query Modes](#query-modes-and-recall-semantics-issue-625) |
+| `--query-noise` | `0.05` | L2 displacement of planted queries from their base vectors |
+| `--recall-epsilon` | `0.0` | Tie tolerance for recall@k; `0` = exact set-intersection recall |
 | `--gt-collection` | `_flat_gt` | FLAT GT collection name |
 | `--auto-create-flat` | `False` | Auto-create FLAT GT collection from source |
 | `--no-create-flat` | `False` | Validate and reuse existing FLAT GT collection |
@@ -1660,6 +1689,9 @@ statistics.json
 Recall fields include:
 
 ```text
+recall_at_k              # normative recall (equals recall_at_k_exact when epsilon = 0)
+recall_at_k_exact        # strict set-intersection recall, always reported
+recall_epsilon           # tie tolerance used for recall_at_k (0 = exact)
 mean_recall
 median_recall
 min_recall
@@ -1673,6 +1705,73 @@ recall_by_query
 ```
 
 The `per_query_recall` and `recall_by_query` fields are used for exact multi-rank aggregation.
+`query_mode`, `query_noise`, and `recall_epsilon` are also recorded in each run's
+`config.json` / `benchmark_meta.json`, so every result is self-describing about
+which recall definition produced it.
+
+### Query Modes and Recall Semantics (Issue #625)
+
+The benchmark generates synthetic vectors. With the historical defaults —
+i.i.d. random database vectors *and* i.i.d. random, independent query
+vectors — recall@k is computed correctly (ground truth is exact brute
+force) but carries almost no signal at high dimension: at 1536-d the
+query-to-corpus cosine similarity concentrates so tightly (relative
+contrast ≈ 1.1) that the true top-k boundary sits within float32 noise,
+recall barely responds to search effort, and results do not transfer to
+real embedding workloads
+([issue #625](https://github.com/mlcommons/storage/issues/625)).
+
+Two opt-in mechanisms address this. Both default **off**, and the defaults
+are identical to the previous behavior.
+
+**Planted queries (`--query-mode planted` / `query_mode: planted`).**
+Each query is a small deterministic perturbation (`--query-noise`, default
+0.05 L2 displacement) of a stored database vector, so every query has a
+genuine planted near neighbor. Stored vectors, ingest, index build, and
+the load-phase I/O profile are unchanged — only the query set differs.
+Measured effect at 1536-d: nearest-neighbor relative contrast rises from
+~1.1 to >100, giving a recall/QPS operating curve that actually responds
+to search parameters. Requires the standard vdbbench data layout (dense
+INT64 primary keys 0..N-1); the benchmark fails loudly, never silently
+falls back, if the collection does not conform.
+
+**Tie-aware epsilon recall (`--recall-epsilon` / `recall_epsilon`).**
+Following the big-ann-benchmarks convention, a returned neighbor whose
+ground-truth score is within epsilon of the k-th neighbor's is credited
+rather than scored as a miss, so float32-level ties do not add noise to
+the metric. `recall_at_k_exact` is always reported alongside, and
+`recall_epsilon` is recorded with every result.
+
+**Note on `search_list_size` / `--search-ef`:** raising the search effort
+is *not* an equivalent workaround. On structureless random data with
+independent queries, even large search-list values move recall only
+marginally while inflating read I/O — and at the extreme the graph search
+degenerates toward an exhaustive scan, distorting the very storage
+access pattern this benchmark exists to measure. Search-effort parameters
+tune a run *within* a recall definition; `query_mode` and
+`recall_epsilon` change the definition itself, and are labeled
+accordingly.
+
+### Guidance for Submitters: Comparability and Reruns
+
+Classification: these features are an **opt-in methodology enhancement**.
+They are **not** a bug fix — the previous pipeline computed recall
+correctly against exact ground truth, and no previously published result
+is wrong or invalidated. When the new modes are *enabled*, they are a
+**metric definition change**, and results are treated the way
+MLPerf treats any definition change between rounds:
+
+* **Existing and in-flight submissions:** no rerun and no restatement
+  required. The defaults are identical to prior behavior (verified by
+  regression test down to the query RNG stream), so this change can merge
+  without affecting anyone.
+* **Current round:** `planted` / epsilon runs are available as a
+  diagnostic mode. Official results remain on the existing definition
+  until the Working Group rules say otherwise.
+* **Comparing runs:** only compare recall numbers produced with the same
+  `query_mode` and `recall_epsilon`. Check `config.json` /
+  `benchmark_meta.json` when in doubt; when epsilon recall is enabled,
+  `recall_at_k_exact` provides the strict metric for cross-checking.
 
 ### Disk I/O Metrics
 
@@ -2073,6 +2172,15 @@ Also check that rank-local `recall_stats.json` files contain non-empty:
 per_query_recall
 recall_by_query
 ```
+
+### Recall is low and does not improve with `search_list` / `ef`
+
+This is expected with the default `--query-mode independent` on
+high-dimensional random data — the recall metric is correct but poorly
+conditioned, not broken. See
+[Query Modes and Recall Semantics](#query-modes-and-recall-semantics-issue-625)
+and re-run with `--query-mode planted` (optionally `--recall-epsilon 1e-4`)
+to obtain a discriminative recall/QPS curve.
 
 ### Milvus is not reachable from worker hosts
 

--- a/vdb_benchmark/tests/tests/test_issue_625_planted_queries.py
+++ b/vdb_benchmark/tests/tests/test_issue_625_planted_queries.py
@@ -1,0 +1,526 @@
+"""
+Regression tests for issue #625:
+
+    Recall computed over i.i.d. uniformly random vectors is not meaningful:
+    at 1536-d the query-to-corpus cosine similarity concentrates around a
+    mean of ~0.75 with std ~0.008 (relative contrast ~1.1), and the gap
+    between the k-th and (k+1)-th neighbor is routinely below float32
+    matmul noise. Recall@k is then non-discriminative between backends /
+    index configurations, and exact set-intersection recall scores
+    numerically-tied neighbors as misses.
+
+Fixes under test:
+
+  1. ``query_mode='planted'`` (``vdbbench/benchmark/generator.py``):
+     queries are perturbations of database vectors, so every query has a
+     genuine planted near neighbor. In the orchestrator path the base
+     vectors are reproduced bit-exactly from the dataset seed; in the
+     simple_bench path they are fetched from the live collection.
+  2. Tie-aware epsilon recall (``search_runner._recall_at_k``,
+     ``simple_bench.calc_recall``, ``enhanced_bench.calc_recall``):
+     a returned neighbor within epsilon of the k-th ground-truth score is
+     credited rather than scored as a miss. Exact recall is always also
+     reported; ``epsilon=0`` preserves historical behavior bit-for-bit.
+
+These tests verify the fixes WITHOUT requiring a live Milvus or the
+pymilvus package: a minimal fake ``pymilvus`` is injected into
+``sys.modules`` before the modules under test are imported (same pattern
+as the issue #489 / #572 tests).
+"""
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make the package importable regardless of where pytest is invoked from.
+# ---------------------------------------------------------------------------
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+# ---------------------------------------------------------------------------
+# simple_bench.py imports pymilvus at module load and calls sys.exit(1) on
+# ImportError. CI does not have pymilvus installed, so we inject a fake
+# module exposing exactly the names simple_bench imports (see #489 tests).
+# ---------------------------------------------------------------------------
+def _install_fake_pymilvus():
+    if "pymilvus" in sys.modules:
+        return
+
+    fake = types.ModuleType("pymilvus")
+
+    class _DataTypeMember:
+        def __init__(self, name):
+            self.name = name
+
+    class DataType:
+        INT64 = _DataTypeMember("INT64")
+        INT32 = _DataTypeMember("INT32")
+        INT16 = _DataTypeMember("INT16")
+        INT8 = _DataTypeMember("INT8")
+        VARCHAR = _DataTypeMember("VARCHAR")
+        FLOAT_VECTOR = _DataTypeMember("FLOAT_VECTOR")
+        BINARY_VECTOR = _DataTypeMember("BINARY_VECTOR")
+        FLOAT16_VECTOR = _DataTypeMember("FLOAT16_VECTOR")
+        BFLOAT16_VECTOR = _DataTypeMember("BFLOAT16_VECTOR")
+
+    fake.DataType = DataType
+    fake.Collection = MagicMock(name="Collection")
+    fake.CollectionSchema = MagicMock(name="CollectionSchema")
+    fake.FieldSchema = MagicMock(name="FieldSchema")
+    fake.connections = MagicMock(name="connections")
+    fake.utility = MagicMock(name="utility")
+
+    sys.modules["pymilvus"] = fake
+
+
+_install_fake_pymilvus()
+
+from vdbbench.benchmark.generator import (  # noqa: E402
+    DEFAULT_QUERY_NOISE,
+    QUERY_MODES,
+    VectorGenerator,
+    _generate_block,
+    generate_query_vectors,
+    plant_queries,
+)
+from vdbbench.benchmark.ground_truth import GroundTruthBuilder  # noqa: E402
+from vdbbench.benchmark.orchestrator import BenchmarkConfig  # noqa: E402
+from vdbbench.benchmark.search_runner import _recall_at_k  # noqa: E402
+from vdbbench import simple_bench  # noqa: E402
+from vdbbench.simple_bench import calc_recall  # noqa: E402
+
+
+DIM = 64
+SEED_DATA = 42
+SEED_QUERY = 99
+
+
+def _normalize(v: np.ndarray) -> np.ndarray:
+    return v / np.linalg.norm(v, axis=1, keepdims=True)
+
+
+# ===========================================================================
+# 1. Planted query generation (generator.py)
+# ===========================================================================
+
+
+class TestPlantedQueryGeneration:
+    """query_mode='planted' plants a genuine near neighbor per query."""
+
+    def test_independent_mode_is_bit_exact_with_historical_behavior(self):
+        """Default mode must reproduce the pre-#625 query stream exactly,
+        so existing artifacts / GT caches remain comparable."""
+        legacy_rng = np.random.RandomState(SEED_QUERY)
+        legacy = legacy_rng.random((50, DIM)).astype(np.float32)
+        norms = np.linalg.norm(legacy, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        legacy = legacy / norms
+
+        current = generate_query_vectors(50, DIM, seed=SEED_QUERY)
+        np.testing.assert_array_equal(current, legacy)
+
+    def test_planted_bases_match_stored_block0_vectors_bit_exactly(self):
+        """Planted queries must be derived from the *stored* vectors: a
+        fresh RandomState(dataset_seed) draw equals the first rows of the
+        producer's block 0, with noise=0 recovering them exactly."""
+        gen = VectorGenerator(
+            total_vectors=200, dimension=DIM, block_size=100, seed=SEED_DATA,
+        )
+        gen.start()
+        block0 = gen.queue.get()
+        # Drain the producer so the thread exits cleanly.
+        while gen.queue.get() is not None:
+            pass
+        gen.join()
+
+        nq = 30
+        planted_zero_noise = generate_query_vectors(
+            nq, DIM, seed=SEED_QUERY,
+            query_mode="planted", dataset_seed=SEED_DATA, query_noise=0.0,
+        )
+        np.testing.assert_array_almost_equal(
+            planted_zero_noise, block0.vectors[:nq], decimal=6,
+        )
+
+    def test_planted_queries_are_near_their_base_and_normalized(self):
+        nq = 30
+        base_rng = np.random.RandomState(SEED_DATA)
+        base = _generate_block(nq, DIM, "uniform", base_rng)
+
+        planted = generate_query_vectors(
+            nq, DIM, seed=SEED_QUERY,
+            query_mode="planted", dataset_seed=SEED_DATA,
+            query_noise=DEFAULT_QUERY_NOISE,
+        )
+
+        # Unit-norm output
+        np.testing.assert_allclose(
+            np.linalg.norm(planted, axis=1), 1.0, atol=1e-5,
+        )
+        # Each query is close to its base (cosine >> random baseline) but
+        # not identical to it.
+        cos_to_base = np.sum(planted * base, axis=1)
+        assert np.all(cos_to_base > 0.99)
+        assert not np.allclose(planted, base)
+
+    def test_planted_queries_are_deterministic(self):
+        a = generate_query_vectors(
+            20, DIM, seed=SEED_QUERY, query_mode="planted",
+            dataset_seed=SEED_DATA,
+        )
+        b = generate_query_vectors(
+            20, DIM, seed=SEED_QUERY, query_mode="planted",
+            dataset_seed=SEED_DATA,
+        )
+        np.testing.assert_array_equal(a, b)
+
+    def test_invalid_query_mode_raises(self):
+        with pytest.raises(ValueError, match="query_mode"):
+            generate_query_vectors(10, DIM, query_mode="clustered")
+        assert "planted" in QUERY_MODES and "independent" in QUERY_MODES
+
+    def test_planted_queries_restore_relative_contrast(self):
+        """The core #625 fix: nearest-neighbor contrast must be
+        overwhelming for planted queries and negligible for independent
+        ones, on the same uniform corpus."""
+        n_db, nq = 2000, 20
+        db = _generate_block(n_db, DIM, "uniform", np.random.RandomState(SEED_DATA))
+
+        independent = generate_query_vectors(nq, DIM, seed=SEED_QUERY)
+        planted = generate_query_vectors(
+            nq, DIM, seed=SEED_QUERY,
+            query_mode="planted", dataset_seed=SEED_DATA,
+        )
+
+        def relative_contrast(queries):
+            sims = queries @ db.T
+            nn = sims.max(axis=1)
+            mean = sims.mean(axis=1)
+            # cosine distance contrast: d_mean / d_nn
+            return float(np.mean((1 - mean) / (1 - nn)))
+
+        rc_independent = relative_contrast(independent)
+        rc_planted = relative_contrast(planted)
+
+        assert rc_planted > 5 * rc_independent
+        assert rc_planted > 10.0
+
+    def test_planted_ground_truth_rank1_is_the_base_vector(self):
+        """With small noise, GT rank-1 for query q must be db id q (the
+        perturbed base), proving the neighbor really was planted."""
+        n_db, nq = 1000, 25
+        gen = VectorGenerator(
+            total_vectors=n_db, dimension=DIM, block_size=n_db, seed=SEED_DATA,
+        )
+        gen.start()
+        block = gen.queue.get()
+        while gen.queue.get() is not None:
+            pass
+        gen.join()
+
+        planted = generate_query_vectors(
+            nq, DIM, seed=SEED_QUERY,
+            query_mode="planted", dataset_seed=SEED_DATA, query_noise=0.02,
+        )
+        builder = GroundTruthBuilder(planted, k=10)
+        builder.update(block)
+        ids, sims = builder.build_with_similarities()
+
+        np.testing.assert_array_equal(ids[:, 0], np.arange(nq))
+        # Similarities are sorted closest-first
+        assert np.all(np.diff(sims, axis=1) <= 1e-6)
+
+
+# ===========================================================================
+# 2. Orchestrator config validation
+# ===========================================================================
+
+
+class TestOrchestratorConfigValidation:
+    def test_config_accepts_new_fields_from_yaml_sections(self):
+        cfg = BenchmarkConfig.from_dict(
+            {
+                "dataset": {
+                    "num_vectors": 1000,
+                    "dimension": DIM,
+                    "query_mode": "planted",
+                    "query_noise": 0.1,
+                    "recall_epsilon": 1e-4,
+                },
+            }
+        )
+        assert cfg.query_mode == "planted"
+        assert cfg.query_noise == pytest.approx(0.1)
+        assert cfg.recall_epsilon == pytest.approx(1e-4)
+
+    def test_defaults_preserve_historical_behavior(self):
+        cfg = BenchmarkConfig()
+        assert cfg.query_mode == "independent"
+        assert cfg.recall_epsilon == 0.0
+
+    def test_planted_mode_rejects_queries_exceeding_block_size(self):
+        from vdbbench.benchmark.orchestrator import BenchmarkOrchestrator
+
+        cfg = BenchmarkConfig(
+            query_mode="planted",
+            num_query_vectors=200_000,
+            block_size=100_000,
+        )
+        orch = BenchmarkOrchestrator(cfg, backend=MagicMock())
+        with pytest.raises(ValueError, match="block_size"):
+            orch.run()
+
+    def test_invalid_query_mode_rejected_by_orchestrator(self):
+        from vdbbench.benchmark.orchestrator import BenchmarkOrchestrator
+
+        cfg = BenchmarkConfig(query_mode="bogus")
+        orch = BenchmarkOrchestrator(cfg, backend=MagicMock())
+        with pytest.raises(ValueError, match="query_mode"):
+            orch.run()
+
+
+# ===========================================================================
+# 3. Epsilon recall -- search_runner._recall_at_k
+# ===========================================================================
+
+
+class TestEpsilonRecallSearchRunner:
+    def _make_case(self):
+        """One query, k=3. GT window of 5. ANN returns id 40 (rank 4,
+        tied with rank 3 within 1e-5) instead of id 30."""
+        truth_ids = np.array([[10, 20, 30, 40, 50]], dtype=np.int64)
+        truth_sims = np.array(
+            [[0.900, 0.850, 0.800, 0.800 - 5e-6, 0.500]], dtype=np.float32,
+        )
+        predicted = np.array([[10, 20, 40]], dtype=np.int64)
+        return predicted, truth_ids, truth_sims
+
+    def test_epsilon_zero_matches_historical_exact_recall(self):
+        predicted, truth_ids, truth_sims = self._make_case()
+        exact = _recall_at_k(predicted, truth_ids, k=3)
+        with_sims = _recall_at_k(
+            predicted, truth_ids, k=3,
+            truth_similarities=truth_sims, epsilon=0.0,
+        )
+        assert exact == pytest.approx(2 / 3)
+        assert with_sims == pytest.approx(exact)
+
+    def test_epsilon_credits_float32_level_ties(self):
+        predicted, truth_ids, truth_sims = self._make_case()
+        recall = _recall_at_k(
+            predicted, truth_ids, k=3,
+            truth_similarities=truth_sims, epsilon=1e-4,
+        )
+        assert recall == pytest.approx(1.0)
+
+    def test_epsilon_does_not_credit_genuine_misses(self):
+        truth_ids = np.array([[10, 20, 30, 40, 50]], dtype=np.int64)
+        truth_sims = np.array(
+            [[0.900, 0.850, 0.800, 0.600, 0.500]], dtype=np.float32,
+        )
+        predicted = np.array([[10, 20, 40]], dtype=np.int64)  # 40 is far
+        recall = _recall_at_k(
+            predicted, truth_ids, k=3,
+            truth_similarities=truth_sims, epsilon=1e-4,
+        )
+        assert recall == pytest.approx(2 / 3)
+
+    def test_epsilon_recall_capped_at_one(self):
+        """When several ties are all returned, credited hits are capped at
+        k so recall never exceeds 1.0."""
+        truth_ids = np.array([[10, 20, 30, 40]], dtype=np.int64)
+        truth_sims = np.array(
+            [[0.800, 0.800, 0.800, 0.800]], dtype=np.float32,
+        )
+        predicted = np.array([[10, 20, 30, 40]], dtype=np.int64)
+        recall = _recall_at_k(
+            predicted, truth_ids, k=3,
+            truth_similarities=truth_sims, epsilon=1e-4,
+        )
+        assert recall == pytest.approx(1.0)
+
+    def test_missing_similarities_falls_back_to_exact(self):
+        predicted, truth_ids, _ = self._make_case()
+        recall = _recall_at_k(
+            predicted, truth_ids, k=3,
+            truth_similarities=None, epsilon=1e-4,
+        )
+        assert recall == pytest.approx(2 / 3)
+
+
+# ===========================================================================
+# 4. Epsilon recall -- simple_bench.calc_recall (dict-based)
+# ===========================================================================
+
+
+class TestEpsilonRecallSimpleBench:
+    def test_defaults_bitwise_compatible_with_pre_625_schema(self):
+        """No epsilon / no scores: values and legacy keys unchanged; new
+        keys report exact recall and epsilon=0 (verdict logic from #489 /
+        #572 keys on num_queries_evaluated, which must be intact)."""
+        ann = {0: [1, 2, 3], 1: [4, 5, 6]}
+        gt = {0: [1, 2, 9], 1: [4, 5, 6]}
+        stats = calc_recall(ann, gt, k=3)
+        assert stats["recall_at_k"] == pytest.approx((2 / 3 + 1.0) / 2)
+        assert stats["recall_at_k_exact"] == stats["recall_at_k"]
+        assert stats["recall_epsilon"] == 0.0
+        assert stats["num_queries_evaluated"] == 2
+        assert "per_query_recall" in stats and "recall_by_query" in stats
+
+    def test_epsilon_credits_ties_cosine_higher_is_better(self):
+        ann = {0: [1, 2, 44]}
+        gt = {0: [1, 2, 3, 44, 5]}
+        scores = {0: [0.9, 0.85, 0.8, 0.8 - 5e-6, 0.5]}
+        stats = calc_recall(
+            ann, gt, k=3,
+            ground_truth_scores=scores, epsilon=1e-4, higher_is_better=True,
+        )
+        assert stats["recall_at_k"] == pytest.approx(1.0)
+        assert stats["recall_at_k_exact"] == pytest.approx(2 / 3)
+        assert stats["recall_epsilon"] == pytest.approx(1e-4)
+
+    def test_epsilon_credits_ties_l2_lower_is_better(self):
+        ann = {0: [1, 2, 44]}
+        gt = {0: [1, 2, 3, 44, 5]}
+        # L2: distance, lower = closer; rank-4 tied with rank-3
+        scores = {0: [0.10, 0.15, 0.20, 0.20 + 5e-6, 0.90]}
+        stats = calc_recall(
+            ann, gt, k=3,
+            ground_truth_scores=scores, epsilon=1e-4, higher_is_better=False,
+        )
+        assert stats["recall_at_k"] == pytest.approx(1.0)
+        assert stats["recall_at_k_exact"] == pytest.approx(2 / 3)
+
+    def test_empty_gt_still_reports_zero_evaluated(self):
+        """#489 guard interplay: empty GT must keep reporting
+        num_queries_evaluated == 0 so the verdict aborts the run."""
+        stats = calc_recall({0: [1, 2, 3]}, {0: []}, k=3, epsilon=1e-4)
+        assert stats["num_queries_evaluated"] == 0
+        assert stats["recall_at_k"] == 0.0
+        assert stats["recall_at_k_exact"] == 0.0
+
+    def test_enhanced_bench_calc_recall_matches(self):
+        """enhanced_bench duplicates calc_recall; the epsilon semantics of
+        the two implementations must agree."""
+        from vdbbench import enhanced_bench
+
+        ann = {0: [1, 2, 44]}
+        gt = {0: [1, 2, 3, 44, 5]}
+        scores = {0: [0.9, 0.85, 0.8, 0.8 - 5e-6, 0.5]}
+        kwargs = dict(
+            ground_truth_scores=scores, epsilon=1e-4, higher_is_better=True,
+        )
+        s1 = simple_bench.calc_recall(ann, gt, 3, **kwargs)
+        s2 = enhanced_bench.calc_recall(ann, gt, 3, **kwargs)
+        assert s1["recall_at_k"] == pytest.approx(s2["recall_at_k"])
+        assert s1["recall_at_k_exact"] == pytest.approx(s2["recall_at_k_exact"])
+
+
+# ===========================================================================
+# 5. precompute_ground_truth captures scores (simple_bench, mocked Milvus)
+# ===========================================================================
+
+
+class TestGroundTruthScoreCapture:
+    def _fake_hits(self, ids_scores):
+        hits = []
+        for hid, dist in ids_scores:
+            h = MagicMock()
+            h.id = hid
+            h.distance = dist
+            hits.append(h)
+        return hits
+
+    def test_scores_out_is_filled_and_aligned(self, monkeypatch):
+        fake_coll = MagicMock()
+        fake_coll.num_entities = 100
+        fake_coll.search.return_value = [
+            self._fake_hits([(7, 0.99), (3, 0.98), (5, 0.97)]),
+        ]
+        monkeypatch.setattr(
+            simple_bench, "Collection", MagicMock(return_value=fake_coll),
+        )
+        monkeypatch.setattr(simple_bench, "open_connection", MagicMock())
+
+        scores: dict = {}
+        gt = simple_bench.precompute_ground_truth(
+            host="h", port="p",
+            flat_collection_name="flat",
+            query_vectors=[[0.0] * DIM],
+            top_k=3,
+            scores_out=scores,
+        )
+        assert gt == {0: [7, 3, 5]}
+        assert scores == {0: [pytest.approx(0.99), pytest.approx(0.98),
+                              pytest.approx(0.97)]}
+
+    def test_return_type_unchanged_without_scores_out(self, monkeypatch):
+        """#489 test compatibility: callers that don't pass scores_out get
+        the same Dict[int, List[int]] as before."""
+        fake_coll = MagicMock()
+        fake_coll.num_entities = 100
+        fake_coll.search.return_value = [self._fake_hits([(1, 0.9)])]
+        monkeypatch.setattr(
+            simple_bench, "Collection", MagicMock(return_value=fake_coll),
+        )
+        monkeypatch.setattr(simple_bench, "open_connection", MagicMock())
+
+        gt = simple_bench.precompute_ground_truth(
+            host="h", port="p",
+            flat_collection_name="flat",
+            query_vectors=[[0.0] * DIM],
+            top_k=1,
+        )
+        assert isinstance(gt, dict)
+        assert gt == {0: [1]}
+
+
+# ===========================================================================
+# 6. GroundTruthBuilder similarities + end-to-end epsilon path
+# ===========================================================================
+
+
+class TestGroundTruthSimilarities:
+    def test_build_with_similarities_alignment(self):
+        rng = np.random.RandomState(SEED_DATA)
+        db = _normalize(rng.normal(0, 1, (500, DIM)).astype(np.float32))
+        queries = _normalize(rng.normal(0, 1, (10, DIM)).astype(np.float32))
+
+        builder = GroundTruthBuilder(queries, k=5)
+        from vdbbench.benchmark.generator import VectorBlock
+
+        builder.update(VectorBlock(
+            ids=np.arange(500, dtype=np.int64), vectors=db, block_index=0,
+        ))
+        ids, sims = builder.build_with_similarities()
+
+        assert ids.shape == (10, 5) and sims.shape == (10, 5)
+        # Verify against brute force
+        ref = queries @ db.T
+        for q in range(10):
+            expected = np.argsort(-ref[q])[:5]
+            np.testing.assert_array_equal(ids[q], expected)
+            np.testing.assert_allclose(sims[q], ref[q][expected], atol=1e-6)
+
+    def test_build_still_returns_ids_only(self):
+        """Backward compatibility: build() keeps its historical contract."""
+        rng = np.random.RandomState(SEED_DATA)
+        db = _normalize(rng.normal(0, 1, (100, DIM)).astype(np.float32))
+        queries = _normalize(rng.normal(0, 1, (4, DIM)).astype(np.float32))
+
+        builder = GroundTruthBuilder(queries, k=3)
+        from vdbbench.benchmark.generator import VectorBlock
+
+        builder.update(VectorBlock(
+            ids=np.arange(100, dtype=np.int64), vectors=db, block_index=0,
+        ))
+        out = builder.build()
+        assert isinstance(out, np.ndarray)
+        assert out.shape == (4, 3)
+        assert out.dtype == np.int64

--- a/vdb_benchmark/vdbbench/benchmark/generator.py
+++ b/vdb_benchmark/vdbbench/benchmark/generator.py
@@ -55,22 +55,101 @@ def _generate_block(
     return vectors
 
 
+# Valid query_mode values (issue #625)
+QUERY_MODES = ("independent", "planted")
+
+# Default L2 displacement of a planted query from its base database vector.
+DEFAULT_QUERY_NOISE = 0.05
+
+
+def plant_queries(
+    base_vectors: np.ndarray,
+    seed: int,
+    query_noise: float = DEFAULT_QUERY_NOISE,
+) -> np.ndarray:
+    """Derive query vectors from database vectors by small perturbation.
+
+    Each query is ``normalize(base + query_noise * u)`` where *u* is a
+    deterministic unit-norm Gaussian direction drawn from *seed*.  This
+    "plants" a genuine near neighbor for every query, so recall@k is
+    well-conditioned even when the database vectors themselves are
+    i.i.d. random (issue #625): with independent queries over uniform
+    1536-d vectors, the query-to-corpus similarity distribution
+    concentrates (relative contrast ~1.1) and the true top-K boundary
+    falls within float32 noise, making recall non-discriminative.
+
+    Parameters
+    ----------
+    base_vectors : np.ndarray
+        Shape ``(nq, dim)``, L2-normalized database vectors to perturb.
+    seed : int
+        Seed for the perturbation directions (independent of the
+        dataset seed).
+    query_noise : float
+        Approximate L2 displacement of each query from its base vector.
+        0 reproduces the base vectors exactly; ~0.05 keeps the base
+        vector as the clear nearest neighbor while still exercising
+        the index.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(nq, dim)``, dtype float32, L2-normalized.
+    """
+    base = np.ascontiguousarray(base_vectors, dtype=np.float32)
+    nq, dim = base.shape
+    rng = np.random.RandomState(seed)
+    noise = rng.normal(0, 1, (nq, dim)).astype(np.float32)
+    noise_norms = np.linalg.norm(noise, axis=1, keepdims=True)
+    noise_norms[noise_norms == 0] = 1.0
+    vectors = base + np.float32(query_noise) * (noise / noise_norms)
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return (vectors / norms).astype(np.float32)
+
+
 def generate_query_vectors(
     num_queries: int,
     dimension: int,
     distribution: str = "uniform",
     seed: int = 99,
+    query_mode: str = "independent",
+    dataset_seed: int = 42,
+    query_noise: float = DEFAULT_QUERY_NOISE,
 ) -> np.ndarray:
     """Deterministically generate a set of query vectors.
 
-    Uses a *separate* seed from the database vectors so that the query
-    set is independent of the dataset.
+    Two modes are supported (issue #625):
+
+    * ``independent`` (default, preserves historical behavior) -- an
+      i.i.d. draw from *seed*, fully independent of the dataset.
+    * ``planted`` -- queries are perturbations of the first
+      ``num_queries`` **database** vectors.  Because the producer's
+      RNG stream is deterministic, regenerating the first rows with
+      ``dataset_seed`` reproduces the stored vectors bit-exactly
+      (requires ``num_queries <= block_size``; the orchestrator
+      validates this).  Perturbation directions come from *seed* so
+      the query set is still distinct from the stored data.
 
     Returns
     -------
     np.ndarray
         Shape ``(num_queries, dimension)``, dtype float32, L2-normalized.
     """
+    if query_mode not in QUERY_MODES:
+        raise ValueError(
+            f"Invalid query_mode '{query_mode}'.  Must be one of {QUERY_MODES}"
+        )
+
+    if query_mode == "planted":
+        # Bit-exact reproduction of the first `num_queries` database
+        # vectors: _generate_block consumes the RNG stream in row-major
+        # order, so a fresh RandomState(dataset_seed) draw of shape
+        # (num_queries, dim) equals the first rows of block 0.
+        base_rng = np.random.RandomState(dataset_seed)
+        base = _generate_block(num_queries, dimension, distribution, base_rng)
+        return plant_queries(base, seed=seed, query_noise=query_noise)
+
     rng = np.random.RandomState(seed)
     return _generate_block(num_queries, dimension, distribution, rng)
 

--- a/vdb_benchmark/vdbbench/benchmark/ground_truth.py
+++ b/vdb_benchmark/vdbbench/benchmark/ground_truth.py
@@ -149,10 +149,32 @@ class GroundTruthBuilder:
             ``result[q]`` contains the IDs of the *k* nearest database
             vectors to query *q*, ordered closest-first.
         """
+        ids, _ = self.build_with_similarities()
+        return ids
+
+    def build_with_similarities(self) -> tuple[np.ndarray, np.ndarray]:
+        """Return the truth table together with its similarities.
+
+        The similarities are the internal "higher is better" inner
+        products (equivalent ranking for COSINE / IP / L2 on
+        L2-normalized vectors) and are required for tie-aware
+        epsilon-recall (issue #625): with random high-dimensional data
+        the gap between the k-th and (k+1)-th neighbor is often below
+        float32 matmul noise, so exact set-intersection recall
+        penalizes ANN results that are numerically indistinguishable
+        from the ground truth.
+
+        Returns
+        -------
+        (ids, similarities) : tuple[np.ndarray, np.ndarray]
+            Both shaped ``(num_queries, k)``, sorted closest-first per
+            query.  ``ids`` is int64, ``similarities`` float32.
+        """
         # Descending similarity -- highest (closest) first.
         order = np.argsort(-self._top_dist, axis=1)
         sorted_ids = np.take_along_axis(self._top_ids, order, axis=1)
-        return sorted_ids
+        sorted_sims = np.take_along_axis(self._top_dist, order, axis=1)
+        return sorted_ids, sorted_sims
 
     # ------------------------------------------------------------------
     # Internals

--- a/vdb_benchmark/vdbbench/benchmark/orchestrator.py
+++ b/vdb_benchmark/vdbbench/benchmark/orchestrator.py
@@ -53,7 +53,12 @@ from typing import Any, Dict, Optional
 import numpy as np
 
 from .backends.base import VectorDBBackend
-from .generator import VectorBlock, VectorGenerator, generate_query_vectors
+from .generator import (
+    QUERY_MODES,
+    VectorBlock,
+    VectorGenerator,
+    generate_query_vectors,
+)
 from .ground_truth import GroundTruthBuilder
 from .search_runner import (
     SearchResult,
@@ -88,9 +93,22 @@ class BenchmarkConfig:
     # Query vectors
     num_query_vectors: int = 10_000
     query_seed: int = 99
+    # "independent" (historical) or "planted" (issue #625): queries are
+    # perturbations of database vectors so every query has genuine near
+    # neighbors and recall@k is discriminative on synthetic data.
+    query_mode: str = "independent"
+    # Approximate L2 displacement of a planted query from its base vector.
+    query_noise: float = 0.05
 
     # Ground truth
     truth_k: int = 100
+    # Tie tolerance for recall (issue #625).  0 = exact set-intersection
+    # recall (historical).  > 0 = a returned neighbor counts as a hit if
+    # its ground-truth similarity is within epsilon of the k-th
+    # neighbor's, so float32-level ties are not scored as misses.
+    # Requires precomputed truth mode (similarities are unavailable in
+    # flat_index mode, which falls back to exact recall with a warning).
+    recall_epsilon: float = 0.0
     truth_mode: str = "precomputed"  # "precomputed" or "flat_index"
 
     # Index
@@ -171,6 +189,7 @@ class BenchmarkOrchestrator:
 
         self.query_vectors: Optional[np.ndarray] = None
         self.truth_table: Optional[np.ndarray] = None
+        self.truth_similarities: Optional[np.ndarray] = None
         self.search_result: Optional[SearchResult] = None
 
         # Timing bookkeeping
@@ -189,6 +208,30 @@ class BenchmarkOrchestrator:
             raise ValueError(
                 f"Invalid mode '{mode}'.  Must be one of {MODES}"
             )
+
+        if self.cfg.query_mode not in QUERY_MODES:
+            raise ValueError(
+                f"Invalid query_mode '{self.cfg.query_mode}'.  "
+                f"Must be one of {QUERY_MODES}"
+            )
+        if self.cfg.query_mode == "planted":
+            # Planted queries are perturbations of the first
+            # num_query_vectors database vectors, which are reproduced
+            # bit-exactly by replaying the producer RNG stream.  That
+            # replay covers exactly one block, so the query count must
+            # fit inside it (and inside the dataset).
+            if self.cfg.num_query_vectors > self.cfg.block_size:
+                raise ValueError(
+                    "query_mode='planted' requires num_query_vectors "
+                    f"({self.cfg.num_query_vectors:,}) <= block_size "
+                    f"({self.cfg.block_size:,})"
+                )
+            if self.cfg.num_query_vectors > self.cfg.num_vectors:
+                raise ValueError(
+                    "query_mode='planted' requires num_query_vectors "
+                    f"({self.cfg.num_query_vectors:,}) <= num_vectors "
+                    f"({self.cfg.num_vectors:,})"
+                )
 
         summary: Dict[str, Any] = {}
 
@@ -218,11 +261,13 @@ class BenchmarkOrchestrator:
         # Ground-truth table
         if self.truth_table is not None:
             gtpath = os.path.join(output_dir, "ground_truth.npz")
-            np.savez_compressed(
-                gtpath,
-                truth_table=self.truth_table,
-                query_vectors=self.query_vectors,
-            )
+            gt_arrays: Dict[str, np.ndarray] = {
+                "truth_table": self.truth_table,
+                "query_vectors": self.query_vectors,
+            }
+            if self.truth_similarities is not None:
+                gt_arrays["truth_similarities"] = self.truth_similarities
+            np.savez_compressed(gtpath, **gt_arrays)
             paths["ground_truth"] = gtpath
 
         # Search results
@@ -256,8 +301,9 @@ class BenchmarkOrchestrator:
 
         # ---- 1. Generate query vectors ---------------------------------
         logger.info(
-            "Generating %s query vectors (%s-d, seed=%d) ...",
-            f"{cfg.num_query_vectors:,}", f"{cfg.dimension:,}", cfg.query_seed,
+            "Generating %s query vectors (%s-d, seed=%d, mode=%s) ...",
+            f"{cfg.num_query_vectors:,}", f"{cfg.dimension:,}",
+            cfg.query_seed, cfg.query_mode,
         )
         t0 = time.time()
         self.query_vectors = generate_query_vectors(
@@ -265,6 +311,9 @@ class BenchmarkOrchestrator:
             dimension=cfg.dimension,
             distribution=cfg.distribution,
             seed=cfg.query_seed,
+            query_mode=cfg.query_mode,
+            dataset_seed=cfg.seed,
+            query_noise=cfg.query_noise,
         )
         self._timings["query_gen_sec"] = time.time() - t0
         logger.info(
@@ -427,7 +476,9 @@ class BenchmarkOrchestrator:
         if gt_builder is not None:
             logger.info("Building final truth table (k=%d) ...", cfg.truth_k)
             t0 = time.time()
-            self.truth_table = gt_builder.build()
+            self.truth_table, self.truth_similarities = (
+                gt_builder.build_with_similarities()
+            )
             self._timings["truth_build_sec"] = time.time() - t0
             logger.info(
                 "Ground truth built in %.2f s  (%s queries x k=%s)",
@@ -487,6 +538,8 @@ class BenchmarkOrchestrator:
             num_rounds=cfg.num_search_rounds,
             batch_size=cfg.search_batch_size,
             log_interval=cfg.log_interval,
+            truth_similarities=self.truth_similarities,
+            recall_epsilon=cfg.recall_epsilon,
         )
 
         t0 = time.time()
@@ -531,6 +584,15 @@ class BenchmarkOrchestrator:
         else:
             gt = np.load(gtpath)
             self.truth_table = gt["truth_table"]
+            if "truth_similarities" in gt.files:
+                self.truth_similarities = gt["truth_similarities"]
+            elif self.cfg.recall_epsilon > 0.0:
+                logger.warning(
+                    "recall_epsilon=%.2e requested but '%s' has no "
+                    "truth_similarities (artifact from an older run); "
+                    "exact recall will be used.",
+                    self.cfg.recall_epsilon, gtpath,
+                )
 
         logger.info(
             "Loaded artifacts from '%s': queries=%s, truth=%s",
@@ -560,6 +622,8 @@ class BenchmarkOrchestrator:
             "search_total_queries": r.total_queries,
             "search_qps": r.qps,
             "search_recall_at_k": r.recall_at_k,
+            "search_recall_at_k_exact": r.recall_at_k_exact,
+            "search_recall_epsilon": r.recall_epsilon,
             "search_latency_p50_ms": r.latency_p50_ms,
             "search_latency_p90_ms": r.latency_p90_ms,
             "search_latency_p99_ms": r.latency_p99_ms,

--- a/vdb_benchmark/vdbbench/benchmark/search_runner.py
+++ b/vdb_benchmark/vdbbench/benchmark/search_runner.py
@@ -61,6 +61,8 @@ class SearchResult:
     total_wall_sec: float
     qps: float
     recall_at_k: float
+    recall_at_k_exact: float
+    recall_epsilon: float
     search_k: int
     truth_k: int
 
@@ -85,6 +87,8 @@ def _recall_at_k(
     predicted_ids: np.ndarray,
     truth_ids: np.ndarray,
     k: int,
+    truth_similarities: Optional[np.ndarray] = None,
+    epsilon: float = 0.0,
 ) -> float:
     """Compute mean recall@k across all queries.
 
@@ -96,6 +100,20 @@ def _recall_at_k(
         Shape ``(nq, truth_k)`` -- ground-truth nearest IDs.
     k : int
         Evaluate recall using the top-*k* of the truth table.
+    truth_similarities : np.ndarray, optional
+        Shape ``(nq, truth_k)`` -- "higher is better" similarities
+        aligned with ``truth_ids`` (from
+        ``GroundTruthBuilder.build_with_similarities``).  Required for
+        ``epsilon > 0``.
+    epsilon : float
+        Tie tolerance (issue #625).  When > 0, a predicted ID is
+        credited if it appears anywhere in the stored truth window with
+        similarity >= (k-th ground-truth similarity - epsilon), i.e.
+        neighbors numerically tied with the k-th are not counted as
+        misses.  Credited hits are capped at *k* per query so recall
+        stays in [0, 1].  Ties beyond the stored ``truth_k`` window
+        cannot be credited, so configure ``truth_k`` comfortably above
+        ``search_k`` (the defaults, 100 vs 10, are fine).
 
     Returns
     -------
@@ -103,6 +121,19 @@ def _recall_at_k(
         Mean recall in [0, 1].
     """
     nq = predicted_ids.shape[0]
+    if nq == 0:
+        return 0.0
+
+    if epsilon > 0.0 and truth_similarities is not None:
+        total = 0.0
+        for q in range(nq):
+            kth_sim = truth_similarities[q, k - 1]
+            credit_mask = truth_similarities[q] >= (kth_sim - epsilon)
+            credit_set = set(truth_ids[q][credit_mask].tolist())
+            pred_set = set(predicted_ids[q].tolist())
+            total += min(len(credit_set & pred_set), k) / k
+        return total / nq
+
     truth_top_k = truth_ids[:, :k]
     hits = 0
     for q in range(nq):
@@ -251,11 +282,23 @@ class SearchRunner:
         num_rounds: int = 1,
         batch_size: int = 1,
         log_interval: int = 1000,
+        truth_similarities: Optional[np.ndarray] = None,
+        recall_epsilon: float = 0.0,
     ) -> None:
         self.backend = backend
         self.collection_name = collection_name
         self.query_vectors = np.ascontiguousarray(query_vectors, dtype=np.float32)
         self.truth_table = truth_table
+        self.truth_similarities = truth_similarities
+        self.recall_epsilon = float(recall_epsilon)
+        if self.recall_epsilon > 0.0 and self.truth_similarities is None:
+            logger.warning(
+                "recall_epsilon=%.2e requested but no ground-truth "
+                "similarities are available (e.g. flat_index truth mode); "
+                "falling back to exact recall.",
+                self.recall_epsilon,
+            )
+            self.recall_epsilon = 0.0
         self.search_k = search_k
         self.metric_type = metric_type
         self.num_rounds = num_rounds
@@ -295,6 +338,7 @@ class SearchRunner:
         batch_latencies: list[float] = []
         all_predicted: list[np.ndarray] = []
         all_truth: list[np.ndarray] = []
+        all_truth_sims: list[np.ndarray] = []
         intervals: list[IntervalStats] = []
         total_per_query_ms: float = 0.0
         total_batches: int = 0
@@ -303,6 +347,7 @@ class SearchRunner:
         interval_latencies: list[float] = []
         interval_predicted: list[np.ndarray] = []
         interval_truth: list[np.ndarray] = []
+        interval_truth_sims: list[np.ndarray] = []
         interval_query_count: int = 0
         interval_idx = 0
 
@@ -323,6 +368,11 @@ class SearchRunner:
                 batch_idx = order[batch_start:batch_end]
                 batch_queries = self.query_vectors[batch_idx]
                 batch_truth = self.truth_table[batch_idx]
+                batch_truth_sims = (
+                    self.truth_similarities[batch_idx]
+                    if self.truth_similarities is not None
+                    else None
+                )
 
                 # Timed search
                 t0 = time.perf_counter()
@@ -348,6 +398,9 @@ class SearchRunner:
                 all_truth.append(batch_truth)
                 interval_predicted.append(predicted_arr)
                 interval_truth.append(batch_truth)
+                if batch_truth_sims is not None:
+                    all_truth_sims.append(batch_truth_sims)
+                    interval_truth_sims.append(batch_truth_sims)
 
                 total_queries += batch_n
                 interval_query_count += batch_n
@@ -362,6 +415,7 @@ class SearchRunner:
                         interval_latencies=interval_latencies,
                         interval_predicted=interval_predicted,
                         interval_truth=interval_truth,
+                        interval_truth_sims=interval_truth_sims,
                         interval_query_count=interval_query_count,
                     )
                     intervals.append(stats)
@@ -371,6 +425,7 @@ class SearchRunner:
                     interval_latencies = []
                     interval_predicted = []
                     interval_truth = []
+                    interval_truth_sims = []
                     interval_query_count = 0
                     interval_start = time.time()
                     interval_idx += 1
@@ -381,13 +436,26 @@ class SearchRunner:
         lat_arr = np.array(batch_latencies)
         pred_all = np.concatenate(all_predicted, axis=0)
         truth_all = np.concatenate(all_truth, axis=0)
-        recall = _recall_at_k(pred_all, truth_all, k)
+        truth_sims_all = (
+            np.concatenate(all_truth_sims, axis=0) if all_truth_sims else None
+        )
+        recall_exact = _recall_at_k(pred_all, truth_all, k)
+        if self.recall_epsilon > 0.0:
+            recall = _recall_at_k(
+                pred_all, truth_all, k,
+                truth_similarities=truth_sims_all,
+                epsilon=self.recall_epsilon,
+            )
+        else:
+            recall = recall_exact
 
         self.result = SearchResult(
             total_queries=total_queries,
             total_wall_sec=wall_elapsed,
             qps=total_queries / wall_elapsed if wall_elapsed > 0 else 0,
             recall_at_k=recall,
+            recall_at_k_exact=recall_exact,
+            recall_epsilon=self.recall_epsilon,
             search_k=k,
             truth_k=self.truth_table.shape[1],
             latency_p50_ms=float(np.percentile(lat_arr, 50)),
@@ -429,6 +497,7 @@ class SearchRunner:
         interval_latencies: list[float],
         interval_predicted: list[np.ndarray],
         interval_truth: list[np.ndarray],
+        interval_truth_sims: Optional[list[np.ndarray]] = None,
         interval_query_count: int = 0,
     ) -> IntervalStats:
         now = time.time()
@@ -439,7 +508,16 @@ class SearchRunner:
         lat_arr = np.array(interval_latencies)
         pred = np.concatenate(interval_predicted, axis=0)
         truth = np.concatenate(interval_truth, axis=0)
-        recall = _recall_at_k(pred, truth, self.search_k)
+        truth_sims = (
+            np.concatenate(interval_truth_sims, axis=0)
+            if interval_truth_sims
+            else None
+        )
+        recall = _recall_at_k(
+            pred, truth, self.search_k,
+            truth_similarities=truth_sims,
+            epsilon=self.recall_epsilon,
+        )
         # Use actual query count for QPS; fall back to batch count if not provided
         iq = interval_query_count if interval_query_count > 0 else len(interval_latencies)
 

--- a/vdb_benchmark/vdbbench/configs/1m_diskann.yaml
+++ b/vdb_benchmark/vdbbench/configs/1m_diskann.yaml
@@ -14,6 +14,18 @@ dataset:
   batch_size: 1000
   num_shards: 1
   vector_dtype: FLOAT_VECTOR
+  # Query realism / recall conditioning (issue #625):
+  #   query_mode: planted   -- queries are perturbations of stored vectors,
+  #                            so every query has genuine near neighbors and
+  #                            recall@k is discriminative on synthetic data.
+  #                            Default 'independent' preserves prior behavior.
+  #   query_noise: 0.05     -- L2 displacement of planted queries.
+  #   recall_epsilon: 1e-4  -- tie tolerance for recall@k; float32-level ties
+  #                            with the k-th neighbor are not scored as misses.
+  #                            Default 0.0 keeps exact set-intersection recall.
+  # query_mode: planted
+  # query_noise: 0.05
+  # recall_epsilon: 1e-4
 
 index:
   index_type: DISKANN

--- a/vdb_benchmark/vdbbench/enhanced_bench.py
+++ b/vdb_benchmark/vdbbench/enhanced_bench.py
@@ -50,6 +50,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 
+from vdbbench.benchmark.generator import DEFAULT_QUERY_NOISE, plant_queries
 from vdbbench.disk_stats import classify_storage_target
 
 try:
@@ -423,6 +424,9 @@ def calc_recall(
     ann_results: Dict[int, List[Any]],
     ground_truth: Dict[int, List[Any]],
     k: int,
+    ground_truth_scores: Optional[Dict[int, List[float]]] = None,
+    epsilon: float = 0.0,
+    higher_is_better: bool = True,
 ) -> Dict[str, Any]:
     """
     Calculate recall@k by comparing ANN search results against FLAT ground truth.
@@ -430,29 +434,64 @@ def calc_recall(
     recall@k = |ANN_top_k ∩ GT_top_k| / |GT_top_k|
 
     The denominator uses the actual ground-truth set size so recall remains
-    valid when k is capped by collection size or Milvus top-k limits.
+    valid when k is capped by collection size or top-k limits.
+
+    Tie-aware epsilon recall (issue #625): with ``epsilon > 0`` and
+    ``ground_truth_scores`` supplied, a returned neighbor is credited if it
+    appears anywhere in the stored ground-truth window with a score within
+    *epsilon* of the k-th neighbor's score (Milvus reports similarity for
+    COSINE/IP — higher is better — and distance for L2 — lower is better).
+    Credited hits are capped at the GT set size. Exact recall is always
+    also computed and reported. Defaults preserve historical behavior.
     """
+    use_epsilon = epsilon > 0.0 and ground_truth_scores is not None
+
     per_query_recall: List[float] = []
+    per_query_recall_exact: List[float] = []
     recall_by_query: Dict[str, float] = {}
 
     for query_idx in sorted(ann_results.keys()):
         if query_idx not in ground_truth:
             continue
-
         ann_top_k = set(ann_results[query_idx][:k])
-        gt_top_k = set(ground_truth[query_idx][:k])
+        gt_ids = ground_truth[query_idx]
+        gt_top_k = set(gt_ids[:k])
         if not gt_top_k:
             continue
 
-        recall_value = len(ann_top_k & gt_top_k) / len(gt_top_k)
+        exact_value = len(ann_top_k & gt_top_k) / len(gt_top_k)
+        per_query_recall_exact.append(exact_value)
+
+        recall_value = exact_value
+        scores = (
+            ground_truth_scores.get(query_idx) if use_epsilon else None
+        )
+        if use_epsilon and scores and len(scores) >= len(gt_top_k):
+            kth_score = scores[len(gt_top_k) - 1]
+            if higher_is_better:
+                credit = {
+                    gt_id
+                    for gt_id, s in zip(gt_ids, scores)
+                    if s >= kth_score - epsilon
+                }
+            else:
+                credit = {
+                    gt_id
+                    for gt_id, s in zip(gt_ids, scores)
+                    if s <= kth_score + epsilon
+                }
+            recall_value = min(len(ann_top_k & credit), len(gt_top_k)) / len(gt_top_k)
+
         per_query_recall.append(recall_value)
         recall_by_query[str(query_idx)] = recall_value
 
     if not per_query_recall:
         return {
             "recall_at_k": 0.0,
+            "recall_at_k_exact": 0.0,
+            "recall_epsilon": float(epsilon) if use_epsilon else 0.0,
             "num_queries_evaluated": 0,
-            "k": int(k),
+            "k": k,
             "min_recall": 0.0,
             "max_recall": 0.0,
             "mean_recall": 0.0,
@@ -464,9 +503,13 @@ def calc_recall(
             "recall_by_query": {},
         }
 
-    recalls_arr = np.asarray(per_query_recall, dtype=float)
+    recalls_arr = np.array(per_query_recall, dtype=float)
+    recalls_exact_arr = np.array(per_query_recall_exact, dtype=float)
+
     return {
         "recall_at_k": float(np.mean(recalls_arr)),
+        "recall_at_k_exact": float(np.mean(recalls_exact_arr)),
+        "recall_epsilon": float(epsilon) if use_epsilon else 0.0,
         "num_queries_evaluated": int(len(per_query_recall)),
         "k": int(k),
         "min_recall": float(np.min(recalls_arr)),
@@ -1099,8 +1142,14 @@ def precompute_ground_truth(
     query_vectors: List[List[float]],
     top_k: int,
     metric_type: str = "COSINE",
+    scores_out: Optional[Dict[int, List[float]]] = None,
 ) -> Dict[int, List[Any]]:
-    """Pre-compute exact ground truth using the FLAT collection."""
+    """Pre-compute exact ground truth using the FLAT collection.
+
+    If *scores_out* is provided (an empty dict), it is filled with
+    ``query_index -> [hit.distance, ...]`` aligned with the returned IDs,
+    enabling tie-aware epsilon recall (issue #625). Return type unchanged.
+    """
     conn_alias = f"gt_compute_{uuid.uuid4().hex[:8]}"
 
     try:
@@ -1140,6 +1189,10 @@ def precompute_ground_truth(
             )
             for i, hits in enumerate(results):
                 ground_truth[batch_start + i] = [hit.id for hit in hits]
+                if scores_out is not None:
+                    scores_out[batch_start + i] = [
+                        float(hit.distance) for hit in hits
+                    ]
 
         gt_elapsed = time.time() - gt_start
         print(f"Ground truth pre-computation complete: {len(ground_truth)} queries in {gt_elapsed:.2f}s")
@@ -2487,6 +2540,34 @@ def main() -> None:
     ap.add_argument("--k", type=int, default=10, help="Top-k for enhanced path.")
     ap.add_argument("--seed", type=int, default=1234)
     ap.add_argument(
+        "--query-mode",
+        choices=["independent", "planted"],
+        default="independent",
+        help=(
+            "Query generation mode (issue #625). 'planted' perturbs stored "
+            "database vectors so every query has genuine near neighbors; "
+            "requires dense INT64 pks 0..N-1 (the vdbbench loader layout). "
+            "Applies to the simple-bench-compatible path."
+        ),
+    )
+    ap.add_argument(
+        "--query-noise",
+        type=float,
+        default=DEFAULT_QUERY_NOISE,
+        help="L2 displacement of planted queries from their base vectors.",
+    )
+    ap.add_argument(
+        "--recall-epsilon",
+        type=float,
+        default=0.0,
+        help=(
+            "Tie tolerance for recall@k (issue #625). 0 keeps exact "
+            "set-intersection recall. Applies to the simple-bench-"
+            "compatible path; the sweep path keeps exact recall because "
+            "its recall targets are defined on the exact metric."
+        ),
+    )
+    ap.add_argument(
         "--data-path",
         default=None,
         help=(
@@ -2665,8 +2746,34 @@ def main() -> None:
         print("Ground truth is pre-computed using a FLAT (brute-force) index.")
         print(f"Using metric type: {metric_type}")
 
-        print(f"\nGenerating {args.num_query_vectors} query vectors (dim={args.vector_dim}, seed={args.seed})...")
-        pre_generated_queries = generate_query_vectors(args.num_query_vectors, args.vector_dim, seed=args.seed)
+        print(
+            f"\nGenerating {args.num_query_vectors} query vectors "
+            f"(dim={args.vector_dim}, seed={args.seed}, mode={args.query_mode})..."
+        )
+        if args.query_mode == "planted":
+            from vdbbench.simple_bench import fetch_planted_query_bases
+
+            base_vectors = fetch_planted_query_bases(
+                host=args.host,
+                port=args.port,
+                collection_name=args.collection,
+                num_queries=args.num_query_vectors,
+                seed=args.seed,
+            )
+            if base_vectors is None:
+                print(
+                    "ERROR: planted-query base fetch failed. Re-run with "
+                    "--query-mode independent, or verify the collection "
+                    "uses dense INT64 pks 0..N-1."
+                )
+                sys.exit(1)
+            pre_generated_queries = plant_queries(
+                base_vectors, seed=args.seed, query_noise=args.query_noise,
+            ).tolist()
+        else:
+            pre_generated_queries = generate_query_vectors(
+                args.num_query_vectors, args.vector_dim, seed=args.seed
+            )
         print(f"Generated {len(pre_generated_queries)} query vectors.")
 
         gt_collection_name = args.gt_collection or f"{args.collection}_flat_gt"
@@ -2706,6 +2813,7 @@ def main() -> None:
                     sys.exit(1)
                 connections.disconnect("default")
 
+        ground_truth_scores: Dict[int, List[float]] = {}
         ground_truth = precompute_ground_truth(
             host=args.host,
             port=args.port,
@@ -2713,6 +2821,7 @@ def main() -> None:
             query_vectors=pre_generated_queries,
             top_k=recall_k,
             metric_type=metric_type,
+            scores_out=ground_truth_scores,
         )
         if not ground_truth:
             print("ERROR: Ground truth computation failed. Cannot compute recall.")
@@ -2824,7 +2933,14 @@ def main() -> None:
         print("\nCalculating recall from per-worker JSONL files...")
         ann_results_by_query = load_recall_hits(output_dir)
         print(f"  Loaded ANN hits for {len(ann_results_by_query)} unique query indices from {args.processes} worker(s).")
-        recall_stats = calc_recall(ann_results_by_query, ground_truth, recall_k)
+        recall_stats = calc_recall(
+            ann_results_by_query,
+            ground_truth,
+            recall_k,
+            ground_truth_scores=ground_truth_scores or None,
+            epsilon=args.recall_epsilon,
+            higher_is_better=metric_type.upper() != "L2",
+        )
 
         recall_output_file = os.path.join(output_dir, "recall_stats.json")
         with open(recall_output_file, "w", encoding="utf-8") as f:

--- a/vdb_benchmark/vdbbench/simple_bench.py
+++ b/vdb_benchmark/vdbbench/simple_bench.py
@@ -38,6 +38,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 from tabulate import tabulate
 
+from vdbbench.benchmark.generator import DEFAULT_QUERY_NOISE, plant_queries
 from vdbbench.config_loader import load_config, merge_config_with_args
 from vdbbench.connection import open_connection
 from vdbbench.disk_stats import build_disk_io_stats, classify_storage_target
@@ -195,6 +196,9 @@ def calc_recall(
     ann_results: Dict[int, List[int]],
     ground_truth: Dict[int, List[int]],
     k: int,
+    ground_truth_scores: Optional[Dict[int, List[float]]] = None,
+    epsilon: float = 0.0,
+    higher_is_better: bool = True,
 ) -> Dict[str, Any]:
     """
     Calculate recall@k by comparing ANN search results against FLAT ground truth.
@@ -204,19 +208,40 @@ def calc_recall(
     The denominator uses the actual ground-truth set size so the metric remains
     valid when k is capped by collection size or Milvus top-k limits.
 
+    Tie-aware epsilon recall (issue #625):
+        With ``epsilon > 0`` and ``ground_truth_scores`` supplied, a returned
+        neighbor is credited if it appears anywhere in the stored ground-truth
+        window with a score within *epsilon* of the k-th neighbor's score.
+        On high-dimensional random data the gap between the k-th and (k+1)-th
+        neighbor is routinely below float32 matmul noise, so exact
+        set-intersection recall scores numerically-tied neighbors as misses.
+        Credited hits are capped at the GT set size so recall stays in [0, 1].
+        The exact recall is always also computed and reported.
+
     Args:
         ann_results:
             Mapping query_index -> ANN result IDs.
         ground_truth:
-            Mapping query_index -> exact FLAT result IDs.
+            Mapping query_index -> exact FLAT result IDs (closest first).
         k:
             Number of top results to evaluate.
+        ground_truth_scores:
+            Optional mapping query_index -> scores aligned with the ground
+            truth IDs (``hit.distance`` from the FLAT search).
+        epsilon:
+            Tie tolerance. 0 (default) preserves historical exact behavior.
+        higher_is_better:
+            Score orientation. True for COSINE / IP (Milvus returns
+            similarity), False for L2 (Milvus returns distance).
 
     Returns:
         Dict containing summary recall metrics plus per-query values, which are
         needed for exact multi-rank aggregation.
     """
+    use_epsilon = epsilon > 0.0 and ground_truth_scores is not None
+
     per_query_recall: List[float] = []
+    per_query_recall_exact: List[float] = []
     recall_by_query: Dict[str, float] = {}
 
     for query_idx in sorted(ann_results.keys()):
@@ -224,18 +249,44 @@ def calc_recall(
             continue
 
         ann_top_k = set(ann_results[query_idx][:k])
-        gt_top_k = set(ground_truth[query_idx][:k])
+        gt_ids = ground_truth[query_idx]
+        gt_top_k = set(gt_ids[:k])
 
         if not gt_top_k:
             continue
 
-        recall_value = len(ann_top_k & gt_top_k) / len(gt_top_k)
+        exact_value = len(ann_top_k & gt_top_k) / len(gt_top_k)
+        per_query_recall_exact.append(exact_value)
+
+        recall_value = exact_value
+        scores = (
+            ground_truth_scores.get(query_idx) if use_epsilon else None
+        )
+        if use_epsilon and scores and len(scores) >= len(gt_top_k):
+            kth_score = scores[len(gt_top_k) - 1]
+            if higher_is_better:
+                credit = {
+                    gt_id
+                    for gt_id, s in zip(gt_ids, scores)
+                    if s >= kth_score - epsilon
+                }
+            else:
+                credit = {
+                    gt_id
+                    for gt_id, s in zip(gt_ids, scores)
+                    if s <= kth_score + epsilon
+                }
+            hits = min(len(ann_top_k & credit), len(gt_top_k))
+            recall_value = hits / len(gt_top_k)
+
         per_query_recall.append(recall_value)
         recall_by_query[str(query_idx)] = recall_value
 
     if not per_query_recall:
         return {
             "recall_at_k": 0.0,
+            "recall_at_k_exact": 0.0,
+            "recall_epsilon": float(epsilon) if use_epsilon else 0.0,
             "num_queries_evaluated": 0,
             "k": k,
             "min_recall": 0.0,
@@ -250,9 +301,12 @@ def calc_recall(
         }
 
     recalls_arr = np.array(per_query_recall, dtype=float)
+    recalls_exact_arr = np.array(per_query_recall_exact, dtype=float)
 
     return {
         "recall_at_k": float(np.mean(recalls_arr)),
+        "recall_at_k_exact": float(np.mean(recalls_exact_arr)),
+        "recall_epsilon": float(epsilon) if use_epsilon else 0.0,
         "num_queries_evaluated": int(len(per_query_recall)),
         "k": int(k),
         "min_recall": float(np.min(recalls_arr)),
@@ -775,11 +829,19 @@ def precompute_ground_truth(
     query_vectors: List[List[float]],
     top_k: int,
     metric_type: str = "COSINE",
+    scores_out: Optional[Dict[int, List[float]]] = None,
 ) -> Dict[int, List[int]]:
     """
     Pre-compute exact nearest-neighbor ground truth using the FLAT collection.
 
     This runs outside the timed benchmark.
+
+    If *scores_out* is provided (an empty dict), it is filled with
+    ``query_index -> [hit.distance, ...]`` aligned with the returned IDs.
+    For COSINE/IP metrics Milvus reports similarity (higher = closer); for
+    L2 it reports distance (lower = closer). The scores enable tie-aware
+    epsilon recall (issue #625). The return type is unchanged for backward
+    compatibility.
     """
     conn_alias = "gt_compute"
 
@@ -828,6 +890,10 @@ def precompute_ground_truth(
             for i, hits in enumerate(results):
                 query_idx = batch_start + i
                 ground_truth[query_idx] = [hit.id for hit in hits]
+                if scores_out is not None:
+                    scores_out[query_idx] = [
+                        float(hit.distance) for hit in hits
+                    ]
 
         gt_elapsed = time.time() - gt_start
 
@@ -881,6 +947,104 @@ def generate_query_vectors(
 
     vectors = vectors / norms
     return vectors.tolist()
+
+
+def fetch_planted_query_bases(
+    host: str,
+    port: str,
+    collection_name: str,
+    num_queries: int,
+    seed: int,
+) -> Optional[np.ndarray]:
+    """
+    Fetch base vectors for planted-query generation (issue #625).
+
+    The vdbbench loaders (load_vdb.py and the orchestrator) assign dense
+    int64 primary keys 0..N-1, so a deterministic seeded sample of that pk
+    range selects a reproducible set of stored vectors. The sampled
+    vectors are fetched with ``Collection.query`` and later perturbed by
+    ``plant_queries`` so every benchmark query has a genuine near
+    neighbor in the corpus.
+
+    Returns None (with a printed reason) if the collection layout does
+    not match (non-int64 pk, sparse pks, or fetch failure); the caller
+    should then abort rather than silently fall back, so the reported
+    query_mode is always truthful.
+    """
+    conn_alias = "planted_query_fetch"
+
+    try:
+        open_connection(alias=conn_alias, host=host, port=port)
+    except Exception as exc:
+        print(f"Failed to connect for planted-query fetch: {exc}")
+        return None
+
+    try:
+        coll = Collection(collection_name, using=conn_alias)
+        pk_field, vec_field, pk_dtype = _detect_schema_fields(coll)
+
+        if pk_dtype != DataType.INT64:
+            print(
+                "ERROR: query_mode='planted' requires dense INT64 primary "
+                f"keys (collection '{collection_name}' has {pk_dtype.name}). "
+                "Use --query-mode independent for this collection."
+            )
+            return None
+
+        coll.load()
+        num_entities = coll.num_entities
+        if num_entities < num_queries:
+            print(
+                f"ERROR: collection has {num_entities} vectors but "
+                f"{num_queries} planted queries were requested."
+            )
+            return None
+
+        rng = np.random.RandomState(seed)
+        sampled_pks = np.sort(
+            rng.choice(num_entities, size=num_queries, replace=False)
+        )
+
+        pk_to_vec: Dict[int, List[float]] = {}
+        fetch_batch = 1000
+        for start in range(0, num_queries, fetch_batch):
+            batch_pks = sampled_pks[start:start + fetch_batch].tolist()
+            rows = coll.query(
+                expr=f"{pk_field} in {batch_pks}",
+                output_fields=[pk_field, vec_field],
+                limit=len(batch_pks),
+            )
+            for row in rows:
+                pk_to_vec[int(row[pk_field])] = row[vec_field]
+
+        missing = [int(pk) for pk in sampled_pks if int(pk) not in pk_to_vec]
+        if missing:
+            print(
+                f"ERROR: {len(missing)} sampled pks not found in "
+                f"'{collection_name}' (e.g. {missing[:5]}). The pk space is "
+                "not dense 0..N-1; use --query-mode independent."
+            )
+            return None
+
+        bases = np.array(
+            [pk_to_vec[int(pk)] for pk in sampled_pks], dtype=np.float32
+        )
+        norms = np.linalg.norm(bases, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        return bases / norms
+
+    except Exception as exc:
+        print(f"Error fetching planted-query base vectors: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return None
+
+    finally:
+        try:
+            connections.disconnect(conn_alias)
+        except Exception:
+            pass
 
 
 # ===========================================================================
@@ -1566,6 +1730,40 @@ def main():
         help="Random seed for deterministic query-vector generation",
     )
     parser.add_argument(
+        "--query-mode",
+        type=str,
+        choices=["independent", "planted"],
+        default="independent",
+        help=(
+            "Query generation mode (issue #625). 'independent' (default) "
+            "draws i.i.d. random queries; 'planted' perturbs stored "
+            "database vectors so every query has genuine near neighbors "
+            "and recall@k is discriminative on synthetic data. 'planted' "
+            "requires dense INT64 pks 0..N-1 (the vdbbench loader layout)."
+        ),
+    )
+    parser.add_argument(
+        "--query-noise",
+        type=float,
+        default=DEFAULT_QUERY_NOISE,
+        help=(
+            "Approximate L2 displacement of a planted query from its base "
+            "database vector (only used with --query-mode planted)."
+        ),
+    )
+    parser.add_argument(
+        "--recall-epsilon",
+        type=float,
+        default=0.0,
+        help=(
+            "Tie tolerance for recall@k (issue #625). 0 (default) keeps "
+            "exact set-intersection recall. > 0 credits returned "
+            "neighbors whose ground-truth score is within epsilon of the "
+            "k-th neighbor's, so float32-level ties are not scored as "
+            "misses. Exact recall is always reported alongside."
+        ),
+    )
+    parser.add_argument(
         "--data-path",
         type=str,
         default=None,
@@ -1702,6 +1900,9 @@ def main():
             source_index_type = str(detected_index_type).upper()
 
     config["recall_k"] = recall_k
+    config["query_mode"] = args.query_mode
+    config["query_noise"] = args.query_noise
+    config["recall_epsilon"] = args.recall_epsilon
     config["metric_type"] = metric_type
     config["index_type"] = source_index_type
     config["search_params"] = build_search_params(
@@ -1746,14 +1947,34 @@ def main():
 
     print(
         f"\nGenerating {args.num_query_vectors} query vectors "
-        f"(dim={args.vector_dim}, seed={args.seed})..."
+        f"(dim={args.vector_dim}, seed={args.seed}, "
+        f"mode={args.query_mode})..."
     )
 
-    pre_generated_queries = generate_query_vectors(
-        args.num_query_vectors,
-        args.vector_dim,
-        seed=args.seed,
-    )
+    if args.query_mode == "planted":
+        base_vectors = fetch_planted_query_bases(
+            host=args.host,
+            port=args.port,
+            collection_name=args.collection_name,
+            num_queries=args.num_query_vectors,
+            seed=args.seed,
+        )
+        if base_vectors is None:
+            print(
+                "ERROR: planted-query base fetch failed. "
+                "Re-run with --query-mode independent, or verify the "
+                "collection uses dense INT64 pks 0..N-1."
+            )
+            sys.exit(1)
+        pre_generated_queries = plant_queries(
+            base_vectors, seed=args.seed, query_noise=args.query_noise,
+        ).tolist()
+    else:
+        pre_generated_queries = generate_query_vectors(
+            args.num_query_vectors,
+            args.vector_dim,
+            seed=args.seed,
+        )
 
     print(f"Generated {len(pre_generated_queries)} query vectors.")
 
@@ -1797,6 +2018,7 @@ def main():
         )
         sys.exit(1)
 
+    ground_truth_scores: Dict[int, List[float]] = {}
     ground_truth = precompute_ground_truth(
         host=args.host,
         port=args.port,
@@ -1804,6 +2026,7 @@ def main():
         query_vectors=pre_generated_queries,
         top_k=recall_k,
         metric_type=metric_type,
+        scores_out=ground_truth_scores,
     )
 
     if not ground_truth:
@@ -1961,7 +2184,14 @@ def main():
         if query_idx not in ann_results_by_query:
             ann_results_by_query[query_idx] = list(ids)
 
-    recall_stats = calc_recall(ann_results_by_query, ground_truth, recall_k)
+    recall_stats = calc_recall(
+        ann_results_by_query,
+        ground_truth,
+        recall_k,
+        ground_truth_scores=ground_truth_scores or None,
+        epsilon=args.recall_epsilon,
+        higher_is_better=metric_type.upper() != "L2",
+    )
 
     recall_output_file = os.path.join(output_dir, "recall_stats.json")
     with open(recall_output_file, "w", encoding="utf-8") as f:


### PR DESCRIPTION
Recall over i.i.d. uniform vectors is non-discriminative: at 1536-d the query-to-corpus cosine similarity concentrates (relative contrast ~1.1) and the top-k boundary gap falls within float32 matmul noise, so exact set-intersection recall penalizes numerically-tied neighbors and does not transfer across index configurations.

Option 1 - query_mode=planted: queries are perturbations of stored database vectors (bit-exact block-0 replay in the orchestrator; live pk-sampled fetch in simple_bench/enhanced_bench), planting a genuine near neighbor per query. Restores relative contrast from ~1.1 to >100 with zero change to ingest, index build, or storage footprint.

Option 2 - recall_epsilon: tie-aware recall credits returned neighbors whose ground-truth score is within epsilon of the k-th neighbor's. Exact recall is always reported alongside. GT similarities are carried through GroundTruthBuilder / ground_truth.npz / hit.distance capture; the backend search API is unchanged.

Defaults (query_mode=independent, recall_epsilon=0) preserve historical behavior bit-for-bit. flat_index truth mode falls back to exact recall with a warning. Verdict semantics from #489/#572 are unchanged.