### PR TITLE
chore: bump 3.0.42 -> 3.0.43

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.42"
+version = "3.0.43"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.42"
+version = "3.0.43"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
## Summary

Release bump picking up the fixes merged since 3.0.42:

- #793 — exclude checkpointing datasize from submission invocation count (storage#791)
- #794 — reject invalid checkpointing --num-processes early and clarify §4.3.5 message (storage#792)
- #796 — ceil for minimum num_files_train to align datagen with rule 3.1.2
- #797 — align datasize output and fail-fast on flat storage_options typos (storage#795)

Also regenerates `uv.lock` so the recorded `mlpstorage` version matches `pyproject.toml`.

## Test plan

- [x] `uv lock` reports "Updated mlpstorage v3.0.42 -> v3.0.43" with no other package changes
- [x] Diff is exactly two lines: the version field in `pyproject.toml` and the matching entry in `uv.lock`