### PR TITLE
fix(storage#805): flag 0.0-recall vector_database runs invalid in mlpstorage validate

### DIFF
--- a/mlpstorage_py/submission_checker/checks/vdb_checks.py
+++ b/mlpstorage_py/submission_checker/checks/vdb_checks.py
@@ -27,6 +27,7 @@ loader gains a vdb branch, the warn paths drop out automatically and the
 real checks fire.
 """
 
+import json
 import os
 
 from .base import BaseCheck
@@ -49,6 +50,37 @@ _REQUIRED_METRIC_FIELDS = (
     "p99_latency_ms",
     "p999_latency_ms",
 )
+
+
+# Keys, in preference order, from which a scalar recall is extracted when the
+# recall field is the whole recall_stats dict rather than a bare float. The
+# engine writes both shapes: a scalar in some paths and the full dict in
+# calculate_statistics (``"recall": recall_stats``). ``max_recall`` is first
+# because max recall == 0 is the exact "every query missed the ground truth"
+# signature the §5.3.2 zero gate targets (issue #805).
+_RECALL_SCALAR_KEYS = ("max_recall", "mean_recall", "recall_at_k", "recall")
+
+
+def _coerce_recall_value(recall):
+    """Return a float recall from either a scalar or a recall_stats dict.
+
+    Returns ``None`` for anything from which a number cannot be read (None, a
+    string, an empty/foreign dict). ``None`` means "value unknown" — callers
+    must never manufacture a 0.0 verdict from it. ``bool`` is rejected on
+    purpose so a stray ``True``/``False`` is not read as ``1.0``/``0.0``.
+    """
+    if isinstance(recall, bool):
+        return None
+    if isinstance(recall, (int, float)):
+        return float(recall)
+    if isinstance(recall, dict):
+        for key in _RECALL_SCALAR_KEYS:
+            value = recall.get(key)
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, (int, float)):
+                return float(value)
+    return None
 
 
 # Allowed CLOSED tunable parameters per Rules.md §5.6.4 table.
@@ -473,11 +505,54 @@ class VdbCheck(BaseCheck):
                         self.path, ts,
                     )
                     valid = False
+                    continue
+                # The file exists, so presence is satisfied; read its value for
+                # the zero gate below. An unreadable file leaves recall None,
+                # which the gate treats as "value unknown" (never a
+                # manufactured 0.0) — legacy present-but-unread behavior.
+                recall = self._read_recall_stats(recall_stats_path)
+
+            # Zero-recall gate (issue #805): recall 0.0 on every evaluated query
+            # means the ANN results share no IDs with the FLAT ground truth — a
+            # stale/mismatched GT or a broken index build, not a low-quality
+            # tuning result. Such a run is invalid regardless of the (still
+            # deferred) per-scale minimum-recall table warned above.
+            recall_value = _coerce_recall_value(recall)
+            if recall_value is not None and recall_value <= 0.0:
+                self.log_violation(
+                    "5.3.2", "vdbRecallReported", self.path,
+                    "vdbRecallReported: recall is 0.0 for every evaluated query "
+                    "at %s/%s — ANN results share no IDs with the FLAT ground "
+                    "truth (stale/mismatched ground-truth collection or a broken "
+                    "index build); the run is invalid and must not be submitted "
+                    "(issue #805)",
+                    self.path, ts,
+                )
+                valid = False
 
         if not any_run:
             self._vdb_loader_gap_warning("5.3.2", "vdbRecallReported")
 
         return valid
+
+    def _read_recall_stats(self, path):
+        """Load a rank-local recall_stats.json for the §5.3.2 zero gate.
+
+        Returns the parsed object (typically the recall_stats dict) or ``None``
+        when the file cannot be read/parsed. ``None`` means "value unknown":
+        presence is already satisfied by the file existing, and the zero gate
+        must not invalidate a run on data it could not read (issue #805).
+        """
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except (OSError, ValueError) as exc:
+            self.log.debug(
+                "[5.3.2] %s: could not read recall_stats.json for the zero "
+                "gate (%s); treating recall value as unknown",
+                path, exc,
+            )
+            return None
 
     @rule("5.3.3", "vdbQueryCountMinimum")
     def vdb_query_count_minimum(self):

--- a/mlpstorage_py/tests/test_vdb_checks.py
+++ b/mlpstorage_py/tests/test_vdb_checks.py
@@ -485,6 +485,159 @@ class Test_5_3_2_VdbRecallReported:
         assert any("no recall value" in v for v in viol), viol
 
 
+class Test_5_3_2_VdbRecallZeroGate:
+    """Issue #805: a run whose recall is 0.0 must be flagged invalid.
+
+    A stale/mismatched FLAT ground truth or a broken index build drives
+    recall to exactly 0.0 on every query while QPS/latency still look
+    healthy (the AISAQ Recall@10 = 0.00 signature). §5.3.2 previously only
+    checked that a recall value was *present*, so 0.0 passed as valid. This
+    zero gate is deliberately separate from the deferred minimum-recall
+    target table: 0.0 is a broken measurement, never an under-target tuning
+    result, so it hard-fails regardless of the (still-deferred) per-scale
+    threshold.
+    """
+
+    def test_zero_scalar_recall_is_invalid(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "DISKANN")
+        run_files = [
+            (_summary_run(recall=0.0), _metadata(), ts)
+            for ts in _DEFAULT_RUN_TIMESTAMPS
+        ]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_recall_reported() is False
+        viol = _violations(mock_logger, "5.3.2", "vdbRecallReported")
+        assert any("recall is 0.0" in v for v in viol), viol
+        assert any("issue #805" in v for v in viol), viol
+        # One zero violation per affected run (mirrors the 5-run #805 report).
+        zero_viol = [v for v in viol if "recall is 0.0" in v]
+        assert len(zero_viol) == len(_DEFAULT_RUN_TIMESTAMPS), zero_viol
+
+    def test_zero_recall_stats_dict_is_invalid(self, tmp_path, mock_logger):
+        # calculate_statistics() writes summary["recall"] as the whole
+        # recall_stats dict (simple_bench.py: '"recall": recall_stats'), so
+        # the gate must coerce a scalar from max_recall/mean_recall/recall_at_k.
+        zero_recall = {
+            "recall_at_k": 0.0,
+            "mean_recall": 0.0,
+            "min_recall": 0.0,
+            "max_recall": 0.0,
+            "num_queries_evaluated": 1000,
+        }
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        run_files = [
+            (_summary_run(recall=zero_recall), _metadata(), _DEFAULT_RUN_TIMESTAMPS[0])
+        ]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_recall_reported() is False
+        assert any(
+            "recall is 0.0" in v
+            for v in _violations(mock_logger, "5.3.2", "vdbRecallReported")
+        )
+
+    def test_nonzero_scalar_recall_stays_valid(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "DISKANN")
+        run_files = [
+            (_summary_run(recall=0.57), _metadata(), ts)
+            for ts in _DEFAULT_RUN_TIMESTAMPS
+        ]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_recall_reported() is True
+        assert _violations(mock_logger, "5.3.2", "vdbRecallReported") == []
+
+    def test_nonzero_recall_dict_stays_valid(self, tmp_path, mock_logger):
+        good = {
+            "recall_at_k": 0.61,
+            "mean_recall": 0.61,
+            "min_recall": 0.2,
+            "max_recall": 1.0,
+            "num_queries_evaluated": 1000,
+        }
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "HNSW")
+        run_files = [(_summary_run(recall=good), _metadata(), _DEFAULT_RUN_TIMESTAMPS[0])]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_recall_reported() is True
+        assert _violations(mock_logger, "5.3.2", "vdbRecallReported") == []
+
+    def test_low_but_nonzero_recall_stays_valid(self, tmp_path, mock_logger):
+        # Mirrors PR #806: tiny-but-real recall is a tuning problem, not a
+        # broken measurement — it stays valid.
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "DISKANN")
+        run_files = [
+            (_summary_run(recall=0.001), _metadata(), _DEFAULT_RUN_TIMESTAMPS[0])
+        ]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_recall_reported() is True
+
+    def test_zero_recall_via_recall_stats_fallback_is_invalid(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        ts = _DEFAULT_RUN_TIMESTAMPS[0]
+        # summary.json has no recall key; the rank-local recall_stats.json is
+        # the fallback the checker consults for presence — now also for value.
+        (leaf / "run" / ts / "recall_stats.json").write_text(
+            json.dumps(
+                {
+                    "recall_at_k": 0.0,
+                    "mean_recall": 0.0,
+                    "max_recall": 0.0,
+                    "num_queries_evaluated": 1000,
+                }
+            ),
+            encoding="utf-8",
+        )
+        bad_summary = _summary_run()
+        bad_summary.pop("recall")
+        run_files = [(bad_summary, _metadata(), ts)]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_recall_reported() is False
+        assert any(
+            "recall is 0.0" in v
+            for v in _violations(mock_logger, "5.3.2", "vdbRecallReported")
+        )
+
+    def test_nonzero_recall_stats_fallback_stays_valid(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        ts = _DEFAULT_RUN_TIMESTAMPS[0]
+        (leaf / "run" / ts / "recall_stats.json").write_text(
+            json.dumps(
+                {
+                    "recall_at_k": 0.9,
+                    "mean_recall": 0.9,
+                    "max_recall": 1.0,
+                    "num_queries_evaluated": 1000,
+                }
+            ),
+            encoding="utf-8",
+        )
+        good_summary = _summary_run()
+        good_summary.pop("recall")
+        run_files = [(good_summary, _metadata(), ts)]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_recall_reported() is True
+        # Presence is satisfied by the file; the coerced value is nonzero, so
+        # no zero violation either.
+        assert _violations(mock_logger, "5.3.2", "vdbRecallReported") == []
+
+    def test_unparseable_recall_stats_fallback_does_not_false_flag(
+        self, tmp_path, mock_logger
+    ):
+        # A present-but-unreadable recall_stats.json keeps legacy behavior:
+        # presence is satisfied and the value is unknown, so the run is not
+        # invalidated by the zero gate (we never manufacture a 0.0 verdict
+        # from missing data).
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        ts = _DEFAULT_RUN_TIMESTAMPS[0]
+        (leaf / "run" / ts / "recall_stats.json").write_text(
+            "{ not json", encoding="utf-8"
+        )
+        summary = _summary_run()
+        summary.pop("recall")
+        run_files = [(summary, _metadata(), ts)]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_recall_reported() is True
+        assert _violations(mock_logger, "5.3.2", "vdbRecallReported") == []
+
+
 # ===========================================================================
 # §5.3.3 vdbQueryCountMinimum
 # ===========================================================================


### PR DESCRIPTION
Relates to #805. Submission-checker backstop that complements the run-time engine gate in #806.

## Problem

`mlpstorage validate` could not detect the failure behind #805 (Solidigm v3.0.42 AISAQ, Recall@10 = 0.00 on all 1,000 queries across all 5 runs). §5.3.2 `vdbRecallReported` only checked that a recall value was **present** in `summary.json` (or that a rank-local `recall_stats.json` existed) — never its magnitude. `recall: 0.0` is a present value, so it passed.

The magnitude/threshold check in §5.3.2 is deliberately deferred (the per-scale minimum-recall target table is not yet in `config.py`). But **all-zero recall is not an under-target tuning result — it is a broken measurement** (stale/mismatched FLAT ground truth or a broken index build). It must fail regardless of that deferred table.

## Why this is separate from #806

#806 fixes the **vdbbench engine** (`vdb_benchmark/vdbbench/`): it stops reusing a stale FLAT ground truth and makes a run *abort loudly* at run time. This PR is the **submission-checker** layer (`mlpstorage_py/`) — a distinct codebase `validate` runs post-hoc.

Crucially, this layer is the only one that catches the **already-produced** #805 artifacts: their `result_verdict.json` says `"valid": true` (the buggy engine wrote it) and `flat_setup.coverage` is `1.0`. So neither honoring the stored engine verdict nor a coverage check would flag them — only re-deriving the verdict from the recorded recall data does. That is exactly what this gate does.

## Changes

- **`vdb_checks.py` §5.3.2 `vdb_recall_reported`**: read the recall *value* and emit a hard `log_violation` (`valid = False`) when it is `0.0`, with an actionable message referencing #805. Independent of the still-deferred per-scale threshold table (that `warn_violation` is unchanged).
- **`_coerce_recall_value()`**: extracts a scalar from either shape the engine writes — a bare float, or the full `recall_stats` dict (`calculate_statistics` writes `"recall": recall_stats`), preferring `max_recall` (max == 0 iff every query missed). `bool` is rejected on purpose; unreadable input returns `None` ("value unknown").
- **`recall_stats.json` fallback**: upgraded from an existence check to a guarded value read. An unreadable file leaves the value unknown and never manufactures a `0.0` verdict, preserving the legacy present-but-unread behavior.
- Low-but-nonzero recall stays **valid** (a tuning problem, not a measurement failure) — same policy as #806's run-time gate.

## Testing

- New `Test_5_3_2_VdbRecallZeroGate` (8 cases) added TDD RED-first: zero scalar, the `recall_stats`-dict shape, and the `recall_stats.json` fallback each fail against current code; nonzero / low-but-nonzero / unparseable-fallback guard cases pin the non-regressive behavior. The existing §5.3.2 presence cases are preserved.
- Full CI-equivalent sweep, all green: `mlpstorage_py/tests` 874 passed, `tests` 2930 passed (1 skipped), `vdb_benchmark/tests` 217 passed, `kv_cache_benchmark/tests` 238 passed.

## Scope note

`validate` still ignores other integrity signals in `result_verdict.json` (`flat_setup.coverage` / `degraded`, `flat_setup.ok`). Those are adjacent GT-integrity failure modes, not #805 (which has `coverage: 1.0`), and are tracked as a separate follow-up rather than folded in here.
