### PR TITLE
fix(storage#792): reject invalid checkpointing --num-processes early; clarify §4.3.5 message

### DIFF
--- a/mlpstorage_py/rules/run_checkers/checkpointing.py
+++ b/mlpstorage_py/rules/run_checkers/checkpointing.py
@@ -6,7 +6,13 @@ Validates checkpointing benchmark parameters for individual runs.
 
 from typing import Optional
 
-from mlpstorage_py.config import BENCHMARK_TYPES, PARAM_VALIDATION, LLM_MODELS
+from mlpstorage_py.config import (
+    BENCHMARK_TYPES,
+    LLM_ALLOWED_VALUES,
+    LLM_MODELS,
+    LLM_SUBSET_PROCS,
+    PARAM_VALIDATION,
+)
 from mlpstorage_py.rules.issues import Issue
 from mlpstorage_py.rules.run_checkers.base import RunRulesChecker
 
@@ -42,3 +48,73 @@ class CheckpointingRunRulesChecker(RunRulesChecker):
                 actual=model
             )
         return None
+
+    def check_num_processes(self) -> Optional[Issue]:
+        """Fail-fast gate on --num-processes against Rules.md 4.6.1 / 4.6.4.
+
+        Per Rules.md §4.6.1 (Table 2), a CLOSED checkpointing submission for a
+        given LLM model must use *exactly* one of two process counts:
+          * ``LLM_SUBSET_PROCS`` (8) — the subset-run form (§4.3.5); or
+          * ``ClosedGPUs`` — the full-run form (8 / 64 / 512 / 1024 for
+            llama3-8b / -70b / -405b / -1t).
+
+        OPEN submissions (§4.6.4) may use any positive multiple of
+        ``GPUpDP`` (TP*PP).
+
+        Any other value — e.g. the ``51 hosts × 8 ranks = 408`` configuration
+        that surfaced in mlcommons/storage#792 — is neither a subset run nor
+        a full CLOSED run, and (for 405b) is not a multiple of TP*PP either,
+        so it cannot qualify for OPEN. Prior to this check the misconfiguration
+        was silently accepted at run time and only surfaced at
+        ``mlpstorage validate`` as the misleading "subset run requires exactly
+        8 accelerators, got 408" (auto-labeled by ``add_checkpoint_params`` in
+        benchmarks/dlio.py setting ``checkpoint.mode="subset"`` for any
+        downscaled run). Failing fast here saves the hours of wasted DLIO run
+        time between the misconfigured launch and the eventual validate call.
+
+        Silent-passes when model is not one of the four recognized LLMs;
+        ``check_model`` above owns that surface.
+        """
+        model = self.benchmark_run.model
+        if model not in LLM_ALLOWED_VALUES:
+            return None
+
+        num_processes = self.benchmark_run.num_processes
+        _min_procs, _zero_level, gpu_per_dp, closed_gpus = LLM_ALLOWED_VALUES[model]
+
+        if num_processes == closed_gpus or num_processes == LLM_SUBSET_PROCS:
+            return None
+
+        if num_processes > 0 and num_processes % gpu_per_dp == 0:
+            return Issue(
+                validation=PARAM_VALIDATION.OPEN,
+                message=(
+                    f"num_processes={num_processes} is not a valid CLOSED "
+                    f"configuration for {model}: Rules.md 4.6.1 requires "
+                    f"exactly {LLM_SUBSET_PROCS} (subset run) or "
+                    f"{closed_gpus} (full run). This value is a multiple of "
+                    f"TP*PP ({gpu_per_dp}), so it qualifies for OPEN only — "
+                    f"re-run with the 'open' positional argument."
+                ),
+                parameter="num_processes",
+                expected=f"{LLM_SUBSET_PROCS} or {closed_gpus}",
+                actual=num_processes,
+            )
+
+        return Issue(
+            validation=PARAM_VALIDATION.INVALID,
+            message=(
+                f"num_processes={num_processes} is not a valid checkpointing "
+                f"configuration for {model}. Rules.md 4.6.1 requires "
+                f"exactly {LLM_SUBSET_PROCS} (subset run per §4.3.5) or "
+                f"{closed_gpus} (full CLOSED run) processes; §4.6.4 allows "
+                f"any positive multiple of TP*PP ({gpu_per_dp}) for OPEN. "
+                f"For a {model} run distributed across N hosts, choose an "
+                f"hosts × ranks-per-host product that lands on one of these "
+                f"values."
+            ),
+            parameter="num_processes",
+            expected=f"{LLM_SUBSET_PROCS} or {closed_gpus} (CLOSED); "
+                     f"positive multiple of {gpu_per_dp} (OPEN)",
+            actual=num_processes,
+        )

--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -505,6 +505,16 @@ class CheckpointingCheck(BaseCheck):
         """
         For subset runs, verify exactly 8 accelerators and not 8B model.
         (Rules.md 4.3.5)
+
+        Note (mlcommons/storage#792): ``checkpoint.mode == "subset"`` in
+        ``override_parameters`` is auto-set by
+        ``mlpstorage_py.benchmarks.dlio.CheckpointingBenchmark.add_checkpoint_params``
+        for *any* run where ``num_processes < ClosedGPUs`` — not just genuine
+        8-accelerator subset runs. So this branch also fires for CLOSED
+        misconfigurations that landed between subset (8) and full
+        (ClosedGPUs) — e.g. 51 hosts × 8 ranks = 408 processes for 405b. The
+        error message calls out both valid submission forms so the user isn't
+        misled into thinking they explicitly opted into subset mode.
         """
         valid = True
         if self.mode != "checkpointing":
@@ -519,11 +529,32 @@ class CheckpointingCheck(BaseCheck):
                 model_name = metadata.get("args", {}).get("model", "").lower()
 
                 if num_accelerators != 8:
-                    self.log_violation(
-                        "4.3.5", "checkpointSubsetRunValidation", self.path,
-                        "subset run requires exactly 8 accelerators, got %d",
-                        num_accelerators,
-                    )
+                    model_size = re.search(r"(8b|70b|405b|1t)", model_name)
+                    if model_size:
+                        model_key = model_size.group(1)
+                        try:
+                            required_closed = self.config.get_closed_mpi_processes(model_key)
+                        except (KeyError, AttributeError):
+                            required_closed = None
+                    else:
+                        required_closed = None
+
+                    if required_closed is not None:
+                        self.log_violation(
+                            "4.3.5", "checkpointSubsetRunValidation", self.path,
+                            "num_accelerators=%d does not match any valid CLOSED "
+                            "submission form for %s: Rules.md 4.6.1 requires "
+                            "exactly 8 (subset run per 4.3.5) or %d (full run). "
+                            "The 'subset' label was auto-set by mlpstorage for "
+                            "this downscaled run — see mlcommons/storage#792.",
+                            num_accelerators, model_name, required_closed,
+                        )
+                    else:
+                        self.log_violation(
+                            "4.3.5", "checkpointSubsetRunValidation", self.path,
+                            "subset run requires exactly 8 accelerators, got %d",
+                            num_accelerators,
+                        )
                     valid = False
 
                 if "8b" in model_name:

--- a/mlpstorage_py/tests/test_issue792_checkpoint_num_processes.py
+++ b/mlpstorage_py/tests/test_issue792_checkpoint_num_processes.py
@@ -1,0 +1,274 @@
+"""
+Regression tests for mlcommons/storage#792.
+
+The reporter ran ``mlpstorage closed checkpointing run file`` with
+``--num-processes 408`` for llama3-405b (51 hosts × 8 ranks). Rules.md §4.6.1
+requires *exactly* 512 (full run) or 8 (subset run per §4.3.5) processes for
+that model in CLOSED. 408 is neither.
+
+Two things went wrong before the fix:
+
+1. **No fail-fast gate.** ``CheckpointingRunRulesChecker`` did not validate
+   ``num_processes``, so DLIO ran the full write+read pair (many minutes to
+   hours of I/O time) before ``mlpstorage validate`` eventually rejected it.
+
+2. **Misleading post-hoc message.** ``add_checkpoint_params`` in
+   ``benchmarks/dlio.py`` auto-labels *any* downscaled run
+   (``num_processes < ClosedGPUs``) with ``checkpoint.mode="subset"`` so DLIO
+   applies the ``model.parallelism.data`` override. At validation time
+   §4.3.5 saw the ``subset`` label and reported "subset run requires exactly
+   8 accelerators, got 408" — implying the user had opted into subset mode
+   when in fact the tool had auto-labeled it.
+
+This module covers both fixes:
+
+* ``TestCheckNumProcessesFailFast`` — new
+  ``CheckpointingRunRulesChecker.check_num_processes`` returns INVALID/OPEN
+  for the misconfigured process counts and None for the two valid CLOSED
+  forms per model.
+* ``TestSubsetRunValidationClarifiedMessage`` — §4.3.5 error now names
+  both valid CLOSED submission forms (8 subset OR ClosedGPUs full) when the
+  auto-set ``subset`` label surfaces on a run that isn't actually a
+  8-accelerator subset run.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mlpstorage_py.config import (
+    BENCHMARK_TYPES,
+    LLAMA3_1T,
+    LLAMA3_8B,
+    LLAMA3_70B,
+    LLAMA3_405B,
+    LLM_SUBSET_PROCS,
+    PARAM_VALIDATION,
+)
+from mlpstorage_py.rules import (
+    BenchmarkRun,
+    BenchmarkRunData,
+    CheckpointingRunRulesChecker,
+)
+from mlpstorage_py.submission_checker.checks.checkpointing_checks import (
+    CheckpointingCheck,
+)
+from mlpstorage_py.submission_checker.configuration.configuration import Config
+from mlpstorage_py.submission_checker.loader import Loader
+from mlpstorage_py.tests.conftest import build_submission
+
+
+# ---------------------------------------------------------------------------
+# Fixture: sample checkpointing BenchmarkRun for the pre-run checker
+# ---------------------------------------------------------------------------
+
+def _make_chkpt_run(model: str, num_processes: int, logger) -> BenchmarkRun:
+    data = BenchmarkRunData(
+        benchmark_type=BENCHMARK_TYPES.checkpointing,
+        model=model,
+        command="run",
+        run_datetime="20260715_071751",
+        num_processes=num_processes,
+        parameters={},
+        override_parameters={},
+    )
+    return BenchmarkRun.from_data(data, logger)
+
+
+class TestCheckNumProcessesFailFast:
+    """Pre-run gate that stops misconfigured runs before DLIO starts.
+
+    Rules.md §4.6.1 (Table 2) — required CLOSED process counts:
+        llama3-8b   → 8
+        llama3-70b  → 64
+        llama3-405b → 512
+        llama3-1t   → 1024
+    §4.3.5 subset form → 8 processes (any model except 8b — that constraint
+    is enforced by ``subset_run_validation``, not here).
+    """
+
+    @pytest.fixture
+    def mock_logger(self):
+        return MagicMock()
+
+    # ------------------ CLOSED-valid cases return None -------------------
+
+    @pytest.mark.parametrize("model,closed_gpus", [
+        (LLAMA3_8B, 8),
+        (LLAMA3_70B, 64),
+        (LLAMA3_405B, 512),
+        (LLAMA3_1T, 1024),
+    ])
+    def test_full_closed_run_passes(self, mock_logger, model, closed_gpus):
+        run = _make_chkpt_run(model, closed_gpus, mock_logger)
+        checker = CheckpointingRunRulesChecker(run, logger=mock_logger)
+        assert checker.check_num_processes() is None
+
+    @pytest.mark.parametrize("model", [LLAMA3_70B, LLAMA3_405B, LLAMA3_1T])
+    def test_subset_run_passes(self, mock_logger, model):
+        run = _make_chkpt_run(model, LLM_SUBSET_PROCS, mock_logger)
+        checker = CheckpointingRunRulesChecker(run, logger=mock_logger)
+        assert checker.check_num_processes() is None
+
+    # ------------------ The reporter's exact scenario --------------------
+
+    def test_issue792_405b_408procs_is_invalid(self, mock_logger):
+        """51 hosts × 8 ranks = 408 for llama3-405b — the exact reporter case."""
+        run = _make_chkpt_run(LLAMA3_405B, 408, mock_logger)
+        checker = CheckpointingRunRulesChecker(run, logger=mock_logger)
+        issue = checker.check_num_processes()
+
+        assert issue is not None
+        assert issue.validation == PARAM_VALIDATION.INVALID
+        # The error must name both valid CLOSED forms so the user isn't left
+        # guessing which knob to turn.
+        assert "8" in issue.message
+        assert "512" in issue.message
+        assert issue.parameter == "num_processes"
+        assert issue.actual == 408
+
+    # -------------- OPEN-only path (multiple of TP*PP) -------------------
+
+    def test_open_only_multiple_of_tp_pp(self, mock_logger):
+        """For 405b, TP*PP=256. num_processes=256 is a multiple → OPEN-only.
+
+        This case matters because reporting INVALID here would push a
+        submitter into the ``--allow-invalid-params`` / re-run cycle when
+        their run *is* a valid OPEN submission. The check should tell them
+        to re-run under the 'open' positional instead.
+        """
+        run = _make_chkpt_run(LLAMA3_405B, 256, mock_logger)
+        checker = CheckpointingRunRulesChecker(run, logger=mock_logger)
+        issue = checker.check_num_processes()
+
+        assert issue is not None
+        assert issue.validation == PARAM_VALIDATION.OPEN
+        assert "open" in issue.message.lower()
+
+    # -------------- Non-LLM model silent-passes --------------------------
+
+    def test_unrecognized_model_silent_passes(self, mock_logger):
+        """``check_model`` owns the unknown-model surface — don't double-report."""
+        run = _make_chkpt_run("unet3d", 408, mock_logger)
+        checker = CheckpointingRunRulesChecker(run, logger=mock_logger)
+        assert checker.check_num_processes() is None
+
+    # -------------- Method discovered by run_checks ----------------------
+
+    def test_check_is_discovered_by_run_checks(self, mock_logger):
+        run = _make_chkpt_run(LLAMA3_405B, 512, mock_logger)
+        checker = CheckpointingRunRulesChecker(run, logger=mock_logger)
+        method_names = [m.__name__ for m in checker.check_methods]
+        assert "check_num_processes" in method_names
+
+
+# ---------------------------------------------------------------------------
+# Post-hoc submission-validator message (§4.3.5)
+# ---------------------------------------------------------------------------
+
+def _inject_override_params_into_chkpt_metadata(root: Path, params: dict) -> None:
+    """Post-fixture: set override_parameters on every checkpoint metadata.json.
+
+    Mirrors ``_inject_yaml_params_into_chkpt_metadata`` from
+    ``test_checkpointing_check_retrofit.py`` — the shared conftest fixture
+    doesn't expose a knob for override_parameters on checkpointing runs, so
+    tests that need to trip auto-subset labeling do it out-of-band.
+    """
+    for meta_path in Path(root).rglob("checkpointing/*/*/metadata.json"):
+        meta = json.loads(meta_path.read_text())
+        meta["override_parameters"] = params
+        meta_path.write_text(json.dumps(meta))
+
+
+def _inject_summary_num_accelerators(root: Path, num_accelerators: int) -> None:
+    """Post-fixture: set ``num_accelerators`` in every checkpoint summary.json."""
+    for summ_path in Path(root).rglob("checkpointing/*/*/summary.json"):
+        summ = json.loads(summ_path.read_text())
+        summ["num_accelerators"] = num_accelerators
+        summ_path.write_text(json.dumps(summ))
+
+
+def _run_checkpointing_check(root: Path, mock_logger):
+    config = Config(version="v2.0", submitters=["Acme"], skip_output_file=True)
+    loader = Loader(config=config, root=str(root), version="v2.0")
+    for logs in loader.load():
+        if logs.loader_metadata.mode == "checkpointing":
+            return CheckpointingCheck(
+                log=mock_logger, config=config, submissions_logs=logs
+            )
+    raise AssertionError("no checkpointing SubmissionLogs from fixture")
+
+
+class TestSubsetRunValidationClarifiedMessage:
+    """§4.3.5 error message clarity for auto-labeled ``subset`` runs.
+
+    The reporter's run landed here with num_accelerators=408 and the
+    auto-set ``checkpoint.mode="subset"`` override. Post-fix the emitted
+    violation must:
+
+      * still fail the check (subset ≠ 8 is a genuine rule violation), and
+      * name both valid CLOSED submission forms (8 or ClosedGPUs) so the
+        user can see which knob to turn.
+    """
+
+    def test_405b_408_accelerators_message_lists_both_valid_forms(
+        self, tmp_path, mock_logger
+    ):
+        # Build a submission with llama3-405b and inject the exact failure state.
+        root = build_submission(
+            tmp_path,
+            chkpt_model="llama3-405b",
+            chkpt_closed_num_processes=408,
+        )
+        _inject_override_params_into_chkpt_metadata(
+            root, {"checkpoint.mode": "subset"}
+        )
+        _inject_summary_num_accelerators(root, 408)
+
+        check = _run_checkpointing_check(root, mock_logger)
+        ok = check.subset_run_validation()
+
+        assert ok is False, "auto-subset labeling with !=8 accelerators must fail"
+
+        errors = [c for c in mock_logger.method_calls if c[0] == "error"]
+        assert errors, f"expected an error to be logged; got {mock_logger.method_calls}"
+        joined = " ".join(str(c) for c in errors)
+        # Message names the CLOSED subset form (8) …
+        assert "8" in joined, joined
+        # … the full CLOSED form for the specific model (512 for 405b) …
+        assert "512" in joined, joined
+        # … and points the reader at the underlying auto-labeling behavior.
+        assert "auto-set" in joined or "storage#792" in joined, joined
+
+    def test_genuine_subset_run_still_passes(self, tmp_path, mock_logger):
+        """Regression guard: a real 8-accelerator subset run (for 405b) does
+        NOT get flagged. This locks the message change to the misconfig path
+        and not the happy path.
+        """
+        root = build_submission(
+            tmp_path,
+            chkpt_model="llama3-405b",
+            chkpt_closed_num_processes=LLM_SUBSET_PROCS,  # 8
+        )
+        _inject_override_params_into_chkpt_metadata(
+            root, {"checkpoint.mode": "subset"}
+        )
+        _inject_summary_num_accelerators(root, LLM_SUBSET_PROCS)
+
+        check = _run_checkpointing_check(root, mock_logger)
+        ok = check.subset_run_validation()
+
+        assert ok is True
+        errors = [c for c in mock_logger.method_calls if c[0] == "error"]
+        assert not errors, f"unexpected errors on happy-path subset run: {errors}"
+
+
+# Fixture at module scope so the class methods can share it.
+@pytest.fixture
+def mock_logger():
+    return MagicMock()


### PR DESCRIPTION
Closes #792.

## The reporter's scenario

Ran `mlpstorage closed checkpointing run file --num-processes 408` for
llama3-405b (51 hosts × 8 ranks). Rules.md §4.6.1 requires exactly **8**
(subset per §4.3.5) or **512** (full) processes for 405b in CLOSED. 408 is
neither. The tool accepted the run, DLIO wrote and read 10 checkpoints,
and `mlpstorage validate` then reported the confusing error:

    [ERROR] [4.3.5 checkpointSubsetRunValidation] ...: subset run
    requires exactly 8 accelerators, got 408

## Two root causes

**1. No fail-fast gate.** `CheckpointingRunRulesChecker`
(`mlpstorage_py/rules/run_checkers/checkpointing.py`) only checked
`benchmark_type` and `model`. `num_processes` was never validated, so a
misconfigured CLOSED run consumed hours of I/O time before eventual
rejection at validate.

**2. Misleading post-hoc message.**
`CheckpointingBenchmark.add_checkpoint_params` in
`mlpstorage_py/benchmarks/dlio.py:1104-1111` auto-labels *any* downscaled
run (`num_processes < ClosedGPUs`) with `checkpoint.mode="subset"` so
DLIO applies the `model.parallelism.data` override. §4.3.5 then saw the
`subset` label and reported the accelerator count against the subset
rule — implying the user had explicitly opted into subset mode.

## Fix

- **`mlpstorage_py/rules/run_checkers/checkpointing.py`** — new
  `check_num_processes`. Returns `None` for the two valid CLOSED forms
  (`LLM_SUBSET_PROCS` = 8 or `ClosedGPUs` per model), `Issue(OPEN)` when
  the count is a positive multiple of `TP*PP` (§4.6.4 — prompts the
  user to re-run under the `open` positional), and `Issue(INVALID)`
  otherwise. The INVALID message names both valid CLOSED forms so the
  user sees which knob to turn. Silent-pass for non-LLM models (that
  surface is owned by `check_model`).

- **`mlpstorage_py/submission_checker/checks/checkpointing_checks.py`** —
  §4.3.5 subset-run message now names the specific model's two valid
  CLOSED forms (e.g. "requires exactly 8 (subset) or 512 (full)") and
  cites the auto-labeling behavior. Users with existing invalid results
  get a clearer message. Genuine 8-accelerator subset runs and
  non-LLM/unknown-model paths keep the original message.

## Tests

`mlpstorage_py/tests/test_issue792_checkpoint_num_processes.py` — 13 new
tests:

- **Pre-run gate** — full CLOSED for all four models (8, 64, 512, 1024);
  subset (8) for 70b/405b/1t; the exact 408×405b reporter case →
  INVALID with both 8 and 512 in the message; 256×405b → OPEN with
  re-run instruction; non-LLM model → silent-pass; method-discovery
  guard.
- **Clarified §4.3.5 message** — asserts both `8` and `512` appear for
  the 408×405b case; genuine 8-accelerator subset run still passes
  (locks the change to the misconfig path only).

## Test plan

- [x] `uv run pytest mlpstorage_py/tests/test_issue792_checkpoint_num_processes.py` — 13/13 pass
- [x] `uv run pytest mlpstorage_py/tests tests/unit` — 3611 passed, 1 skipped (unchanged from baseline)
- [ ] Manual: attempt `mlpstorage closed checkpointing run file --num-processes 408 --model llama3-405b …` and confirm the run aborts pre-DLIO with the new error message naming both valid forms.
- [ ] Manual: re-validate an existing invalid results dir (like the reporter's) and confirm the new §4.3.5 message references both valid forms and storage#792.