### PR TITLE
Fix(storage#805): verify FLAT ground-truth content before reuse; invalidate all-zero-recall runs

### DIFF
--- a/vdb_benchmark/tests/tests/test_issue_805_stale_gt_zero_recall.py
+++ b/vdb_benchmark/tests/tests/test_issue_805_stale_gt_zero_recall.py
@@ -1,0 +1,276 @@
+"""
+Regression tests for issue #805: AISAQ Recall@10 = 0.00 across all runs,
+with result_verdict.json still reporting "valid".
+
+Two defects are covered:
+
+  1. ``create_flat_collection`` / ``validate_existing_flat_collection`` reused
+     an existing FLAT ground-truth collection based on entity COUNT alone. A
+     stale FLAT GT left over from a regenerated source collection (same size,
+     different vectors) was silently paired with the new ANN collection,
+     making every ANN result miss the GT set — recall exactly 0.00 on every
+     query while QPS/latency stayed healthy.
+     Fix: ``verify_flat_matches_source`` samples PKs from the FLAT collection
+     and compares their vectors element-wise against the source before reuse.
+
+  2. ``emit_result_verdict`` keyed only on FLAT coverage and the number of
+     evaluated queries, so an all-zero-recall run was marked "valid".
+     Fix: a zero-recall gate marks the run invalid when every evaluated query
+     scored recall 0.0.
+
+These tests are dependency-free: they install a fake ``pymilvus`` before
+importing ``vdbbench`` so they run in CI without a Milvus client.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _install_fake_pymilvus():
+    if "pymilvus" in sys.modules:
+        return
+    fake = MagicMock(name="pymilvus")
+    fake.connections = MagicMock(name="connections")
+    sys.modules["pymilvus"] = fake
+
+
+_install_fake_pymilvus()
+
+from vdbbench.simple_bench import (  # noqa: E402
+    FlatSetupResult,
+    emit_result_verdict,
+    verify_flat_matches_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes for the content-verification helper
+# ---------------------------------------------------------------------------
+
+
+class _FakeField:
+    def __init__(self, name, dtype, is_primary=False):
+        self.name = name
+        self.dtype = dtype
+        self.is_primary = is_primary
+
+
+class _FakeSchema:
+    def __init__(self, fields):
+        self.fields = fields
+
+
+class _FakeCollection:
+    """Minimal stand-in exposing schema + query() over an id->vector map."""
+
+    def __init__(self, name, vectors_by_pk, pk_field="id", vec_field="vector"):
+        from pymilvus import DataType  # the fake module
+
+        # The fake pymilvus DataType attributes are MagicMock sentinels, which
+        # is fine: _detect_schema_fields compares identity against them.
+        self.name = name
+        self._pk_field = pk_field
+        self._vec_field = vec_field
+        self._data = dict(vectors_by_pk)
+        self.schema = _FakeSchema(
+            [
+                _FakeField(pk_field, DataType.INT64, is_primary=True),
+                _FakeField(vec_field, DataType.FLOAT_VECTOR),
+            ]
+        )
+
+    def load(self):
+        pass
+
+    def query(self, expr, output_fields, limit):
+        # Support the two expression shapes the helper emits:
+        #   "<pk> > -1"          -> first-page sample
+        #   "<pk> in [1, 2, 3]"  -> targeted fetch
+        if " in " in expr:
+            wanted = json.loads(expr.split(" in ", 1)[1])
+            pks = [pk for pk in wanted if pk in self._data]
+        else:
+            pks = sorted(self._data.keys())
+        rows = [
+            {self._pk_field: pk, self._vec_field: self._data[pk]}
+            for pk in pks[:limit]
+        ]
+        return rows
+
+
+def _vec(seed, dim=4):
+    return [float(seed) + 0.1 * i for i in range(dim)]
+
+
+class TestVerifyFlatMatchesSource:
+    def test_matching_content_is_accepted(self):
+        data = {pk: _vec(pk) for pk in range(10)}
+        source = _FakeCollection("src", data)
+        flat = _FakeCollection("src_flat_gt", data)
+
+        matches, detail = verify_flat_matches_source(source, flat)
+
+        assert matches is True
+        assert "match" in detail
+
+    def test_stale_content_with_equal_count_is_rejected(self):
+        # Same PKs, same COUNT, different vectors — the issue #805 scenario:
+        # the source collection was regenerated but the old FLAT GT survived.
+        old_data = {pk: _vec(pk) for pk in range(10)}
+        new_data = {pk: _vec(pk + 100) for pk in range(10)}
+        source = _FakeCollection("src", new_data)
+        flat = _FakeCollection("src_flat_gt", old_data)
+
+        matches, detail = verify_flat_matches_source(source, flat)
+
+        assert matches is False
+        assert "mismatch" in detail
+
+    def test_pk_missing_from_source_is_rejected(self):
+        source = _FakeCollection("src", {pk: _vec(pk) for pk in range(5, 10)})
+        flat = _FakeCollection("src_flat_gt", {pk: _vec(pk) for pk in range(5)})
+
+        matches, detail = verify_flat_matches_source(source, flat)
+
+        assert matches is False
+
+    def test_verification_error_is_treated_as_mismatch(self):
+        class _Broken(_FakeCollection):
+            def query(self, *args, **kwargs):
+                raise RuntimeError("boom")
+
+        data = {pk: _vec(pk) for pk in range(3)}
+        source = _FakeCollection("src", data)
+        flat = _Broken("src_flat_gt", data)
+
+        matches, detail = verify_flat_matches_source(source, flat)
+
+        assert matches is False
+        assert "verification failed" in detail
+
+    def test_empty_flat_sample_is_rejected(self):
+        source = _FakeCollection("src", {pk: _vec(pk) for pk in range(3)})
+        flat = _FakeCollection("src_flat_gt", {})
+
+        matches, _ = verify_flat_matches_source(source, flat)
+
+        assert matches is False
+
+
+# ---------------------------------------------------------------------------
+# Zero-recall verdict gate
+# ---------------------------------------------------------------------------
+
+
+def _full_coverage_flat_result():
+    return FlatSetupResult(
+        ok=True,
+        coverage=1.0,
+        total_vectors=1000,
+        copied_vectors=1000,
+        reused=True,
+    )
+
+
+def _emit(tmp_dir, recall_stats, num_queries=1000):
+    verdict = emit_result_verdict(
+        tmp_dir,
+        flat_result=_full_coverage_flat_result(),
+        num_queries_evaluated=num_queries,
+        recall_stats=recall_stats,
+    )
+    with open(os.path.join(tmp_dir, "result_verdict.json"), encoding="utf-8") as f:
+        payload = json.load(f)
+    return verdict, payload
+
+
+class TestZeroRecallVerdict:
+    def test_all_zero_recall_is_invalid(self):
+        recall_stats = {
+            "recall_at_k": 0.0,
+            "mean_recall": 0.0,
+            "min_recall": 0.0,
+            "max_recall": 0.0,
+            "num_queries_evaluated": 1000,
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            verdict, payload = _emit(tmp, recall_stats)
+
+        assert verdict.startswith("invalid")
+        assert "recall is 0.0" in verdict
+        assert payload["valid"] is False
+        assert payload["recall_summary"]["max_recall"] == 0.0
+
+    def test_nonzero_recall_stays_valid(self):
+        recall_stats = {
+            "recall_at_k": 0.57,
+            "mean_recall": 0.57,
+            "min_recall": 0.1,
+            "max_recall": 1.0,
+            "num_queries_evaluated": 1000,
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            verdict, payload = _emit(tmp, recall_stats)
+
+        assert verdict == "valid"
+        assert payload["valid"] is True
+        assert payload["recall_summary"]["recall_at_k"] == 0.57
+
+    def test_low_but_nonzero_recall_stays_valid(self):
+        # The gate targets the degenerate all-zero case only; a poorly tuned
+        # index with tiny-but-real recall is a quality problem, not a broken
+        # measurement, and remains a "valid" run.
+        recall_stats = {
+            "recall_at_k": 0.001,
+            "mean_recall": 0.001,
+            "min_recall": 0.0,
+            "max_recall": 0.1,
+            "num_queries_evaluated": 1000,
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            verdict, _ = _emit(tmp, recall_stats)
+
+        assert verdict == "valid"
+
+    def test_missing_recall_stats_preserves_legacy_behavior(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            verdict = emit_result_verdict(
+                tmp,
+                flat_result=_full_coverage_flat_result(),
+                num_queries_evaluated=1000,
+            )
+            with open(
+                os.path.join(tmp, "result_verdict.json"), encoding="utf-8"
+            ) as f:
+                payload = json.load(f)
+
+        assert verdict == "valid"
+        assert payload["recall_summary"] is None
+
+    def test_zero_queries_still_takes_precedence(self):
+        recall_stats = {"max_recall": 0.0}
+        with tempfile.TemporaryDirectory() as tmp:
+            verdict = emit_result_verdict(
+                tmp,
+                flat_result=_full_coverage_flat_result(),
+                num_queries_evaluated=0,
+                recall_stats=recall_stats,
+            )
+
+        assert verdict == "invalid: 0 queries had valid ground truth"
+
+    def test_malformed_recall_stats_do_not_crash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            verdict = emit_result_verdict(
+                tmp,
+                flat_result=_full_coverage_flat_result(),
+                num_queries_evaluated=1000,
+                recall_stats={"max_recall": "not-a-number"},
+            )
+
+        assert verdict == "valid"

--- a/vdb_benchmark/vdbbench/benchmark/backends/milvus/README.md
+++ b/vdb_benchmark/vdbbench/benchmark/backends/milvus/README.md
@@ -72,7 +72,9 @@ compressed index format.
 | `max_degree` | int | 32 | Maximum out-degree of each graph node |
 | `search_list_size` | int | 100 | Candidate-list size during build |
 
-No search-time parameters.
+| Search Parameter | Type | Default | Description |
+|-----------------|------|---------|-------------|
+| `search_list` | int | 16 | Candidate-pool size during graph traversal; must be >= top_k. The benchmark maps `--search-ef` to this key for AISAQ, clamped to the search limit (same as DISKANN). |
 
 ### FLAT
 

--- a/vdb_benchmark/vdbbench/enhanced_bench.py
+++ b/vdb_benchmark/vdbbench/enhanced_bench.py
@@ -874,18 +874,36 @@ def create_flat_collection(
             source_coll = Collection(source_collection_name, using=conn_alias)
 
             if flat_coll.num_entities > 0 and flat_coll.num_entities == source_coll.num_entities:
-                print(
-                    f"FLAT collection '{flat_collection_name}' already exists "
-                    f"with {flat_coll.num_entities} vectors, reusing it."
-                )
-                flat_coll.load()
-                return True
+                # Count equality alone is not identity — a stale FLAT GT from
+                # a regenerated source collection silently drives recall to
+                # exactly 0.00 (issue #805). Verify content before reuse.
+                from vdbbench.simple_bench import verify_flat_matches_source
 
-            print(
-                f"FLAT collection exists but has {flat_coll.num_entities} vs "
-                f"{source_coll.num_entities} vectors. Dropping and recreating..."
-            )
-            utility.drop_collection(flat_collection_name, using=conn_alias)
+                flat_coll.load()
+                source_coll.load()
+                matches, detail = verify_flat_matches_source(
+                    source_coll, flat_coll
+                )
+                if matches:
+                    print(
+                        f"FLAT collection '{flat_collection_name}' already "
+                        f"exists with {flat_coll.num_entities} vectors and "
+                        f"passed the content check ({detail}), reusing it."
+                    )
+                    return True
+
+                print(
+                    f"WARNING: FLAT collection '{flat_collection_name}' has a "
+                    f"matching row count but stale content ({detail}). "
+                    f"Dropping and recreating (issue #805)."
+                )
+                utility.drop_collection(flat_collection_name, using=conn_alias)
+            else:
+                print(
+                    f"FLAT collection exists but has {flat_coll.num_entities} vs "
+                    f"{source_coll.num_entities} vectors. Dropping and recreating..."
+                )
+                utility.drop_collection(flat_collection_name, using=conn_alias)
 
         print(
             f"Creating FLAT collection '{flat_collection_name}' "

--- a/vdb_benchmark/vdbbench/simple_bench.py
+++ b/vdb_benchmark/vdbbench/simple_bench.py
@@ -113,6 +113,7 @@ def emit_result_verdict(
     *,
     flat_result: Optional["FlatSetupResult"],
     num_queries_evaluated: int,
+    recall_stats: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Emit a single unambiguous validity verdict for the whole run.
@@ -129,11 +130,34 @@ def emit_result_verdict(
       * valid    - full coverage and queries actually evaluated.
       * degraded - coverage >= MIN_FLAT_COVERAGE but < 100% (recall computed on
                    an incomplete ground truth; numbers are not trustworthy).
-      * invalid  - no queries evaluated, or a caught error left coverage below
-                   the minimum threshold.
+      * invalid  - no queries evaluated, a caught error left coverage below
+                   the minimum threshold, or every evaluated query scored
+                   recall 0.0 (issue #805).
+
+    The zero-recall gate (issue #805): recall exactly 0.0 on *every* evaluated
+    query means the ANN results share no IDs at all with the FLAT ground
+    truth. That is not a "low quality" configuration — it is the signature of
+    a stale/mismatched ground-truth collection or a broken index build, and
+    the accompanying QPS/latency numbers describe a no-hit workload. Such a
+    run must never be reported as valid.
     """
+    all_zero_recall = False
+    if recall_stats is not None and num_queries_evaluated > 0:
+        try:
+            all_zero_recall = float(recall_stats.get("max_recall", 1.0)) <= 0.0
+        except (TypeError, ValueError):
+            all_zero_recall = False
+
     if num_queries_evaluated <= 0:
         verdict = "invalid: 0 queries had valid ground truth"
+    elif all_zero_recall:
+        verdict = (
+            f"invalid: recall is 0.0 for every one of {num_queries_evaluated} "
+            f"evaluated queries — ANN results share no IDs with the FLAT "
+            f"ground truth (stale/mismatched ground-truth collection or a "
+            f"broken index build); QPS/latency numbers do not represent a "
+            f"real search workload"
+        )
     elif flat_result is None:
         # No FLAT setup ran in this process (e.g. --no-create-flat worker that
         # only validated a pre-existing collection). Coverage was checked
@@ -155,11 +179,26 @@ def emit_result_verdict(
     else:
         verdict = "valid"
 
+    recall_summary = None
+    if recall_stats is not None:
+        recall_summary = {
+            key: recall_stats.get(key)
+            for key in (
+                "recall_at_k",
+                "mean_recall",
+                "min_recall",
+                "max_recall",
+                "num_queries_evaluated",
+            )
+            if key in recall_stats
+        }
+
     payload = {
         "result": verdict,
         "valid": verdict.startswith("valid"),
         "num_queries_evaluated": int(num_queries_evaluated),
         "flat_setup": flat_result.to_dict() if flat_result else None,
+        "recall_summary": recall_summary,
     }
     try:
         with open(
@@ -368,6 +407,110 @@ def _detect_schema_fields(collection: Collection) -> Tuple[str, str, DataType]:
     return pk_field, vec_field, pk_dtype
 
 
+# Number of sampled vectors compared between the source and FLAT collections
+# when deciding whether an existing FLAT ground truth can be reused, and the
+# element-wise tolerance for that comparison (issue #805).
+GT_CONTENT_SAMPLE_SIZE = 8
+GT_CONTENT_ATOL = 1e-4
+
+
+def verify_flat_matches_source(
+    source_coll: Collection,
+    flat_coll: Collection,
+    sample_size: int = GT_CONTENT_SAMPLE_SIZE,
+    atol: float = GT_CONTENT_ATOL,
+) -> Tuple[bool, str]:
+    """
+    Verify that a FLAT ground-truth collection contains the *source
+    collection's* vectors, not merely the same number of rows (issue #805).
+
+    An equal entity count is not identity: if the source collection is dropped
+    and re-generated (new random vectors, same size — e.g. rebuilding the same
+    collection name with a different index type or seed) while an old
+    ``<name>_flat_gt`` survives on the server, the count-only reuse guard
+    silently pairs the new ANN collection with a ground truth computed from
+    unrelated vectors. Every ANN result ID then misses the GT set, recall
+    collapses to exactly 0.00 for every query, and QPS/latency still look
+    healthy — the failure signature of issue #805 (AISAQ Recall@10 = 0.00
+    across all runs).
+
+    The check samples a few PKs from the FLAT collection and compares their
+    vectors element-wise against the same PKs in the source collection. Both
+    collections must be loaded by the caller.
+
+    Returns ``(matches, detail)``. Any error during verification is reported
+    as a mismatch so callers rebuild (or fail loudly) instead of trusting an
+    unverifiable ground truth.
+    """
+    try:
+        flat_pk, flat_vec, flat_pk_dtype = _detect_schema_fields(flat_coll)
+        src_pk, src_vec, _ = _detect_schema_fields(source_coll)
+
+        is_int_pk = flat_pk_dtype in (
+            DataType.INT64,
+            DataType.INT32,
+            DataType.INT16,
+            DataType.INT8,
+        )
+
+        # Benchmark IDs are >= 0; "-1" is a safe in-range int64 sentinel
+        # (see the pk-cursor fallback note above about INT64_MIN parsing).
+        first_expr = f"{flat_pk} > -1" if is_int_pk else f'{flat_pk} >= ""'
+
+        flat_rows = flat_coll.query(
+            expr=first_expr,
+            output_fields=[flat_pk, flat_vec],
+            limit=sample_size,
+        )
+        if not flat_rows:
+            return False, "FLAT collection returned no sample rows"
+
+        sample_pks = [row[flat_pk] for row in flat_rows]
+
+        if is_int_pk:
+            src_filter = f"{src_pk} in {[int(v) for v in sample_pks]}"
+        else:
+            escaped = [str(v).replace('"', '\\"') for v in sample_pks]
+            src_filter = (
+                f"{src_pk} in ["
+                + ",".join(f'"{v}"' for v in escaped)
+                + "]"
+            )
+
+        src_rows = source_coll.query(
+            expr=src_filter,
+            output_fields=[src_pk, src_vec],
+            limit=len(sample_pks),
+        )
+        src_map = {row[src_pk]: row[src_vec] for row in src_rows}
+
+        for row in flat_rows:
+            pk_value = row[flat_pk]
+            src_vector = src_map.get(pk_value)
+            if src_vector is None:
+                return (
+                    False,
+                    f"pk {pk_value} exists in the FLAT collection but not in "
+                    f"the source collection",
+                )
+            flat_arr = np.asarray(row[flat_vec], dtype=np.float32)
+            src_arr = np.asarray(src_vector, dtype=np.float32)
+            if flat_arr.shape != src_arr.shape or not np.allclose(
+                flat_arr, src_arr, atol=atol
+            ):
+                return (
+                    False,
+                    f"vector content mismatch at pk {pk_value}; the FLAT "
+                    f"ground truth was built from different data than the "
+                    f"current source collection",
+                )
+
+        return True, f"{len(flat_rows)} sampled vectors match the source"
+
+    except Exception as exc:
+        return False, f"content verification failed: {exc}"
+
+
 def validate_existing_flat_collection(
     host: str,
     port: str,
@@ -418,9 +561,23 @@ def validate_existing_flat_collection(
             return False
 
         flat_coll.load()
+        source_coll.load()
+
+        matches, detail = verify_flat_matches_source(source_coll, flat_coll)
+        if not matches:
+            print(
+                f"ERROR: FLAT collection '{flat_collection_name}' has a "
+                f"matching row count but its content does not match source "
+                f"collection '{source_collection_name}' ({detail}). It is "
+                f"stale and would drive recall to 0.00 (issue #805). "
+                f"Drop it and re-run without --no-create-flat on one rank to "
+                f"rebuild the ground truth."
+            )
+            return False
+
         print(
             f"Using existing FLAT collection '{flat_collection_name}' "
-            f"with {flat_count} vectors."
+            f"with {flat_count} vectors (content check: {detail})."
         )
         return True
 
@@ -476,24 +633,45 @@ def create_flat_collection(
             if flat_coll.num_entities > 0 and (
                 flat_coll.num_entities == source_coll.num_entities
             ):
-                print(
-                    f"FLAT collection '{flat_collection_name}' already exists "
-                    f"with {flat_coll.num_entities} vectors, reusing it."
-                )
+                # A matching row count alone is NOT sufficient to reuse the
+                # FLAT collection: a stale GT left over from a regenerated
+                # source collection has the same size but unrelated vectors,
+                # which silently drives recall to 0.00 (issue #805). Verify
+                # actual content before trusting it.
                 flat_coll.load()
-                return FlatSetupResult(
-                    ok=True,
-                    coverage=1.0,
-                    total_vectors=source_coll.num_entities,
-                    copied_vectors=flat_coll.num_entities,
-                    reused=True,
+                source_coll.load()
+                matches, detail = verify_flat_matches_source(
+                    source_coll, flat_coll
                 )
+                if matches:
+                    print(
+                        f"FLAT collection '{flat_collection_name}' already "
+                        f"exists with {flat_coll.num_entities} vectors and "
+                        f"passed the content check ({detail}), reusing it."
+                    )
+                    return FlatSetupResult(
+                        ok=True,
+                        coverage=1.0,
+                        total_vectors=source_coll.num_entities,
+                        copied_vectors=flat_coll.num_entities,
+                        reused=True,
+                    )
 
-            print(
-                f"FLAT collection exists but has {flat_coll.num_entities} vs "
-                f"{source_coll.num_entities} vectors. Dropping and recreating..."
-            )
-            utility.drop_collection(flat_collection_name, using=conn_alias)
+                print(
+                    f"WARNING: FLAT collection '{flat_collection_name}' has a "
+                    f"matching row count but its content does not match the "
+                    f"source collection ({detail}). It is stale — likely left "
+                    f"over from a previous data generation of "
+                    f"'{source_collection_name}'. Dropping and recreating "
+                    f"(issue #805)."
+                )
+                utility.drop_collection(flat_collection_name, using=conn_alias)
+            else:
+                print(
+                    f"FLAT collection exists but has {flat_coll.num_entities} vs "
+                    f"{source_coll.num_entities} vectors. Dropping and recreating..."
+                )
+                utility.drop_collection(flat_collection_name, using=conn_alias)
 
         print(
             f"Creating FLAT collection '{flat_collection_name}' "
@@ -2224,6 +2402,7 @@ def main():
         output_dir,
         flat_result=flat_result,
         num_queries_evaluated=num_queries_evaluated,
+        recall_stats=recall_stats,
     )
     if not verdict.startswith("valid"):
         print(


### PR DESCRIPTION
Fixes #805.

## Problem

The Solidigm v3.0.42 AISAQ submission reported **Recall@10 = 0.00 for all 1,000 queries in all 5 runs**, yet `result_verdict.json` said `"result": "valid", "valid": true`. Two defects combined to produce this:

**1. Stale FLAT ground-truth reuse (root cause of the 0.00).** `create_flat_collection()` reused an existing `<collection>_flat_gt` whenever its *entity count* matched the source collection. Count equality is not identity: when a source collection is dropped and regenerated (rebuilding the same collection name for a different index type, seed, or fresh datagen) while the old `_flat_gt` survives on the Milvus server, the benchmark silently pairs the new ANN collection with a ground truth computed from the *previous* dataset's random vectors. Every ANN result ID then misses the GT set — recall is exactly 0.00 on every query, deterministically — while QPS, latency, and `flat_setup.coverage: 1.0` (which only measures row count) all look healthy. This matches the issue's evidence precisely, including why only AISAQ was affected: that collection was rebuilt over a stale GT, while the DISKANN/HNSW collections were paired with GTs built from their own data. The `--no-create-flat` worker path (`validate_existing_flat_collection()`) had the identical count-only defect.

**2. Verdict blind to recall.** `emit_result_verdict()` keyed only on FLAT coverage and evaluated-query count, so a run in which every per-query recall was 0.0 sailed through as valid and flowed into the submission as trustworthy. All-zero recall is never a tuning outcome — it is the signature of a mismatched ground truth or a broken index build — and per the #489/#572 loud-failure policy it must invalidate the run.

## Changes

- **New `verify_flat_matches_source()`** (`simple_bench.py`): before reusing a count-matching FLAT GT, sample `GT_CONTENT_SAMPLE_SIZE=8` PKs from the FLAT collection and compare their vectors element-wise (`np.allclose`, atol 1e-4) against the same PKs in the source. Uses the int64-safe `pk > -1` sentinel from the #572 cursor fix and VARCHAR-safe `in` filters. Any verification error is treated as a mismatch, so callers rebuild rather than trust an unverifiable GT. Cost is ~8 point queries — negligible against the 10M-row GT rebuild it correctly forces or avoids.
- **`create_flat_collection()`** (`simple_bench.py` and `enhanced_bench.py`): a count match now also requires a content match; stale GTs are dropped and rebuilt with a loud `WARNING … (issue #805)` message.
- **`validate_existing_flat_collection()`** (`--no-create-flat` distributed workers, which cannot rebuild): content mismatch fails validation with actionable remediation instructions instead of silently proceeding.
- **`emit_result_verdict()`**: new optional `recall_stats` input. When queries were evaluated but `max_recall == 0.0` (every query zero), the verdict becomes `invalid: recall is 0.0 for every one of N evaluated queries — ANN results share no IDs with the FLAT ground truth …`, the process exits non-zero, and a `recall_summary` block (`recall_at_k`, `mean/min/max_recall`, `num_queries_evaluated`) is written into `result_verdict.json` so the verdict is auditable without opening `recall_stats.json`. Deliberately, low-but-nonzero recall remains valid (a tuning problem, not a measurement failure), and omitting `recall_stats` preserves legacy behavior for the early-abort call sites.
- **Docs**: correct the Milvus backend README — AISAQ *does* take `search_list` at query time (>= top_k, same as DISKANN, which the code already handles via #621); it previously claimed "No search-time parameters."

## Testing

- New `tests/tests/test_issue_805_stale_gt_zero_recall.py` — 11 dependency-free cases using the fake-pymilvus pattern from #572:
  - **Content check**: matching content accepted; stale content with equal count rejected (the #805 scenario); PK missing from source rejected; query errors treated as mismatch; empty FLAT sample rejected.
  - **Verdict gate**: all-zero recall → invalid with `valid: false` and populated `recall_summary`; nonzero and low-but-nonzero recall → valid; missing `recall_stats` → legacy behavior (`recall_summary: null`); zero-queries branch keeps precedence; malformed `recall_stats` does not crash.
- Full vdb suite: **188 passed** with this change vs **177 on main**, with the identical set of pre-existing environment-dependent collection errors (modules requiring a real `pymilvus`/`h5py`) on both — no regressions in the #489/#572/#625/#621 guard suites.
- Verified end-to-end against live Milvus: regenerate the same collection name with a new seed, run the benchmark — on main the stale GT is silently reused (recall 0.00, `RESULT: valid`); with this PR the run prints the stale-content warning, rebuilds the GT, and reports non-zero recall. Forcing the stale-GT condition via `--no-create-flat` now aborts with the new invalid verdict and non-zero exit code.

## Submitter impact

- Affected AISAQ runs should be re-executed. Remediation: drop the stale GT (`utility.drop_collection("<collection>_flat_gt")`) or simply run with this fix, which detects and rebuilds it automatically.
- No results-schema break: `result_verdict.json` gains one additive field (`recall_summary`); existing consumers keying on `result`/`valid` are unaffected.
- A recurrence of this failure mode can no longer produce a "valid" artifact — it aborts loudly at run time, before anything reaches the submission checker.
