### PR TITLE
fix: use ceil for minimum num_files_train (rule 3.1.2)

### DIFF
--- a/mlpstorage_py/rules/utils.py
+++ b/mlpstorage_py/rules/utils.py
@@ -5,6 +5,7 @@ This module contains helper functions used by rules checkers and other
 components for calculating requirements and generating output paths.
 """
 
+import math
 import os
 import re
 import sys
@@ -181,12 +182,17 @@ def calculate_training_data_size(args, cluster_information, dataset_params, read
     file_size_bytes = dataset_params['num_samples_per_file'] * record_length_bytes
 
     if file_size_bytes > 0:
-        min_num_files_by_bytes = dataset_size_bytes // file_size_bytes
+        # Ceil, not floor: the rule requires *at least* dataset_size_bytes
+        # (5x total host memory). Floor division would silently produce a
+        # dataset one file short of the minimum whenever dataset_size_bytes
+        # is not an exact multiple of file_size_bytes, which the submission
+        # checker (float compare in rule 3.1.2) then rejects.
+        min_num_files_by_bytes = math.ceil(dataset_size_bytes / file_size_bytes)
     else:
         min_num_files_by_bytes = 0
     num_samples_by_bytes = min_num_files_by_bytes * dataset_params['num_samples_per_file']
     min_samples = 500 * num_processes * reader_params['batch_size']
-    min_num_files_by_samples = min_samples // dataset_params['num_samples_per_file']
+    min_num_files_by_samples = math.ceil(min_samples / dataset_params['num_samples_per_file'])
 
     required_file_count = max(min_num_files_by_bytes, min_num_files_by_samples)
     total_disk_bytes = required_file_count * file_size_bytes

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -22,6 +22,7 @@ from mlpstorage_py.rules.run_checkers.training import (
 )
 _TOOL_INJECTED_PARAMS = _TrainingRunRulesChecker.TOOL_INJECTED_PARAMS
 
+import math
 import os
 import hashlib
 import re
@@ -191,9 +192,14 @@ class TrainingCheck(BaseCheck):
                 min_samples_memory = (total_host_memory * HOST_MEMORY_MULTIPLIER *
                                     1024 * 1024 * 1024 / record_length)
 
-                # Take max of both constraints
+                # Take max of both constraints. The memory-derived branch is
+                # a float, so ceil (not floor/int cast) to stay in lockstep
+                # with datagen (rules/utils.py) — otherwise a dataset sized
+                # to the floor passes runtime but fails this check by a
+                # single file, and the message would read "N < N" because
+                # int(min_total_files) truncates the float.
                 min_samples = max(min_samples_steps, min_samples_memory)
-                min_total_files = min_samples / num_samples_per_file
+                min_total_files = math.ceil(min_samples / num_samples_per_file)
                 min_files_size_gb = min_samples * record_length / 1024 / 1024 / 1024
 
                 # Verify actual matches expected
@@ -203,7 +209,7 @@ class TrainingCheck(BaseCheck):
                         "3.1.2", "trainingRecalculateDatasetSize", self.path,
                         "dataset size mismatch: actual files %d < minimum required %d",
                         actual_num_files,
-                        int(min_total_files),
+                        min_total_files,
                     )
                     valid = False
 


### PR DESCRIPTION
## Summary

- Rule 3.1.2's memory-derived minimum (`5 × host_memory / record_length / samples_per_file`) is a float. Datagen and the runtime verifier were truncating to floor via `//` and `int()`, so a dataset sized to the floor passed at runtime but the post-submission checker re-derived the threshold as a float and rejected the same dataset by a single file.
- The submission-checker error message also `int()`-truncated the float, producing a confusing `"4710038 < 4710038"`.
- Fix: use `math.ceil` for `min_num_files_by_bytes` and `min_num_files_by_samples` in `rules/utils.py`, and for `min_total_files` in the 3.1.2 check. All three sites (datasize/dry-run, runtime verifier, submission checker) now agree.

## Note

This is a retroactive review PR. Commit `f9d414d` was already pushed to `main` (bypassing the PR requirement). The base of this PR (`review-base/pre-ceil-fix`) points at `90bc58e`, the parent of the fix, so the diff is viewable for review.

## Test plan

- [x] `uv run pytest tests` — 2913 passed
- [x] `uv run pytest mlpstorage_py/tests` — 853 passed
- [x] `uv run pytest vdb_benchmark/tests` — 174 passed
- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed