### PR TITLE
fix: soften D-B8 fs_separation evidence-gap from ERROR to WARN

### DIFF
--- a/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
+++ b/mlpstorage_py/submission_checker/checks/checkpointing_checks.py
@@ -1034,8 +1034,9 @@ class CheckpointingCheck(BaseCheck):
 
         Analog of TRAIN-02 for checkpointing. Per D-B5, shares
         _check_filesystem_separation helper. Per D-B7, silent-passes when
-        benchmark_API == 'object'. Per D-B4, 'df output not found' is itself a
-        violation tagged with this rule ID.
+        benchmark_API == 'object'. D-B8: when both the CAP-03 sidecar and
+        the df block are absent, emit a WARN under this rule ID so pre-#601
+        legacy runs are not blocked at ingest.
         """
         valid = True
         if self.mode != "checkpointing":
@@ -1064,14 +1065,14 @@ class CheckpointingCheck(BaseCheck):
             ok, df_found = _check_filesystem_separation(chkpt_args, logfile_path)
             if not df_found:
                 # D-B8: no CAP-03 sidecar AND no df block → no evidence of
-                # FS separation at all. Fire a hard violation so producers
-                # that predate #601 and never captured df cannot silently
-                # pass 4.4.2.
-                self.log_violation(
+                # FS separation. Emit at WARN so pre-#601 legacy runs are
+                # not silently blocked at ingest; reviewers must confirm
+                # checkpoint_folder / results_dir separation manually.
+                self.warn_violation(
                     "4.4.2", "checkpointFilesystemCheck", logfile_path,
-                    "fs_separation.json sidecar not found; df block also absent",
+                    "fs_separation.json sidecar not found and df block also absent; "
+                    "cannot verify checkpoint_folder/results_dir separation — reviewer must confirm manually",
                 )
-                valid = False
                 continue
             if not ok:
                 self.warn_violation(

--- a/mlpstorage_py/submission_checker/checks/helpers.py
+++ b/mlpstorage_py/submission_checker/checks/helpers.py
@@ -113,8 +113,9 @@ def _check_filesystem_separation(
     Returns a ``(ok, df_found)`` tuple:
       - ``(True,  True)``  — different mounts found (pass) or silent-skip (D-B3)
       - ``(False, True)``  — same mount (violation; caller emits [3.4.2] or [4.4.2])
-      - ``(False, False)`` — df block not found / logfile missing (D-B4; caller
-                              emits "df output not found" violation)
+      - ``(False, False)`` — df block not found / logfile missing (D-B4; when
+                              the CAP-03 sidecar is also absent, caller emits
+                              a WARN under the D-B8 evidence-gap path)
 
     **D-B3 silent-skip:** returns ``(True, True)`` when either ``data_dir`` or
     ``results_dir`` is absent from *metadata_args*. The sibling check
@@ -129,8 +130,9 @@ def _check_filesystem_separation(
     device-name wrapping (some ``df`` versions write the device name on its own
     line when it is too long) is OUT OF SCOPE for this MVP. TODO-001 defines a
     machine-readable ``df`` output contract that will supersede this parser.
-    Until then, real submissions with wrapped device names hard-fail with
-    "df output not found" (D-B4), which is the desired gap-surfacing behaviour.
+    Until then, real submissions with wrapped device names fall through to
+    the D-B8 evidence-gap WARN path (unless a CAP-03 sidecar is present),
+    which is the desired gap-surfacing behaviour.
 
     Args:
         metadata_args: The ``metadata["args"]`` dict from a submission log tuple.
@@ -171,8 +173,8 @@ def _check_filesystem_separation(
     # metadata, compared for equality across nodes. That removes both this
     # multi-line-device-name parse limitation and the substring-matching
     # fragility called out in WR-06's silent-pass case. Until that migration
-    # lands, real submissions with wrapped device names hard-fail with
-    # "df output not found" (D-B4), which is the desired gap-surfacing behaviour.
+    # lands, real submissions with wrapped device names fall through to the
+    # D-B8 evidence-gap WARN path (unless a CAP-03 sidecar is present).
     mounts = []
     header_end = content.find("\n", match.end())  # find the end of the header line
     if header_end == -1:

--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -965,14 +965,14 @@ class TrainingCheck(BaseCheck):
             ok, df_found = _check_filesystem_separation(args, logfile_path)
             if not df_found:
                 # D-B8: no CAP-03 sidecar AND no df block → no evidence of
-                # FS separation at all. Fire a hard violation so producers
-                # that predate #601 and never captured df cannot silently
-                # pass 3.4.2.
-                self.log_violation(
+                # FS separation. Emit at WARN so pre-#601 legacy runs are
+                # not silently blocked at ingest; reviewers must confirm
+                # data_dir / results_dir separation manually.
+                self.warn_violation(
                     "3.4.2", "trainingMlpstorageFilesystemCheck", logfile_path,
-                    "fs_separation.json sidecar not found; df block also absent",
+                    "fs_separation.json sidecar not found and df block also absent; "
+                    "cannot verify data_dir/results_dir separation — reviewer must confirm manually",
                 )
-                valid = False
                 continue
             if not ok:
                 self.warn_violation(

--- a/mlpstorage_py/submission_checker/checks/vdb_checks.py
+++ b/mlpstorage_py/submission_checker/checks/vdb_checks.py
@@ -664,11 +664,15 @@ class VdbCheck(BaseCheck):
                     shim_args["data_dir"] = storage_root
             ok, df_found = _check_filesystem_separation(shim_args, logfile_path)
             if not df_found:
-                self.log_violation(
+                # D-B8: no CAP-03 sidecar AND no df block → no evidence of
+                # FS separation. Emit at WARN so pre-#601 legacy runs are
+                # not silently blocked at ingest; reviewers must confirm
+                # storage_root / results_dir separation manually.
+                self.warn_violation(
                     "5.4.2", "vdbFilesystemCheck", logfile_path,
-                    "df output not found",
+                    "fs_separation.json sidecar not found and df block also absent; "
+                    "cannot verify vdb storage_root/results_dir separation — reviewer must confirm manually",
                 )
-                valid = False
                 continue
             if not ok:
                 self.warn_violation(

--- a/mlpstorage_py/tests/test_checkpointing_check_phase2.py
+++ b/mlpstorage_py/tests/test_checkpointing_check_phase2.py
@@ -683,13 +683,13 @@ class TestChkpt06_CheckpointFilesystemCheck:
         assert "same filesystem" in mock_logger.warnings[0]
 
     def test_df_not_found_emits_4_4_2_missing(self, tmp_path, mock_logger):
-        """No sidecar AND no df logfile → hard [4.4.2] violation (D-B8, #601).
+        """No sidecar AND no df logfile → WARN [4.4.2] (D-B8, #601).
 
-        Post-#601 D-B8 contract: when neither the CAP-03 sidecar nor the
-        df block is present, the rule has no evidence of FS separation and
-        must fire a hard violation. The pre-#601 TODO-001 warn-only
-        downgrade is no longer in effect now that the producer side ships
-        the sidecar.
+        D-B8 evidence-gap path: when neither the CAP-03 sidecar nor the
+        df block is present, the rule has no evidence of FS separation.
+        Emitted at WARN (not hard-fail) so pre-#601 legacy submissions
+        without the sidecar are not blocked at ingest — reviewers must
+        confirm separation manually.
         """
         from mlpstorage_py.tests.conftest import build_submission
         root = build_submission(
@@ -700,10 +700,12 @@ class TestChkpt06_CheckpointFilesystemCheck:
         )
         check = _run_checkpointing_check(root, mock_logger)
         result = check.checkpoint_filesystem_check()
-        assert result is False
-        assert len(mock_logger.errors) >= 1
-        assert mock_logger.errors[0].startswith("[4.4.2 checkpointFilesystemCheck]"), \
-            f"Expected [4.4.2 checkpointFilesystemCheck]; got {mock_logger.errors[0]!r}"
+        assert result is True
+        assert mock_logger.errors == []
+        assert len(mock_logger.warnings) >= 1
+        assert mock_logger.warnings[0].startswith("[4.4.2 checkpointFilesystemCheck]"), \
+            f"Expected [4.4.2 checkpointFilesystemCheck]; got {mock_logger.warnings[0]!r}"
+        assert "sidecar not found" in mock_logger.warnings[0]
 
     def test_object_api_silent_passes(self, tmp_path, mock_logger):
         """benchmark_API='object' → silent-pass; no errors emitted (D-B7)."""

--- a/mlpstorage_py/tests/test_issue601_validator_reads_sidecar.py
+++ b/mlpstorage_py/tests/test_issue601_validator_reads_sidecar.py
@@ -268,7 +268,11 @@ class TestRule3_4_2_TrainingSidecar:
         assert any("same filesystem" in v for v in violations), violations
 
     def test_no_sidecar_no_df_fires_db8(self, tmp_path):
-        """Missing sidecar AND missing df-block → new D-B8 violation under 3.4.2."""
+        """Missing sidecar AND missing df-block → D-B8 WARN under 3.4.2.
+
+        Downgraded from hard-fail to WARN so pre-#601 legacy runs are not
+        blocked at ingest — reviewers verify separation manually.
+        """
         leaf, ts_dir, run_files = _build_training_tree(
             tmp_path, write_sidecar=False, write_logfile=True,
         )
@@ -276,13 +280,12 @@ class TestRule3_4_2_TrainingSidecar:
 
         result = check.mlpstorage_filesystem_check()
 
-        assert result is False
-        violations = [str(c) for c in check.log.error.call_args_list]
-        # New D-B8 message is acceptable; "df output not found" fallback is also
-        # acceptable for one release. Either way, SOMETHING fires under 3.4.2.
+        assert result is True
+        assert check.log.error.call_args_list == []
+        violations = [str(c) for c in check.log.warning.call_args_list]
         assert any(
             "[3.4.2 trainingMlpstorageFilesystemCheck]" in v for v in violations
-        ), f"expected a 3.4.2 violation; got: {violations}"
+        ), f"expected a 3.4.2 warning; got: {violations}"
 
 
 # ---------------------------------------------------------------------------

--- a/mlpstorage_py/tests/test_training_check_phase2.py
+++ b/mlpstorage_py/tests/test_training_check_phase2.py
@@ -181,13 +181,13 @@ class TestTrain02_MlpstorageFilesystemCheck:
             f"Expected 'same filesystem' in warning; got {mock_logger.warnings[0]!r}"
 
     def test_df_not_found_emits_3_4_2_missing(self, tmp_path, mock_logger):
-        """No sidecar AND no df logfile → hard [3.4.2] violation (D-B8, #601).
+        """No sidecar AND no df logfile → WARN [3.4.2] (D-B8, #601).
 
-        Post-#601 D-B8 contract: when neither the CAP-03 sidecar nor the
-        df block is present, the rule has no evidence of FS separation and
-        must fire a hard violation. The pre-#601 TODO-001 warn-only
-        downgrade is no longer in effect now that the producer side ships
-        the sidecar.
+        D-B8 evidence-gap path: when neither the CAP-03 sidecar nor the
+        df block is present, the rule has no evidence of FS separation.
+        Emitted at WARN (not hard-fail) so pre-#601 legacy submissions
+        without the sidecar are not blocked at ingest — reviewers must
+        confirm separation manually.
         """
         from mlpstorage_py.tests.conftest import build_submission
         root = build_submission(
@@ -198,10 +198,13 @@ class TestTrain02_MlpstorageFilesystemCheck:
         )
         check = _run_training_check(root, mock_logger)
         result = check.mlpstorage_filesystem_check()
-        assert result is False
-        assert len(mock_logger.errors) >= 1
-        assert mock_logger.errors[0].startswith("[3.4.2 trainingMlpstorageFilesystemCheck]"), \
-            f"Expected prefix [3.4.2 trainingMlpstorageFilesystemCheck]; got {mock_logger.errors[0]!r}"
+        assert result is True
+        assert mock_logger.errors == []
+        assert len(mock_logger.warnings) >= 1
+        assert mock_logger.warnings[0].startswith("[3.4.2 trainingMlpstorageFilesystemCheck]"), \
+            f"Expected prefix [3.4.2 trainingMlpstorageFilesystemCheck]; got {mock_logger.warnings[0]!r}"
+        assert "sidecar not found" in mock_logger.warnings[0], \
+            f"Expected 'sidecar not found' in warning; got {mock_logger.warnings[0]!r}"
 
     def test_object_api_silent_passes(self, tmp_path, mock_logger):
         """benchmark_API='object' → silent-pass; no errors emitted (D-B7)."""
@@ -256,10 +259,10 @@ class TestTrain02_DfBlockNotFoundIsRuleIdTagged:
     def test_df_not_found_violation_includes_logfile_path(self, tmp_path, mock_logger):
         """df-not-found violation must include 'training_run.stdout.log' in the message.
 
-        Post-#601 D-B8: df-not-found (with sidecar also absent) is a hard
-        violation on ``mock_logger.errors``. The submitter-grep contract
-        still applies — the logfile path must appear so submitters can
-        locate the failing run.
+        D-B8: df-not-found (with sidecar also absent) is a WARN on
+        ``mock_logger.warnings``. The reviewer-grep contract still applies —
+        the logfile path must appear so reviewers can locate the run that
+        needs manual verification.
         """
         from mlpstorage_py.tests.conftest import build_submission
         root = build_submission(
@@ -269,11 +272,11 @@ class TestTrain02_DfBlockNotFoundIsRuleIdTagged:
         )
         check = _run_training_check(root, mock_logger)
         check.mlpstorage_filesystem_check()
-        assert len(mock_logger.errors) >= 1
+        assert len(mock_logger.warnings) >= 1
         assert any(
             "training_run.stdout.log" in m
-            for m in mock_logger.errors
+            for m in mock_logger.warnings
         ), (
-            f"Expected 'training_run.stdout.log' in at least one error message; "
-            f"got {mock_logger.errors}"
+            f"Expected 'training_run.stdout.log' in at least one warning message; "
+            f"got {mock_logger.warnings}"
         )


### PR DESCRIPTION
## Summary
- Downgrade the "no CAP-03 sidecar AND no df block" path in `trainingMlpstorageFilesystemCheck` (3.4.2), `checkpointFilesystemCheck` (4.4.2), and `vdbFilesystemCheck` (5.4.2) from a hard violation to a warning.
- Reviewer-grep contract preserved: the WARN still fires under the original rule ID and includes the logfile path, so reviewers see a clear marker calling for manual verification.
- Refresh a few stale comments/docstrings in `helpers.py` and `checkpointing_checks.py` that still described the old hard-fail semantics.

## Motivation
Legacy submissions produced before CAP-03 sidecar emission was implemented have no `fs_separation.json` and, in cases where the df block also wasn't captured, would be refused outright by `mlpstorage validate` at submission ingest. That blocks a submitter this round who no longer has cloud credits to re-run. The WARN keeps the gap visible to reviewers without denying ingest.

## Trade-off
This is a permanent policy softening — future submissions that skip the sidecar will only get a warning under 3.4.2 / 4.4.2 / 5.4.2, not a hard fail. The sidecar-present and df-present paths are unchanged (shared-filesystem is still WARN per PR #788, and different-filesystem still passes silently).

## Test plan
- [x] `uv run pytest mlpstorage_py/tests` — 866 passed
- [x] `uv run pytest tests` — 2925 passed
- [x] `uv run pytest vdb_benchmark/tests` — 199 passed
- [ ] CI covers `uv run pytest kv_cache_benchmark/tests` (no changes touch kvcache code)