### PR TITLE
fix(storage#791): exclude checkpointing datasize from submission invocation count

### DIFF
--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -1354,7 +1354,17 @@ class ReportGenerator:
         # while preserving accelerator-scoped grouping for multi-
         # accelerator submissions (b200 + mi355 datasize runs stay in
         # separate groups per accelerator).
-        if bt == BENCHMARK_TYPES.training and benchmark_run.command != 'run':
+        #
+        # Issue #791: checkpointing ``datasize`` has the same collision
+        # shape — it carries the same (model, accelerator) as the
+        # ``run`` invocations, so under the plain 5-tuple key it lands
+        # in the same workload group and inflates the invocation count
+        # past the 1-or-2 Rules.md §4.7.1 bound. Extend the
+        # discriminator to cover checkpointing for the same reason.
+        if (
+            bt in (BENCHMARK_TYPES.training, BENCHMARK_TYPES.checkpointing)
+            and benchmark_run.command != 'run'
+        ):
             return (
                 category, orgname, systemname, model, accelerator,
                 str(benchmark_run.command),

--- a/mlpstorage_py/rules/submission_checkers/checkpointing.py
+++ b/mlpstorage_py/rules/submission_checkers/checkpointing.py
@@ -37,6 +37,24 @@ class CheckpointSubmissionRulesChecker(MultiRunRulesChecker):
     REQUIRED_WRITES = 10
     REQUIRED_READS = 10
 
+    def _submission_invocations(self):
+        """Return checkpointing runs that count as submission invocations.
+
+        Issue #791: only ``command == 'run'`` invocations perform checkpoint
+        reads/writes and count toward the Rules.md §4.7.1 invocation
+        structure. Auxiliary commands like ``datasize`` are preflight
+        helpers — they emit a results directory but carry the CLI defaults
+        for ``--num-checkpoints-read``/``--num-checkpoints-write`` (both
+        10) in their parameters, which would otherwise double-count into
+        ``check_num_runs`` and inflate the invocation count past the
+        1-or-2 bound.
+        """
+        return [
+            run for run in self.benchmark_runs
+            if run.benchmark_type == BENCHMARK_TYPES.checkpointing
+            and run.command == 'run'
+        ]
+
     def check_num_runs(self) -> List[Issue]:
         """
         Require 10 total writes and 10 total reads for checkpointing benchmarks.
@@ -49,11 +67,14 @@ class CheckpointSubmissionRulesChecker(MultiRunRulesChecker):
         issues = []
         num_writes = num_reads = 0
 
-        for run in self.benchmark_runs:
-            if run.benchmark_type == BENCHMARK_TYPES.checkpointing:
-                checkpoint_params = run.parameters.get('checkpoint', {})
-                num_writes += checkpoint_params.get('num_checkpoints_write', 0)
-                num_reads += checkpoint_params.get('num_checkpoints_read', 0)
+        submission_runs = self._submission_invocations()
+        if not submission_runs:
+            return issues
+
+        for run in submission_runs:
+            checkpoint_params = run.parameters.get('checkpoint', {})
+            num_writes += checkpoint_params.get('num_checkpoints_write', 0)
+            num_reads += checkpoint_params.get('num_checkpoints_read', 0)
 
         # Check reads
         if num_reads != self.REQUIRED_READS:
@@ -118,10 +139,7 @@ class CheckpointSubmissionRulesChecker(MultiRunRulesChecker):
         """
         issues = []
 
-        checkpoint_runs = [
-            run for run in self.benchmark_runs
-            if run.benchmark_type == BENCHMARK_TYPES.checkpointing
-        ]
+        checkpoint_runs = self._submission_invocations()
         if not checkpoint_runs:
             return issues
 

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -1239,6 +1239,91 @@ class TestInvalidRulesStrict:
             f"{list(gen.workload_results.keys())!r}"
         )
 
+    def test_checkpointing_datasize_does_not_inflate_run_group_count(self, tmp_path):
+        """Issue #791: checkpointing ``datasize`` MUST NOT collide with the run-group key.
+
+        Rules.md §4.7.1 bounds a CLOSED checkpointing submission at 1
+        or 2 ``run`` invocations. ``datasize`` is a preflight helper
+        that emits a results directory but performs no checkpoint
+        reads/writes. Because its parameters inherit the CLI defaults
+        (``--num-checkpoints-read=10``/``--num-checkpoints-write=10``),
+        grouping it with the real ``run`` invocations both inflates the
+        invocation count past the 1-or-2 bound AND doubles the summed
+        read/write totals — exactly the failure the issue reporter
+        observed.
+
+        Parallels the Issue #771 training fix: the workload key adds
+        ``command`` as a 6th discriminator for non-``run`` commands so
+        datasize lands in its own group.
+        """
+        gen = _make_bare_generator(tmp_path)
+        model = "llama3-8b"
+        model_root = (
+            tmp_path / "closed" / "acme" / "results" / "sys-a"
+            / "checkpointing" / model
+        )
+
+        write_ts = "20260715_071751"
+        read_ts = "20260715_072104"
+        write_leaf = model_root / "run" / write_ts
+        read_leaf = model_root / "run" / read_ts
+        write_leaf.mkdir(parents=True)
+        read_leaf.mkdir(parents=True)
+
+        write_run = _make_run(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            model=model,
+            result_dir=str(write_leaf),
+            metrics={},
+            parameters={"checkpoint": {
+                "num_checkpoints_write": 10, "num_checkpoints_read": 0,
+            }},
+            accelerator=None,
+            run_datetime=write_ts,
+            command="run",
+        )
+        read_run = _make_run(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            model=model,
+            result_dir=str(read_leaf),
+            metrics={},
+            parameters={"checkpoint": {
+                "num_checkpoints_write": 0, "num_checkpoints_read": 10,
+            }},
+            accelerator=None,
+            run_datetime=read_ts,
+            command="run",
+        )
+
+        datasize_ts = "20260715_071658"
+        datasize_leaf = model_root / "datasize" / datasize_ts
+        datasize_leaf.mkdir(parents=True)
+        datasize_run = _make_run(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            model=model,
+            result_dir=str(datasize_leaf),
+            metrics={},
+            # datasize inherits the CLI defaults of 10/10 even though it
+            # performs no I/O — this is what previously double-counted.
+            parameters={"checkpoint": {
+                "num_checkpoints_write": 10, "num_checkpoints_read": 10,
+            }},
+            accelerator=None,
+            run_datetime=datasize_ts,
+            command="datasize",
+        )
+
+        _run_process_workload_groups(gen, [datasize_run, write_run, read_run])
+
+        # Two workload groups: one for ``run`` (2 invocations), one for
+        # ``datasize`` (1). Pre-fix produced a single 3-invocation group
+        # with 20 writes / 20 reads.
+        assert len(gen.workload_results) == 2, (
+            f"Issue #791 regression: expected 2 workload groups "
+            f"(run + datasize), got {len(gen.workload_results)} — "
+            f"keys={list(gen.workload_results.keys())!r}"
+        )
+
     def test_statistics_error_not_swallowed(self, tmp_path):
         """D-23 loud-failure: helper propagates ``StatisticsError`` on empty metric list.
 

--- a/tests/unit/test_rules_checkers.py
+++ b/tests/unit/test_rules_checkers.py
@@ -784,6 +784,118 @@ class TestCheckpointSubmissionRulesChecker:
         # All should be CLOSED
         assert all(i.validation == PARAM_VALIDATION.CLOSED for i in issues)
 
+    def create_checkpointing_run_with_command(
+        self, mock_logger, num_reads, num_writes, command
+    ):
+        """Helper: build a checkpointing run with an explicit ``command``.
+
+        ``create_checkpointing_run`` hard-codes ``command='run'``; the
+        Issue #791 tests need to build ``datasize`` runs too.
+        """
+        data = BenchmarkRunData(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            model="llama3-8b",
+            command=command,
+            run_datetime="20250111_143022",
+            num_processes=8,
+            parameters={
+                "checkpoint": {
+                    "num_checkpoints_read": num_reads,
+                    "num_checkpoints_write": num_writes,
+                }
+            },
+            override_parameters={},
+        )
+        run = BenchmarkRun.from_data(data, mock_logger)
+        run.category = PARAM_VALIDATION.CLOSED
+        return run
+
+    def test_check_num_runs_ignores_datasize_command(self, mock_logger):
+        """Issue #791: ``datasize`` runs MUST NOT contribute to read/write totals.
+
+        The CLI defaults ``--num-checkpoints-read`` and ``--num-checkpoints-write``
+        to 10 for every checkpointing subcommand — including ``datasize``,
+        which performs no I/O. Before the fix, a ``datasize`` run bundled
+        alongside a valid two-invocation write/read pair added a phantom
+        10/10 to the totals, producing the ``found 20`` INVALID that the
+        issue reporter hit.
+        """
+        write_run = self.create_checkpointing_run_with_command(
+            mock_logger, num_reads=0, num_writes=10, command="run"
+        )
+        read_run = self.create_checkpointing_run_with_command(
+            mock_logger, num_reads=10, num_writes=0, command="run"
+        )
+        datasize_run = self.create_checkpointing_run_with_command(
+            mock_logger, num_reads=10, num_writes=10, command="datasize"
+        )
+
+        checker = CheckpointSubmissionRulesChecker(
+            [write_run, read_run, datasize_run], logger=mock_logger
+        )
+        issues = checker.check_num_runs()
+
+        invalid = [i for i in issues if i.validation == PARAM_VALIDATION.INVALID]
+        assert invalid == [], (
+            f"Issue #791 regression: datasize inflated read/write totals; "
+            f"got INVALID issues: {[i.message for i in invalid]}"
+        )
+        # All three CLOSED confirmations should be present (reads, writes, combined).
+        closed = [i for i in issues if i.validation == PARAM_VALIDATION.CLOSED]
+        assert len(closed) == 3
+
+    def test_check_invocation_structure_ignores_datasize_command(self, mock_logger):
+        """Issue #791: ``datasize`` MUST NOT count as a §4.7.1 invocation.
+
+        A valid two-invocation CLOSED submission (write phase + read
+        phase) bundled with a ``datasize`` preflight run must NOT trip
+        the ``got 3`` invocation-structure error.
+        """
+        # Two-invocation split: write (10/0) then read (0/10) within 30 s.
+        write_run = self.create_checkpointing_run_with_command(
+            mock_logger, num_reads=0, num_writes=10, command="run"
+        )
+        write_run._data.run_datetime = "20260715_071751"
+        write_run._data.end_datetime = "20260715_071800"
+        read_run = self.create_checkpointing_run_with_command(
+            mock_logger, num_reads=10, num_writes=0, command="run"
+        )
+        read_run._data.run_datetime = "20260715_071810"
+        datasize_run = self.create_checkpointing_run_with_command(
+            mock_logger, num_reads=10, num_writes=10, command="datasize"
+        )
+
+        checker = CheckpointSubmissionRulesChecker(
+            [datasize_run, write_run, read_run], logger=mock_logger
+        )
+        issues = checker.check_invocation_structure()
+
+        invalid = [i for i in issues if i.validation == PARAM_VALIDATION.INVALID]
+        assert invalid == [], (
+            f"Issue #791 regression: datasize counted as an invocation; "
+            f"got INVALID issues: {[i.message for i in invalid]}"
+        )
+
+    def test_check_invocation_structure_datasize_only_group_is_no_op(self, mock_logger):
+        """Issue #791: a group containing ONLY a ``datasize`` run emits no issues.
+
+        After the report-generator workload-key discriminator fix (parallel
+        to Issue #771), ``datasize`` runs land in their own workload
+        group. The checker must treat that group as a no-op rather than
+        rubber-stamp it as a valid single-invocation submission just
+        because the CLI defaults happen to be 10/10.
+        """
+        datasize_run = self.create_checkpointing_run_with_command(
+            mock_logger, num_reads=10, num_writes=10, command="datasize"
+        )
+
+        checker = CheckpointSubmissionRulesChecker(
+            [datasize_run], logger=mock_logger
+        )
+
+        assert checker.check_invocation_structure() == []
+        assert checker.check_num_runs() == []
+
 
 class TestRulesCheckerInitialization:
     """Tests for rules checker initialization order.


### PR DESCRIPTION
## Summary
- Extends the Issue #771 workload-key discriminator in `report_generator._derive_workload_key` to cover checkpointing, so non-`run` commands (notably `datasize`) land in their own workload group instead of colliding with the real `run` invocations.
- Filters `CheckpointSubmissionRulesChecker.check_num_runs` and `check_invocation_structure` to `command == 'run'` runs, and treats a datasize-only group as a no-op.

## Why
The reporter in #791 saw `reports reportgen` fail with:
- `CLOSED checkpointing submission must consist of 1 or 2 invocations (got 3)`
- `Expected 10 total read/write operations, but found 20`

on a legitimate two-invocation CLOSED submission that happened to be bundled with a `checkpointing datasize` preflight run. Two things went wrong: (1) the workload-key had no discriminator for non-`run` checkpointing commands, so datasize joined the run group; (2) `--num-checkpoints-read` / `--num-checkpoints-write` both default to `10` for every checkpointing subcommand, so the datasize run contributed a phantom 10/10 into the totals. Fix addresses both.

## Test plan
- [x] `tests/unit/test_rules_checkers.py::TestCheckpointSubmissionRulesChecker` — 3 new tests: datasize ignored in read/write totals, datasize ignored in invocation structure, datasize-only group is a no-op. All 7 in the class pass.
- [x] `tests/unit/test_aggregation.py::TestInvalidRulesStrict::test_checkpointing_datasize_does_not_inflate_run_group_count` — end-to-end regression: 1 datasize + write + read invocations produce 2 workload groups, not 1 group of 3.
- [x] Full CI matrix run locally: `tests/` (2913 passed), `mlpstorage_py/tests` (853 passed), `vdb_benchmark/tests` (174 passed), `kv_cache_benchmark/tests` (238 passed) — 4178 total, 0 failures.

Fixes #791.