### PR TITLE
fix(storage#795): align datasize output and fail-fast on flat storage_options typos

### DIFF
--- a/mlpstorage_py/benchmarks/dlio.py
+++ b/mlpstorage_py/benchmarks/dlio.py
@@ -287,7 +287,7 @@ class DLIOBenchmark(Benchmark, abc.ABC):
             return 1_000
         return 10_000
 
-    def _apply_skip_listing_params(self):
+    def _apply_skip_listing_params(self, num_files_override: Optional[int] = None):
         """Inject skip_listing=True and an adaptive listing_validation_interval.
 
         Applies to both file and object storage.  skip_listing is safe whenever
@@ -302,16 +302,31 @@ class DLIOBenchmark(Benchmark, abc.ABC):
         ~100 s even at 50 M files.
 
         Both params respect user --params overrides.
+
+        storage#795: for the ``datasize`` command the workload YAML default
+        for ``num_files_train`` is *not* what the user will use downstream —
+        ``datasize`` computes a DRAM-derived recommendation that supersedes
+        it. Callers on the datasize path pass ``num_files_override`` after
+        the recommendation is known so the emitted interval and the INFO log
+        agree with the number reported on the ``Number of training files:``
+        result line and the ``num_files_train=`` value in the datagen-command
+        hint.
         """
         if 'dataset.skip_listing' not in self.params_dict:
             self.params_dict['dataset.skip_listing'] = 'True'
 
         if 'dataset.listing_validation_interval' not in self.params_dict:
-            raw = (self.combined_params or {}).get('dataset', {}).get('num_files_train', 0)
-            try:
-                num_files = int(raw)
-            except (ValueError, TypeError):
-                num_files = 0
+            if num_files_override is not None:
+                try:
+                    num_files = int(num_files_override)
+                except (ValueError, TypeError):
+                    num_files = 0
+            else:
+                raw = (self.combined_params or {}).get('dataset', {}).get('num_files_train', 0)
+                try:
+                    num_files = int(raw)
+                except (ValueError, TypeError):
+                    num_files = 0
             interval = self._compute_validation_interval(num_files)
             self.params_dict['dataset.listing_validation_interval'] = str(interval)
             checks = (num_files // interval) + 2 if interval > 0 and num_files > 0 else num_files
@@ -676,7 +691,13 @@ class TrainingBenchmark(DLIOBenchmark):
         self._apply_odirect_params(storage_root=getattr(self.args, 'data_dir', None))
         # Enable skip_listing for all storage types (file and object).  Must be
         # called after _apply_object_storage_params so combined_params is final.
-        self._apply_skip_listing_params()
+        # storage#795: skip during ``datasize`` — the YAML default for
+        # num_files_train is not what the user will use; the interval and
+        # INFO log must be derived from the recommendation, which is not
+        # computed until ``datasize()`` runs. The datasize path calls this
+        # method itself once the recommendation is known.
+        if self.args.command != "datasize":
+            self._apply_skip_listing_params()
 
         if self.args.command not in ("datagen", "datasize"):
             self.verify_benchmark()
@@ -949,6 +970,14 @@ class TrainingBenchmark(DLIOBenchmark):
         # datagen actual bytes) can read the datasize sentinel end-to-end
         # from datasize/<ts>/*_metadata.json. See Rules.md §3.3.1.
         self.params_dict['dataset.total_disk_bytes'] = int(total_disk_bytes)
+
+        # storage#795: now that the DRAM-derived recommendation is known,
+        # inject skip_listing/listing_validation_interval so the INFO log,
+        # the num_files_train value on the result line below, and the
+        # params baked into the emitted datagen-command hint all agree.
+        # The __init__ call was skipped for datasize precisely so this
+        # deferred call could use the correct num_files_train.
+        self._apply_skip_listing_params(num_files_override=num_files_train)
 
         self.logger.result(f'Number of training files: {num_files_train}')
         self.logger.result(f'Number of training subfolders: {num_subfolders_train}')

--- a/mlpstorage_py/cli_parser.py
+++ b/mlpstorage_py/cli_parser.py
@@ -361,6 +361,32 @@ def update_args(args):
                 "  Multiple overrides: --params A=1 B=2 C=3"
             )
             sys.exit(EXIT_CODE.INVALID_ARGUMENTS)
+
+        # storage#795: reject known-typo dotted keys at CLI-parse time so the
+        # user doesn't wait through MPI cluster collection, code-image
+        # capture, and results-directory creation only to be told the
+        # parameter was disallowed. All three keys are auto-injected by the
+        # tool in --object mode, so the user typically does not need to pass
+        # them at all.
+        from mlpstorage_py.rules.param_hints import KNOWN_PARAM_TYPOS
+        typo_hits = []
+        for tok in flattened_params:
+            key = tok.split('=', 1)[0]
+            canonical = KNOWN_PARAM_TYPOS.get(key)
+            if canonical:
+                typo_hits.append((key, canonical))
+        if typo_hits:
+            lines = ["Error: --params contains dotted key(s) that are not real DLIO parameters:"]
+            for typed, canonical in typo_hits:
+                lines.append(f"  '{typed}' → did you mean '{canonical}'?")
+            lines.append(
+                "  Note: storage.storage_options.* keys are auto-injected by "
+                "the tool in --object mode; you typically do not need to pass "
+                "them explicitly."
+            )
+            print("\n".join(lines))
+            sys.exit(EXIT_CODE.INVALID_ARGUMENTS)
+
         setattr(args, 'params', flattened_params)
 
     if hasattr(args, 'mpi_params') and args.mpi_params:

--- a/mlpstorage_py/rules/param_hints.py
+++ b/mlpstorage_py/rules/param_hints.py
@@ -1,0 +1,45 @@
+"""Known-typo hints for DLIO ``--params`` keys.
+
+When a user types a param path that's syntactically similar to a real DLIO
+config key but is missing an intermediate node (a common mistake for the
+nested ``storage.storage_options.*`` family), fail fast at CLI parse time
+with the canonical spelling. Also used as a fallback hint in the runtime
+and submission-checker disallowed-override messages so users who hit those
+paths (e.g. re-validating an older result) still see the suggestion.
+
+See storage#795 for the reporter case: a user passed
+``--params storage.storage_library=s3dlio``, expecting it to configure
+DLIO's storage backend. It did not — DLIO's config uses the nested
+``storage.storage_options.storage_library`` key, and the flat form was
+a stray parameter that a) had zero effect on the run (the tool auto-
+injects the nested key from ``STORAGE_LIBRARY`` env in ``--object`` mode)
+and b) tripped the CLOSED-mode disallowed-override check.
+
+The map is intentionally small: only paths that have been seen typed
+incorrectly by real users. Do not add every conceivable typo — the
+value of this hint depends on it staying targeted, not exhaustive.
+"""
+
+# Map of user-typed dotted key -> canonical DLIO dotted key.
+KNOWN_PARAM_TYPOS = {
+    # storage#795: reporter dropped the ``storage_options.`` middle segment
+    # for all three ``storage.storage_options.*`` keys. All three are auto-
+    # injected by ``_apply_object_storage_params`` in ``--object`` mode, so
+    # the user typically does not need to pass them at all.
+    'storage.storage_library': 'storage.storage_options.storage_library',
+    'storage.uri_scheme': 'storage.storage_options.uri_scheme',
+    'storage.prefetch_window': 'storage.storage_options.prefetch_window',
+}
+
+
+def format_typo_hint(user_key: str) -> str:
+    """Return a ``' Did you mean X?'`` suffix for known-typo keys, else ''.
+
+    Callers append this to their existing error message so the hint reads as
+    a natural continuation. Returns the empty string for unknown keys so
+    the caller can concatenate unconditionally.
+    """
+    canonical = KNOWN_PARAM_TYPOS.get(user_key)
+    if not canonical:
+        return ''
+    return f" Did you mean '{canonical}'?"

--- a/mlpstorage_py/rules/run_checkers/training.py
+++ b/mlpstorage_py/rules/run_checkers/training.py
@@ -8,6 +8,7 @@ from typing import Optional, List
 
 from mlpstorage_py.config import BENCHMARK_TYPES, PARAM_VALIDATION, UNET, DLRM, RETINANET, FLUX, MODELS
 from mlpstorage_py.rules.issues import Issue
+from mlpstorage_py.rules.param_hints import format_typo_hint
 from mlpstorage_py.rules.run_checkers.base import RunRulesChecker
 from mlpstorage_py.rules.utils import calculate_training_data_size
 
@@ -202,9 +203,15 @@ class TrainingRunRulesChecker(RunRulesChecker):
                     actual=value
                 ))
             else:
+                # storage#795: append a "Did you mean X?" hint for known-typo
+                # dotted keys (e.g. flat ``storage.storage_library`` instead
+                # of nested ``storage.storage_options.storage_library``). The
+                # CLI-parse-time gate catches these before the run starts,
+                # but this path still fires when re-validating older results
+                # whose metadata already contains the typo.
                 issues.append(Issue(
                     validation=PARAM_VALIDATION.INVALID,
-                    message=f"Disallowed parameter override: {param} = {value}",
+                    message=f"Disallowed parameter override: {param} = {value}.{format_typo_hint(param)}",
                     parameter="Overrode Parameters",
                     expected="None",
                     actual=value

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -20,6 +20,7 @@ from .helpers import (
 from mlpstorage_py.rules.run_checkers.training import (
     TrainingRunRulesChecker as _TrainingRunRulesChecker,
 )
+from mlpstorage_py.rules.param_hints import format_typo_hint
 _TOOL_INJECTED_PARAMS = _TrainingRunRulesChecker.TOOL_INJECTED_PARAMS
 
 import math
@@ -793,10 +794,16 @@ class TrainingCheck(BaseCheck):
                     if param_key in _TOOL_INJECTED_PARAMS:
                         continue
                     if param_key not in allowed_params:
+                        # storage#795: append "Did you mean X?" for known
+                        # typo keys so ``mlpstorage validate`` on a stored
+                        # submission that carries the typo surfaces the
+                        # same suggestion the CLI-parse gate emits for new
+                        # runs.
                         self.log_violation(
                             "3.6.2", "trainingClosedSubmissionParameters", self.path,
-                            "CLOSED submission modifies disallowed parameter: %s",
+                            "CLOSED submission modifies disallowed parameter: %s%s",
                             param_key,
+                            format_typo_hint(param_key),
                         )
                         valid = False
 
@@ -856,10 +863,12 @@ class TrainingCheck(BaseCheck):
                     if param_key in _TOOL_INJECTED_PARAMS:
                         continue
                     if param_key not in allowed_params:
+                        # storage#795: same "Did you mean X?" hint as 3.6.2.
                         self.log_violation(
                             "3.6.3", "trainingOpenSubmissionParameters", self.path,
-                            "OPEN submission modifies disallowed parameter: %s",
+                            "OPEN submission modifies disallowed parameter: %s%s",
                             param_key,
+                            format_typo_hint(param_key),
                         )
                         valid = False
 

--- a/tests/unit/test_param_typo_hints.py
+++ b/tests/unit/test_param_typo_hints.py
@@ -1,0 +1,218 @@
+"""
+Regression tests for storage#795 (bug 3): flat ``storage.storage_library``
+and its two siblings are not real DLIO config keys — the real form is nested
+under ``storage_options``. The reporter passed the flat form via ``--params``,
+which had zero effect on the run but tripped the CLOSED-mode disallowed-
+override check with a message that didn't hint at the correct spelling.
+
+Fix has three parts:
+
+ 1. CLI-parse-time fail-fast in ``parse_arguments`` so the user doesn't wait
+    through MPI cluster collection before being told the param is wrong.
+ 2. Runtime disallowed-override message (``TrainingRunRulesChecker
+    .check_allowed_params``) carries the "Did you mean X?" hint. Fires when
+    validating stored metadata that still contains the typo.
+ 3. Submission-checker rules 3.6.2 (CLOSED) and 3.6.3 (OPEN) carry the same
+    hint so ``mlpstorage validate`` on old submissions gives the same
+    suggestion.
+"""
+
+import shlex
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mlpstorage_py.rules.param_hints import KNOWN_PARAM_TYPOS, format_typo_hint
+
+
+# ---------------------------------------------------------------------------
+# The typo map itself
+# ---------------------------------------------------------------------------
+
+def test_reporter_case_is_covered():
+    """The exact flat key from the storage#795 reporter must map to the
+    nested canonical form. Guards against someone deleting the entry."""
+    assert KNOWN_PARAM_TYPOS['storage.storage_library'] == \
+        'storage.storage_options.storage_library'
+
+
+def test_all_typos_target_canonical_nested_form():
+    """Every entry must point at a real nested ``storage.storage_options.*``
+    path. Prevents drift where someone adds a typo → typo mapping."""
+    for typed, canonical in KNOWN_PARAM_TYPOS.items():
+        assert canonical.startswith('storage.storage_options.'), (
+            f"canonical for {typed!r} should be a nested storage_options.* "
+            f"key, got {canonical!r}"
+        )
+        assert typed != canonical, f"typo map maps {typed!r} to itself"
+
+
+def test_format_typo_hint_returns_suggestion_for_known_typo():
+    hint = format_typo_hint('storage.storage_library')
+    assert "Did you mean" in hint
+    assert 'storage.storage_options.storage_library' in hint
+
+
+def test_format_typo_hint_returns_empty_for_unknown_key():
+    """Caller concatenates unconditionally, so unknown keys must return ''
+    (not None) — otherwise the messages get 'None' appended in the log."""
+    assert format_typo_hint('dataset.num_files_train') == ''
+    assert format_typo_hint('completely.made.up') == ''
+
+
+# ---------------------------------------------------------------------------
+# Part 1: CLI-parse-time fail-fast
+# ---------------------------------------------------------------------------
+
+def _run_parse_and_update(argv, capsys):
+    """Invoke the pipeline as ``main.py`` does: parse_arguments → update_args.
+
+    The typo check lives in ``update_args`` (next to the existing --params
+    KEY=VALUE normalization), so both stages must run to reach it. We pass
+    --systemname and --results-dir explicitly on the CLI rather than via
+    env-var monkeypatching because ``DEFAULT_SYSTEMNAME`` / ``DEFAULT_
+    RESULTS_DIR`` are resolved once at module import time (config.py), so
+    late env-var changes don't reach the argparse defaults.
+    """
+    from mlpstorage_py.cli_parser import parse_arguments, update_args
+
+    with patch.object(sys, 'argv', argv):
+        with pytest.raises(SystemExit) as exc_info:
+            ns = parse_arguments()
+            update_args(ns)
+    captured = capsys.readouterr()
+    return captured.out, captured.err, exc_info.value.code
+
+
+def test_cli_parse_rejects_flat_storage_library_typo(capsys):
+    """The reporter's exact command shape must fail at parse time with a
+    "Did you mean" pointing at the nested key."""
+    argv = shlex.split(
+        "mlpstorage open training retinanet run object "
+        "--num-accelerators 1 --accelerator-type b200 "
+        "--client-host-memory-in-gb 15 --data-dir retinanet "
+        "--results-dir /tmp/results --systemname test-sys "
+        "--skip-validation "
+        "--params storage.storage_library=s3dlio"
+    )
+    stdout, _, code = _run_parse_and_update(argv, capsys)
+
+    assert code != 0, "parse must fail non-zero when a known typo is passed"
+    assert 'storage.storage_library' in stdout
+    assert "did you mean 'storage.storage_options.storage_library'?" in stdout
+    # Reminder that the user probably does not need this param at all.
+    assert 'auto-injected' in stdout
+
+
+def test_cli_parse_reports_multiple_typos_together(capsys):
+    """If a user typos more than one key at once, list all of them in a
+    single error rather than fail-fast on the first one — otherwise the
+    user fixes one, re-runs, and gets slapped by the next."""
+    argv = shlex.split(
+        "mlpstorage open training retinanet run object "
+        "--num-accelerators 1 --accelerator-type b200 "
+        "--client-host-memory-in-gb 15 --data-dir retinanet "
+        "--results-dir /tmp/results --systemname test-sys "
+        "--skip-validation "
+        "--params storage.storage_library=s3dlio storage.uri_scheme=s3"
+    )
+    stdout, _, code = _run_parse_and_update(argv, capsys)
+
+    assert code != 0
+    assert 'storage.storage_library' in stdout
+    assert 'storage.uri_scheme' in stdout
+    assert 'storage.storage_options.storage_library' in stdout
+    assert 'storage.storage_options.uri_scheme' in stdout
+
+
+def test_cli_parse_accepts_correct_nested_form(tmp_path):
+    """The canonical nested form must pass through the typo gate without
+    firing. Otherwise the fix creates a new bug — users who read the docs
+    and typed the right thing get rejected."""
+    from mlpstorage_py.cli_parser import parse_arguments, update_args
+
+    argv = shlex.split(
+        f"mlpstorage open training retinanet run object "
+        f"--num-accelerators 1 --accelerator-type b200 "
+        f"--client-host-memory-in-gb 15 --data-dir retinanet "
+        f"--results-dir {tmp_path} --systemname test-sys "
+        f"--skip-validation "
+        f"--params storage.storage_options.storage_library=s3dlio"
+    )
+    with patch.object(sys, 'argv', argv):
+        ns = parse_arguments()
+        update_args(ns)
+    # After update_args flattens, params is a flat list of KEY=VALUE tokens.
+    assert 'storage.storage_options.storage_library=s3dlio' in ns.params
+
+
+# ---------------------------------------------------------------------------
+# Part 2: Runtime disallowed-override message
+# ---------------------------------------------------------------------------
+
+def test_runtime_check_appends_hint_to_disallowed_override():
+    """The check still marks the param INVALID (correct), but the message
+    now names the canonical spelling so the user knows what to type
+    instead. Fires on ``mlpstorage validate`` against a stored result
+    whose metadata carries the typo — the CLI-parse gate does not help
+    for already-written metadata files."""
+    from mlpstorage_py.config import BENCHMARK_TYPES, PARAM_VALIDATION
+    from mlpstorage_py.rules.models import BenchmarkRun, BenchmarkRunData
+    from mlpstorage_py.rules.run_checkers.training import TrainingRunRulesChecker
+
+    data = BenchmarkRunData(
+        benchmark_type=BENCHMARK_TYPES.training,
+        model="retinanet",
+        command="run",
+        run_datetime="20260715_135049",
+        num_processes=1,
+        parameters={
+            "dataset": {"num_files_train": 257173},
+            "reader": {"read_threads": 1},
+        },
+        override_parameters={
+            "storage.storage_library": "s3dlio",  # the reporter's typo
+        },
+    )
+    logger = MagicMock()
+    run = BenchmarkRun.from_data(data, logger)
+    checker = TrainingRunRulesChecker(run, logger=logger)
+    issues = checker.check_allowed_params()
+
+    invalid = [i for i in issues if i.validation == PARAM_VALIDATION.INVALID]
+    assert len(invalid) == 1
+    assert 'storage.storage_library' in invalid[0].message
+    assert "Did you mean 'storage.storage_options.storage_library'?" in invalid[0].message
+
+
+def test_runtime_check_message_unchanged_for_unknown_typo():
+    """A disallowed param that isn't in the typo map must still be reported,
+    just without a "Did you mean" suffix. Guards against the hint suffix
+    leaking as a literal empty ' Did you mean ?' fragment."""
+    from mlpstorage_py.config import BENCHMARK_TYPES, PARAM_VALIDATION
+    from mlpstorage_py.rules.models import BenchmarkRun, BenchmarkRunData
+    from mlpstorage_py.rules.run_checkers.training import TrainingRunRulesChecker
+
+    data = BenchmarkRunData(
+        benchmark_type=BENCHMARK_TYPES.training,
+        model="retinanet",
+        command="run",
+        run_datetime="20260715_135049",
+        num_processes=1,
+        parameters={
+            "dataset": {"num_files_train": 257173},
+            "reader": {"read_threads": 1},
+        },
+        override_parameters={
+            "some.completely.made.up.key": "value",
+        },
+    )
+    logger = MagicMock()
+    run = BenchmarkRun.from_data(data, logger)
+    checker = TrainingRunRulesChecker(run, logger=logger)
+    issues = checker.check_allowed_params()
+
+    invalid = [i for i in issues if i.validation == PARAM_VALIDATION.INVALID]
+    assert len(invalid) == 1
+    assert 'Did you mean' not in invalid[0].message

--- a/tests/unit/test_skip_listing_datasize_interval.py
+++ b/tests/unit/test_skip_listing_datasize_interval.py
@@ -1,0 +1,103 @@
+"""
+Regression test for storage#795.
+
+When the ``datasize`` command runs, ``_apply_skip_listing_params`` must derive
+``dataset.listing_validation_interval`` and its INFO log from the DRAM-derived
+recommendation that ``datasize()`` computes — not from the workload YAML's
+``num_files_train`` default. Reading the YAML default (e.g. 1,170,301 for
+retinanet_b200) produced two visible defects:
+
+ 1. The datasize INFO log said "skip_listing enabled: 1,170,301 train files"
+    even though the ``Number of training files:`` result line seconds later
+    said 257,173. The two lines contradicted each other.
+ 2. The emitted ``mlpstorage ... datagen ...`` hint carried
+    ``dataset.listing_validation_interval=1000`` (correct bucket for 1.17M)
+    but ``dataset.num_files_train=257173`` — inconsistent params. A user
+    running the hint literally got an interval computed for a dataset 4.5x
+    larger than they actually generate.
+
+The fix threads a ``num_files_override`` argument through
+``_apply_skip_listing_params`` and calls it from ``datasize()`` after the
+recommendation lands in ``params_dict``. This test exercises the method
+directly with the override to make sure the interval bucket is chosen from
+the override, not from ``combined_params``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mlpstorage_py.benchmarks.dlio import TrainingBenchmark
+
+
+def _make_stub(*, combined_num_files_train, params_dict=None):
+    """Minimal shape ``_apply_skip_listing_params`` reads off ``self``.
+
+    ``_compute_validation_interval`` is a @staticmethod on the class, but the
+    method under test calls it as ``self._compute_validation_interval(...)``,
+    so the stub needs to route that lookup through to the real staticmethod.
+    """
+    return SimpleNamespace(
+        params_dict=dict(params_dict or {}),
+        combined_params={'dataset': {'num_files_train': combined_num_files_train}},
+        logger=MagicMock(),
+        _compute_validation_interval=TrainingBenchmark._compute_validation_interval,
+    )
+
+
+def test_override_takes_precedence_over_combined_params_default():
+    """The retinanet_b200 scenario from issue #795.
+
+    combined_params still holds the workload YAML default (1,170,301). If the
+    method reads combined_params, the interval bucket is 1,000 (right for
+    1.17M files). The datasize recommendation is 257,173 files, whose correct
+    bucket is 100. The override argument must win so the emitted interval
+    matches the num_files_train the user is actually going to use.
+    """
+    stub = _make_stub(combined_num_files_train=1_170_301)
+
+    TrainingBenchmark._apply_skip_listing_params(stub, num_files_override=257_173)
+
+    assert stub.params_dict['dataset.skip_listing'] == 'True'
+    assert stub.params_dict['dataset.listing_validation_interval'] == '100'
+
+    # The INFO log must also reflect the override, not the YAML default, or
+    # the user sees a "1,170,301 train files" message right above a
+    # "Number of training files: 257173" result line.
+    logged = ' '.join(str(call.args[0]) for call in stub.logger.info.call_args_list)
+    assert '257,173 train files' in logged
+    assert '1,170,301' not in logged
+    assert 'validation_interval=100' in logged
+
+
+def test_no_override_falls_back_to_combined_params():
+    """Non-datasize commands (run, datagen) still read the effective
+    num_files_train off combined_params — either the YAML default, or the
+    user's ``--params dataset.num_files_train=N`` override, which flows into
+    combined_params before ``__init__`` calls this method."""
+    stub = _make_stub(combined_num_files_train=50_000)
+
+    TrainingBenchmark._apply_skip_listing_params(stub)
+
+    # 50,000 files falls in the 10,000 <= n < 100,000 bucket → interval=10.
+    assert stub.params_dict['dataset.listing_validation_interval'] == '10'
+
+    logged = ' '.join(str(call.args[0]) for call in stub.logger.info.call_args_list)
+    assert '50,000 train files' in logged
+    assert 'validation_interval=10' in logged
+
+
+def test_override_respects_user_supplied_interval():
+    """If the user already set ``dataset.listing_validation_interval`` via
+    ``--params`` it must not be overwritten — the whole point of the guard
+    in the method. The override argument only decides what to compute *if*
+    the method is going to compute anything."""
+    stub = _make_stub(
+        combined_num_files_train=1_170_301,
+        params_dict={'dataset.listing_validation_interval': '42'},
+    )
+
+    TrainingBenchmark._apply_skip_listing_params(stub, num_files_override=257_173)
+
+    assert stub.params_dict['dataset.listing_validation_interval'] == '42'
+    # Since the guard short-circuited, no INFO log should have fired either.
+    assert stub.logger.info.call_count == 0


### PR DESCRIPTION
Closes #795.

## Summary

Reporter ran `mlpstorage open training retinanet datasize` for a b200/15GiB host and saw the recommendation "Number of training files: **257,173**" — but the log line one second earlier said "skip_listing enabled: **1,170,301** train files", and the emitted datagen-command hint bundled `num_files_train=257173` with `listing_validation_interval=1000` (right bucket for 1.17M, wrong for 257K). Their later `run` also failed with `Disallowed parameter override: storage.storage_library = s3dlio` when they tried to pass the storage backend explicitly.

Three related bugs, one PR:

1. **Datasize log/hint discrepancy**: `_apply_skip_listing_params` ran in `__init__` before `datasize()` computed its recommendation, so it read `num_files_train` from the workload YAML default (`retinanet_b200.yaml: 1170301`). Moved the call to fire in `datasize()` after the DRAM-derived recommendation lands in `params_dict`, threaded through as `num_files_override`. Now the INFO log, the `Number of training files:` result line, and the emitted datagen-hint's interval all agree.

2. **Emitted datagen-hint inconsistency**: same root cause — the hint's `listing_validation_interval` came from the pre-computed injection. Fixed by (1).

3. **Flat `storage.storage_library` typo UX**: the flat form isn't a real DLIO config path; the tool auto-injects `storage.storage_options.storage_library` from `STORAGE_LIBRARY` env in `--object` mode, so the user's `--params` had zero effect on the run. But the CLOSED disallowed-override check rejected it with a message that didn't hint at the correct spelling. Added `mlpstorage_py/rules/param_hints.py` with a `KNOWN_PARAM_TYPOS` map (three known-typo entries: `storage.storage_library`, `storage.uri_scheme`, `storage.prefetch_window`), a fail-fast gate in `cli_parser.update_args` so the user doesn't wait through MPI cluster collection just to be told the param was wrong, and a "Did you mean X?" hint appended to the runtime and submission-checker (3.6.2 CLOSED, 3.6.3 OPEN) disallowed-override messages so `mlpstorage validate` on stored submissions gives the same suggestion.

## Backwards compatibility

- **No new CLI flag.** `num_files_override` is an internal Python parameter used only by `datasize()`.
- **Existing runs are unaffected.** The datasize change is display-side only; the runtime and submission-checker file-count rules re-derive their thresholds from run metadata, not from anything the log or hint said.
- **Comparability across the fix boundary is unchanged.** `listing_validation_interval` controls startup HEAD-check density, not measured throughput; both values pre/post fix are TOOL_INJECTED_PARAMS and don't gate any rule.

## Test plan

- [x] `uv run pytest tests` — 2925 passed, 1 skipped, 13 deselected (+9 new)
- [x] `uv run pytest mlpstorage_py/tests` — 866 passed
- [x] `uv run pytest vdb_benchmark/tests` — 174 passed
- [x] `uv run pytest kv_cache_benchmark/tests` — 238 passed

New tests:

- `tests/unit/test_skip_listing_datasize_interval.py` (3 tests) — override wins over `combined_params` for the 257,173 recommendation, no-override still falls back to combined_params for non-datasize commands, user-supplied `--params dataset.listing_validation_interval=N` still short-circuits.
- `tests/unit/test_param_typo_hints.py` (9 tests) — typo-map integrity, CLI-parse fail-fast for the reporter's exact command shape, multiple typos surfaced in one error, canonical nested form still accepted, runtime check appends hint, unknown-typo message unchanged.