### PR TITLE
fix(storage#801): stop double-counting VDB storage throughput across disk partitions

### DIFF
--- a/vdb_benchmark/test_disk_stats.py
+++ b/vdb_benchmark/test_disk_stats.py
@@ -75,6 +75,50 @@ def test_payload_empty_diff():
     p = build_disk_io_stats({}, 10.0, tgt, fmt)
     assert p["applicable"] is False and "error" in p
 
+# --- issue #801: /proc/diskstats double-counts a whole disk and its partitions ---
+
+def test_partition_not_double_counted():
+    # /proc/diskstats reports a whole NVMe device and its data partition with
+    # identical read counters; summing both inflates throughput ~2x.
+    diff = {
+        "nvme0n1":   {"bytes_read": 560280633344, "bytes_written": 0},
+        "nvme0n1p1": {"bytes_read": 560280633344, "bytes_written": 0},
+    }
+    tgt = classify_storage_target("/var/lib/milvus", mounts=MOUNTS_LOCAL)
+    p = build_disk_io_stats(diff, 300.0, tgt, fmt)
+    assert p["total_bytes_read"] == 560280633344   # not 2x
+    assert "nvme0n1" in p["devices"]               # parent kept
+    assert "nvme0n1p1" not in p["devices"]         # partition collapsed
+
+def test_multiple_disks_each_deduped():
+    diff = {
+        "nvme2n1":   {"bytes_read": 1351680, "bytes_written": 0},
+        "nvme2n1p2": {"bytes_read": 1351680, "bytes_written": 0},
+        "nvme0n1":   {"bytes_read": 560280633344, "bytes_written": 0},
+        "nvme0n1p1": {"bytes_read": 560280633344, "bytes_written": 0},
+    }
+    tgt = classify_storage_target("/var/lib/milvus", mounts=MOUNTS_LOCAL)
+    p = build_disk_io_stats(diff, 300.0, tgt, fmt)
+    assert p["total_bytes_read"] == 1351680 + 560280633344
+
+def test_scsi_partition_deduped():
+    diff = {
+        "sda":  {"bytes_read": 4096, "bytes_written": 0},
+        "sda1": {"bytes_read": 4096, "bytes_written": 0},
+        "sda2": {"bytes_read": 4096, "bytes_written": 0},
+    }
+    tgt = classify_storage_target("/var/lib/milvus", mounts=MOUNTS_LOCAL)
+    p = build_disk_io_stats(diff, 10.0, tgt, fmt)
+    assert p["total_bytes_read"] == 4096           # only the whole disk
+
+def test_orphan_partition_retained():
+    # A partition whose parent whole-disk is absent must still be counted.
+    diff = {"nvme0n1p1": {"bytes_read": 4096, "bytes_written": 0}}
+    tgt = classify_storage_target("/var/lib/milvus", mounts=MOUNTS_LOCAL)
+    p = build_disk_io_stats(diff, 10.0, tgt, fmt)
+    assert p["total_bytes_read"] == 4096
+    assert "nvme0n1p1" in p["devices"]
+
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     for f in fns:

--- a/vdb_benchmark/tests/tests/test_disk_stats.py
+++ b/vdb_benchmark/tests/tests/test_disk_stats.py
@@ -1,7 +1,19 @@
-"""Unit tests for vdbbench.disk_stats (issue #591)."""
+"""Unit tests for vdbbench.disk_stats (issue #591).
+
+Relocated from vdb_benchmark/test_disk_stats.py so the suite is collected by
+CI (`pytest vdb_benchmark/tests`); the old top-level path was never run. The
+``sys.path`` bootstrap is anchored to the package root so the tests import the
+same way whether invoked by pytest from the repo root or run standalone.
+"""
+import os
 import sys
-sys.path.insert(0, ".")
-from vdbbench.disk_stats import (
+
+# Make the vdbbench package importable regardless of pytest's invocation dir.
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from vdbbench.disk_stats import (  # noqa: E402
     build_disk_io_stats, classify_storage_target, find_mount_for_path,
     is_network_fs, list_network_mounts,
 )
@@ -75,53 +87,8 @@ def test_payload_empty_diff():
     p = build_disk_io_stats({}, 10.0, tgt, fmt)
     assert p["applicable"] is False and "error" in p
 
-# --- issue #801: /proc/diskstats double-counts a whole disk and its partitions ---
-
-def test_partition_not_double_counted():
-    # /proc/diskstats reports a whole NVMe device and its data partition with
-    # identical read counters; summing both inflates throughput ~2x.
-    diff = {
-        "nvme0n1":   {"bytes_read": 560280633344, "bytes_written": 0},
-        "nvme0n1p1": {"bytes_read": 560280633344, "bytes_written": 0},
-    }
-    tgt = classify_storage_target("/var/lib/milvus", mounts=MOUNTS_LOCAL)
-    p = build_disk_io_stats(diff, 300.0, tgt, fmt)
-    assert p["total_bytes_read"] == 560280633344   # not 2x
-    assert "nvme0n1" in p["devices"]               # parent kept
-    assert "nvme0n1p1" not in p["devices"]         # partition collapsed
-
-def test_multiple_disks_each_deduped():
-    diff = {
-        "nvme2n1":   {"bytes_read": 1351680, "bytes_written": 0},
-        "nvme2n1p2": {"bytes_read": 1351680, "bytes_written": 0},
-        "nvme0n1":   {"bytes_read": 560280633344, "bytes_written": 0},
-        "nvme0n1p1": {"bytes_read": 560280633344, "bytes_written": 0},
-    }
-    tgt = classify_storage_target("/var/lib/milvus", mounts=MOUNTS_LOCAL)
-    p = build_disk_io_stats(diff, 300.0, tgt, fmt)
-    assert p["total_bytes_read"] == 1351680 + 560280633344
-
-def test_scsi_partition_deduped():
-    diff = {
-        "sda":  {"bytes_read": 4096, "bytes_written": 0},
-        "sda1": {"bytes_read": 4096, "bytes_written": 0},
-        "sda2": {"bytes_read": 4096, "bytes_written": 0},
-    }
-    tgt = classify_storage_target("/var/lib/milvus", mounts=MOUNTS_LOCAL)
-    p = build_disk_io_stats(diff, 10.0, tgt, fmt)
-    assert p["total_bytes_read"] == 4096           # only the whole disk
-
-def test_orphan_partition_retained():
-    # A partition whose parent whole-disk is absent must still be counted.
-    diff = {"nvme0n1p1": {"bytes_read": 4096, "bytes_written": 0}}
-    tgt = classify_storage_target("/var/lib/milvus", mounts=MOUNTS_LOCAL)
-    p = build_disk_io_stats(diff, 10.0, tgt, fmt)
-    assert p["total_bytes_read"] == 4096
-    assert "nvme0n1p1" in p["devices"]
-
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     for f in fns:
         f(); print(f"PASS {f.__name__}")
     print(f"\n{len(fns)} tests passed")
-

--- a/vdb_benchmark/tests/tests/test_issue_801_partition_double_count.py
+++ b/vdb_benchmark/tests/tests/test_issue_801_partition_double_count.py
@@ -1,0 +1,137 @@
+"""
+Regression tests for issue #801:
+
+    Storage throughput double-counted for a single NVMe drive.
+
+``/proc/diskstats`` reports I/O counters for both a whole block device
+(e.g. ``nvme0n1``) and each of its partitions (``nvme0n1p1``) with
+identical values. ``build_disk_io_stats`` — and the sibling aggregation
+paths in ``enhanced_bench`` — naively summed every entry, so a single
+physical drive whose only active partition holds the data was counted
+twice, inflating ``total_bytes_read`` / ``total_bytes_read_per_sec`` by
+~2x for single-drive configs (worse with more partitions).
+
+The fix collapses whole-disk/partition duplicates before summing: when a
+partition's parent whole-disk device is present in the same snapshot the
+parent is kept (its counters already cover all partition I/O) and the
+partition is dropped; an orphan partition with no present parent is kept.
+
+These tests need neither a live Milvus nor pymilvus — ``disk_stats``
+depends only on the standard library.
+"""
+import os
+import sys
+
+# Make the vdbbench package importable regardless of pytest's invocation dir.
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from vdbbench.disk_stats import (  # noqa: E402
+    build_disk_io_stats,
+    classify_storage_target,
+    collapse_partition_duplicates,
+    parent_disk,
+)
+
+MOUNTS_LOCAL = [
+    {"source": "/dev/nvme0n1p2", "mountpoint": "/", "fstype": "ext4"},
+    {"source": "/dev/nvme1n1", "mountpoint": "/var/lib/milvus", "fstype": "xfs"},
+]
+
+
+def _fmt(b):
+    return f"{b} B"
+
+
+def _local_target():
+    return classify_storage_target("/var/lib/milvus", mounts=MOUNTS_LOCAL)
+
+
+# --- parent_disk --------------------------------------------------------------
+
+def test_parent_disk_nvme_partition():
+    assert parent_disk("nvme0n1p1") == "nvme0n1"
+    assert parent_disk("nvme2n1p2") == "nvme2n1"
+
+
+def test_parent_disk_scsi_and_mmc_partition():
+    assert parent_disk("sda1") == "sda"
+    assert parent_disk("vdb2") == "vdb"
+    assert parent_disk("xvda1") == "xvda"
+    assert parent_disk("mmcblk0p1") == "mmcblk0"
+
+
+def test_parent_disk_whole_disks_and_virtual_return_none():
+    for dev in ("nvme0n1", "sda", "vdb", "mmcblk0", "dm-0", "md0"):
+        assert parent_disk(dev) is None, dev
+
+
+# --- collapse_partition_duplicates -------------------------------------------
+
+def test_collapse_drops_partition_keeps_parent():
+    diff = {
+        "nvme0n1":   {"bytes_read": 100, "bytes_written": 0},
+        "nvme0n1p1": {"bytes_read": 100, "bytes_written": 0},
+    }
+    out = collapse_partition_duplicates(diff)
+    assert set(out) == {"nvme0n1"}
+
+
+def test_collapse_retains_orphan_partition():
+    # Parent not present in the snapshot -> partition must be kept.
+    diff = {"nvme0n1p1": {"bytes_read": 100, "bytes_written": 0}}
+    out = collapse_partition_duplicates(diff)
+    assert set(out) == {"nvme0n1p1"}
+
+
+def test_collapse_keeps_independent_whole_disks():
+    diff = {
+        "nvme0n1": {"bytes_read": 1, "bytes_written": 0},
+        "nvme1n1": {"bytes_read": 2, "bytes_written": 0},
+        "sda":     {"bytes_read": 3, "bytes_written": 0},
+    }
+    assert collapse_partition_duplicates(diff) == diff
+
+
+# --- build_disk_io_stats (end-to-end payload) --------------------------------
+
+def test_single_drive_not_double_counted():
+    # Exact numbers from the issue's DISKANN run 20260714_124702.
+    diff = {
+        "nvme0n1":   {"bytes_read": 560280633344, "bytes_written": 0},
+        "nvme0n1p1": {"bytes_read": 560280633344, "bytes_written": 0},
+    }
+    p = build_disk_io_stats(diff, 300.0, _local_target(), _fmt)
+    assert p["total_bytes_read"] == 560280633344          # not 2x
+    assert p["total_bytes_read_per_sec"] == 560280633344 / 300.0
+    assert "nvme0n1" in p["devices"]
+    assert "nvme0n1p1" not in p["devices"]
+
+
+def test_multiple_drives_each_deduped():
+    diff = {
+        "nvme2n1":   {"bytes_read": 1351680, "bytes_written": 0},
+        "nvme2n1p2": {"bytes_read": 1351680, "bytes_written": 0},
+        "nvme0n1":   {"bytes_read": 560280633344, "bytes_written": 0},
+        "nvme0n1p1": {"bytes_read": 560280633344, "bytes_written": 0},
+    }
+    p = build_disk_io_stats(diff, 300.0, _local_target(), _fmt)
+    assert p["total_bytes_read"] == 1351680 + 560280633344
+
+
+def test_multiple_partitions_on_one_disk():
+    diff = {
+        "sda":  {"bytes_read": 4096, "bytes_written": 0},
+        "sda1": {"bytes_read": 4096, "bytes_written": 0},
+        "sda2": {"bytes_read": 4096, "bytes_written": 0},
+    }
+    p = build_disk_io_stats(diff, 10.0, _local_target(), _fmt)
+    assert p["total_bytes_read"] == 4096                  # whole disk only
+
+
+def test_orphan_partition_still_counted():
+    diff = {"nvme0n1p1": {"bytes_read": 4096, "bytes_written": 0}}
+    p = build_disk_io_stats(diff, 10.0, _local_target(), _fmt)
+    assert p["total_bytes_read"] == 4096
+    assert "nvme0n1p1" in p["devices"]

--- a/vdb_benchmark/vdbbench/disk_stats.py
+++ b/vdb_benchmark/vdbbench/disk_stats.py
@@ -14,9 +14,16 @@ as N/A in statistics.json instead of emitting empty or misleading values.
 The QPS score is unaffected: this is purely a reporting-clarity change.
 """
 
+import re
 from typing import Any, Dict, List, Optional
 
 MOUNTS_FILE = "/proc/self/mounts"
+
+# Partition-name patterns used to collapse /proc/diskstats double-counting
+# (issue #801). nvme0n1p1 -> nvme0n1, mmcblk0p1 -> mmcblk0; sda1 -> sda,
+# vdb2 -> vdb, xvda1 -> xvda.
+_NVME_MMC_PARTITION_RE = re.compile(r"^(nvme\d+n\d+|mmcblk\d+)p\d+$")
+_SCSI_PARTITION_RE = re.compile(r"^([a-z]+)\d+$")
 
 # Filesystem types that indicate the mount is network / remote-attached.
 # /proc/diskstats has no local block device for these targets.
@@ -257,6 +264,43 @@ def classify_storage_target(
     return result
 
 
+def parent_disk(device: str) -> Optional[str]:
+    """Return the whole-disk device a partition belongs to, else ``None``.
+
+    ``/proc/diskstats`` lists both whole block devices (``nvme0n1``, ``sda``)
+    and their partitions (``nvme0n1p1``, ``sda1``). This maps a partition name
+    back to its parent so duplicate counters can be collapsed (issue #801).
+    Whole disks and non-partition entries (``dm-0``, ``loop0``) return ``None``.
+    """
+    m = _NVME_MMC_PARTITION_RE.match(device)
+    if m:
+        return m.group(1)
+    m = _SCSI_PARTITION_RE.match(device)
+    if m:
+        return m.group(1)
+    return None
+
+
+def collapse_partition_duplicates(
+    disk_io_diff: Dict[str, Dict[str, int]],
+) -> Dict[str, Dict[str, int]]:
+    """Drop partition entries whose parent whole-disk device is also present.
+
+    ``/proc/diskstats`` reports I/O counters for a whole block device *and*
+    separately for each of its partitions, so the same bytes are counted twice
+    when every entry is summed (issue #801). When a partition's parent device
+    appears in the same snapshot we keep the parent — whose counters already
+    cover all partition I/O — and drop the partition. An orphan partition whose
+    parent is absent is retained so its I/O is not lost.
+    """
+    present = set(disk_io_diff)
+    return {
+        device: stats
+        for device, stats in disk_io_diff.items()
+        if parent_disk(device) not in present
+    }
+
+
 def build_disk_io_stats(
     disk_io_diff: Dict[str, Dict[str, int]],
     duration_seconds: float,
@@ -302,6 +346,10 @@ def build_disk_io_stats(
             "storage_target": target_summary,
             "error": "Disk I/O statistics not available",
         }
+
+    # Issue #801: collapse whole-disk/partition duplicates before summing so a
+    # single physical drive is not counted once per partition.
+    disk_io_diff = collapse_partition_duplicates(disk_io_diff)
 
     total_bytes_read = sum(d["bytes_read"] for d in disk_io_diff.values())
     total_bytes_written = sum(d["bytes_written"] for d in disk_io_diff.values())

--- a/vdb_benchmark/vdbbench/disk_stats.py
+++ b/vdb_benchmark/vdbbench/disk_stats.py
@@ -20,10 +20,15 @@ from typing import Any, Dict, List, Optional
 MOUNTS_FILE = "/proc/self/mounts"
 
 # Partition-name patterns used to collapse /proc/diskstats double-counting
-# (issue #801). nvme0n1p1 -> nvme0n1, mmcblk0p1 -> mmcblk0; sda1 -> sda,
-# vdb2 -> vdb, xvda1 -> xvda.
-_NVME_MMC_PARTITION_RE = re.compile(r"^(nvme\d+n\d+|mmcblk\d+)p\d+$")
-_SCSI_PARTITION_RE = re.compile(r"^([a-z]+)\d+$")
+# (issue #801). Linux names a partition by appending its number to the whole
+# disk, inserting a 'p' separator when the disk name already ends in a digit:
+#   - digit-ending disks use 'p': nvme0n1 -> nvme0n1p1, mmcblk0 -> mmcblk0p1
+#   - traditional letter-named disks append directly: sda -> sda1, vdb -> vdb2
+# The direct-suffix form is anchored to the sd/vd/hd/xvd families so whole
+# disks whose own name ends in a digit (mmcblk0, loop0, md0) are not mistaken
+# for partitions.
+_PSEP_PARTITION_RE = re.compile(r"^(.+\d)p\d+$")
+_DIRECT_PARTITION_RE = re.compile(r"^((?:sd|vd|hd|xvd)[a-z]+)\d+$")
 
 # Filesystem types that indicate the mount is network / remote-attached.
 # /proc/diskstats has no local block device for these targets.
@@ -272,10 +277,10 @@ def parent_disk(device: str) -> Optional[str]:
     back to its parent so duplicate counters can be collapsed (issue #801).
     Whole disks and non-partition entries (``dm-0``, ``loop0``) return ``None``.
     """
-    m = _NVME_MMC_PARTITION_RE.match(device)
+    m = _PSEP_PARTITION_RE.match(device)
     if m:
         return m.group(1)
-    m = _SCSI_PARTITION_RE.match(device)
+    m = _DIRECT_PARTITION_RE.match(device)
     if m:
         return m.group(1)
     return None

--- a/vdb_benchmark/vdbbench/enhanced_bench.py
+++ b/vdb_benchmark/vdbbench/enhanced_bench.py
@@ -51,7 +51,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 import numpy as np
 
 from vdbbench.benchmark.generator import DEFAULT_QUERY_NOISE, plant_queries
-from vdbbench.disk_stats import classify_storage_target
+from vdbbench.disk_stats import classify_storage_target, collapse_partition_duplicates
 
 try:
     from pymilvus import (
@@ -1544,6 +1544,9 @@ def _disk_totals(
         devs = {d: diff[d] for d in disk_devices if d in diff}
     else:
         devs = filter_real_disk_devices(diff)
+    # Issue #801: drop whole-disk/partition duplicates so one physical drive
+    # is not summed once per partition.
+    devs = collapse_partition_duplicates(devs)
 
     rd = wr = rio = wio = 0
     for s in devs.values():
@@ -2929,6 +2932,10 @@ def main() -> None:
         print("Reading final disk statistics...")
         end_disk_stats = read_disk_stats()
         disk_io_diff = calculate_disk_io_diff(start_disk_stats, end_disk_stats)
+        # Issue #801: /proc/diskstats reports a whole disk and each of its
+        # partitions with identical counters; collapse the duplicates so a
+        # single physical drive is not counted twice in the totals below.
+        disk_io_diff = collapse_partition_duplicates(disk_io_diff)
 
         print("\nCalculating recall from per-worker JSONL files...")
         ann_results_by_query = load_recall_hits(output_dir)


### PR DESCRIPTION
## Summary

Fixes #801. VDB disk I/O statistics double-counted storage throughput because `/proc/diskstats` reports counters for both a whole block device (`nvme0n1`) **and** each of its partitions (`nvme0n1p1`) with identical values. The reporting code summed every entry, so a single physical drive whose data lives on one partition was counted twice — inflating `total_bytes_read` / `total_bytes_read_per_sec` by ~2× (worse with more partitions per device).

## Fix

Added `collapse_partition_duplicates()` (and a `parent_disk()` helper) in `vdbbench/disk_stats.py`. Before summing, when a partition's parent whole-disk device is present in the same snapshot we keep the parent — whose counters already cover all partition I/O — and drop the partition. An orphan partition whose parent is absent is retained so no I/O is lost.

Applied at every producer of the `disk_io` payload:
- `build_disk_io_stats()` — the `simple_bench` path (matches the `statistics.json` in the issue).
- The inline aggregation in `enhanced_bench` (per-rank `disk_io` block).
- `_disk_totals()` in `enhanced_bench` (RunResult rates).

The MPI aggregators (`mpi_aggregate.py`) consume the corrected per-rank `total_bytes_read` unchanged, so multi-node summaries are fixed transitively.

### Partition-name handling

`parent_disk()` follows Linux naming: a partition appends its number to the whole disk, inserting a `p` separator when the disk name already ends in a digit.
- `p`-separated form for digit-ending disks: `nvme0n1p1 → nvme0n1`, `mmcblk0p1 → mmcblk0`
- direct-suffix form anchored to the `sd`/`vd`/`hd`/`xvd` families: `sda1 → sda`, `vdb2 → vdb`

This deliberately does **not** treat whole disks whose own name ends in a digit (`mmcblk0`, `loop0`, `md0`) as partitions.

## Tests

- New `tests/tests/test_issue_801_partition_double_count.py`: `parent_disk`/`collapse_*` unit tests plus end-to-end `build_disk_io_stats` assertions using the issue's exact byte counts (single-drive, multi-drive, multi-partition, orphan-partition).
- Relocated the pre-existing `test_disk_stats.py` (issue #591) from the package top level into `tests/tests/` so CI (`pytest vdb_benchmark/tests`) actually collects it — it was previously never run.

Developed test-first (RED → GREEN). Full CI suite green locally: root `tests/` 2925 passed, `mlpstorage_py/tests` 866, `vdb_benchmark/tests` 217, `kv_cache_benchmark/tests` 238.
