### PR TITLE
fix(storage#808): add §5.3.5 vdbGroundTruthIntegrity — flag incomplete/failed FLAT ground truth in mlpstorage validate

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -559,6 +559,8 @@ System:
 
 5.3.4. **vdbMetricsReported** -- Each run's `summary.json` must report `throughput_qps` and the latency percentile set (`mean_latency_ms`, `p95_latency_ms`, `p99_latency_ms`, `p999_latency_ms`). The *submission validator* must verify these fields exist and are populated.
 
+5.3.5. **vdbGroundTruthIntegrity** -- Each run's recall must be measured against a complete, correctly built ground truth: the exact (brute-force) reference used to score recall must cover every vector in the queried dataset. A run whose ground truth failed to build, or that covers fewer than all of the dataset's vectors, does not yield a trustworthy recall measurement and is invalid. The *submission validator* must fail any such run.
+
 ## 5.4. VDB Access Via POSIX API Options
 
 5.4.1. **vdbPathArgs** -- The arguments to `mlpstorage` that set the storage path for the vector database data and the directory where output logfiles/results are stored must both be set and must be set to different values.

--- a/mlpstorage_py/submission_checker/checks/vdb_checks.py
+++ b/mlpstorage_py/submission_checker/checks/vdb_checks.py
@@ -152,7 +152,7 @@ class VdbCheck(BaseCheck):
         self.init_checks()
 
     def init_checks(self):
-        """Register all 16 §5 rule methods (Phase 4 D-01 full implementation)."""
+        """Register all 17 §5 rule methods (Phase 4 D-01 + §5.3.5, storage#808)."""
         self.checks = [
             self.vdb_dataset_scale,                # 5.1.1
             self.vdb_dimension_consistency,        # 5.1.2
@@ -162,6 +162,7 @@ class VdbCheck(BaseCheck):
             self.vdb_recall_reported,              # 5.3.2
             self.vdb_query_count_minimum,          # 5.3.3
             self.vdb_metrics_reported,             # 5.3.4
+            self.vdb_ground_truth_integrity,       # 5.3.5
             self.vdb_path_args,                    # 5.4.1
             self.vdb_filesystem_check,             # 5.4.2
             self.vdb_object_storage_backend,       # 5.5.1
@@ -629,6 +630,114 @@ class VdbCheck(BaseCheck):
             self._vdb_loader_gap_warning("5.3.4", "vdbMetricsReported")
 
         return valid
+
+    @rule("5.3.5", "vdbGroundTruthIntegrity")
+    def vdb_ground_truth_integrity(self):
+        """Verify each run's recall was measured against a complete, correctly
+        built ground truth. (Rules.md 5.3.5)
+
+        The benchmark records FLAT ground-truth setup per run in
+        ``result_verdict.json`` (``flat_setup.ok`` and ``flat_setup.coverage``).
+        ``ok == false`` means the ground truth failed to build; ``coverage <
+        1.0`` means recall was scored against an incomplete ground truth (the
+        benchmark's "degraded" state). Either makes the recall untrustworthy,
+        so the run is invalid (issue #808).
+
+        The raw ``flat_setup`` fields are read directly; the stored
+        ``valid``/``result`` verdict is deliberately not trusted — issue #805
+        showed a buggy run can record ``valid: true`` over a broken
+        measurement. A run whose ``result_verdict.json`` is absent, unreadable,
+        or carries no ``flat_setup`` record (e.g. a ``--no-create-flat`` worker
+        that validated the ground truth elsewhere) cannot be assessed here and
+        is warned, never failed.
+        """
+        valid = True
+        if self.mode != "vector_database":
+            return valid
+
+        any_run = False
+        for summary, metadata, ts in self._iter_run_files():
+            any_run = True
+            verdict_path = os.path.join(self.run_path, ts, "result_verdict.json")
+            if not os.path.isfile(verdict_path):
+                self.warn_violation(
+                    "5.3.5", "vdbGroundTruthIntegrity", self.path,
+                    "no result_verdict.json at %s/%s; FLAT ground-truth "
+                    "coverage cannot be assessed (run predates the integrity "
+                    "record)",
+                    self.path, ts,
+                )
+                continue
+
+            verdict = self._read_result_verdict(verdict_path)
+            if verdict is None:
+                self.warn_violation(
+                    "5.3.5", "vdbGroundTruthIntegrity", self.path,
+                    "result_verdict.json at %s/%s could not be read; FLAT "
+                    "ground-truth coverage not assessed",
+                    self.path, ts,
+                )
+                continue
+
+            flat_setup = verdict.get("flat_setup") if isinstance(verdict, dict) else None
+            if not isinstance(flat_setup, dict):
+                self.warn_violation(
+                    "5.3.5", "vdbGroundTruthIntegrity", self.path,
+                    "result_verdict.json at %s/%s carries no flat_setup record; "
+                    "FLAT ground-truth coverage not asserted for this run",
+                    self.path, ts,
+                )
+                continue
+
+            if flat_setup.get("ok") is False:
+                reason = flat_setup.get("reason") or "FLAT ground-truth setup failed"
+                self.log_violation(
+                    "5.3.5", "vdbGroundTruthIntegrity", self.path,
+                    "FLAT ground-truth setup failed for run %s/%s (%s); recall "
+                    "was not measured against a valid ground truth — the run is "
+                    "invalid (issue #808)",
+                    self.path, ts, reason,
+                )
+                valid = False
+                continue
+
+            coverage = flat_setup.get("coverage")
+            if (
+                isinstance(coverage, (int, float))
+                and not isinstance(coverage, bool)
+                and coverage < 1.0
+            ):
+                self.log_violation(
+                    "5.3.5", "vdbGroundTruthIntegrity", self.path,
+                    "FLAT ground-truth coverage is %.4f (< 1.0) for run %s/%s; "
+                    "recall was computed against an incomplete ground truth — "
+                    "the run is invalid (issue #808)",
+                    coverage, self.path, ts,
+                )
+                valid = False
+
+        if not any_run:
+            self._vdb_loader_gap_warning("5.3.5", "vdbGroundTruthIntegrity")
+
+        return valid
+
+    def _read_result_verdict(self, path):
+        """Load a run's result_verdict.json for the §5.3.5 integrity gate.
+
+        Returns the parsed object, or ``None`` when the file cannot be
+        read/parsed. The caller treats ``None`` (and a missing ``flat_setup``)
+        as "not assessable" and warns rather than failing, so an unreadable
+        record never false-fails a run (issue #808).
+        """
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except (OSError, ValueError) as exc:
+            self.log.debug(
+                "[5.3.5] %s: could not read result_verdict.json (%s)",
+                path, exc,
+            )
+            return None
 
     # -----------------------------------------------------------------------
     # 5.4 POSIX-API options

--- a/mlpstorage_py/tests/test_vdb_checks.py
+++ b/mlpstorage_py/tests/test_vdb_checks.py
@@ -708,6 +708,138 @@ class Test_5_3_4_VdbMetricsReported:
 
 
 # ===========================================================================
+# §5.3.5 vdbGroundTruthIntegrity
+# ===========================================================================
+
+class Test_5_3_5_VdbGroundTruthIntegrity:
+    """Issue #808: a run whose FLAT ground truth was incomplete or failed to
+    build must be flagged invalid.
+
+    The engine records FLAT ground-truth setup in result_verdict.json
+    (flat_setup.ok / flat_setup.coverage). coverage < 1.0 means recall was
+    computed against a partial ground truth — the engine's own "degraded"
+    (valid: false) — and ok == false means setup failed outright; either
+    invalidates the run. The raw flat_setup fields are read directly; the
+    stored verdict string is not trusted (issue #805 showed it can be wrong).
+
+    A missing/unreadable result_verdict.json (pre-#806 artifacts, or a
+    --no-create-flat worker whose verdict carries flat_setup: null) is "not
+    assessable": it warns but never false-fails a run.
+    """
+
+    def _write_verdict(self, leaf, ts, flat_setup, valid=True):
+        payload = {
+            "result": "valid" if valid else "invalid",
+            "valid": valid,
+            "num_queries_evaluated": 1000,
+            "flat_setup": flat_setup,
+        }
+        (leaf / "run" / ts / "result_verdict.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+    def test_full_coverage_ok_passes(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        for ts in _DEFAULT_RUN_TIMESTAMPS:
+            self._write_verdict(
+                leaf, ts,
+                {"ok": True, "coverage": 1.0,
+                 "total_vectors": 1000, "copied_vectors": 1000},
+            )
+        run_files = [(_summary_run(), _metadata(), ts) for ts in _DEFAULT_RUN_TIMESTAMPS]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_ground_truth_integrity() is True
+        assert _violations(mock_logger, "5.3.5", "vdbGroundTruthIntegrity") == []
+
+    def test_incomplete_coverage_is_invalid(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        ts = _DEFAULT_RUN_TIMESTAMPS[0]
+        self._write_verdict(
+            leaf, ts,
+            {"ok": True, "coverage": 0.8,
+             "total_vectors": 1000, "copied_vectors": 800},
+            valid=False,
+        )
+        run_files = [(_summary_run(), _metadata(), ts)]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_ground_truth_integrity() is False
+        viol = _violations(mock_logger, "5.3.5", "vdbGroundTruthIntegrity")
+        assert any("coverage" in v for v in viol), viol
+        assert any("issue #808" in v for v in viol), viol
+
+    def test_failed_flat_setup_is_invalid(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        ts = _DEFAULT_RUN_TIMESTAMPS[0]
+        self._write_verdict(
+            leaf, ts,
+            {"ok": False, "coverage": 0.0,
+             "reason": "could not connect to Milvus for FLAT setup"},
+            valid=False,
+        )
+        run_files = [(_summary_run(), _metadata(), ts)]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_ground_truth_integrity() is False
+        viol = _violations(mock_logger, "5.3.5", "vdbGroundTruthIntegrity")
+        assert any("setup failed" in v for v in viol), viol
+        assert any("issue #808" in v for v in viol), viol
+
+    def test_all_five_runs_incomplete_each_flagged(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        for ts in _DEFAULT_RUN_TIMESTAMPS:
+            self._write_verdict(
+                leaf, ts,
+                {"ok": True, "coverage": 0.5,
+                 "total_vectors": 1000, "copied_vectors": 500},
+                valid=False,
+            )
+        run_files = [(_summary_run(), _metadata(), ts) for ts in _DEFAULT_RUN_TIMESTAMPS]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_ground_truth_integrity() is False
+        viol = _violations(mock_logger, "5.3.5", "vdbGroundTruthIntegrity")
+        assert len([v for v in viol if "coverage" in v]) == len(_DEFAULT_RUN_TIMESTAMPS)
+
+    def test_missing_result_verdict_warns_not_fails(self, tmp_path, mock_logger):
+        # No result_verdict.json — a pre-#806 artifact. Not assessable.
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        run_files = [(_summary_run(), _metadata(), _DEFAULT_RUN_TIMESTAMPS[0])]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_ground_truth_integrity() is True
+        assert _violations(mock_logger, "5.3.5", "vdbGroundTruthIntegrity") == []
+        assert _warnings(mock_logger, "5.3.5", "vdbGroundTruthIntegrity")
+
+    def test_null_flat_setup_warns_not_fails(self, tmp_path, mock_logger):
+        # --no-create-flat worker path: verdict present, flat_setup null.
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        ts = _DEFAULT_RUN_TIMESTAMPS[0]
+        self._write_verdict(leaf, ts, None)
+        run_files = [(_summary_run(), _metadata(), ts)]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_ground_truth_integrity() is True
+        assert _violations(mock_logger, "5.3.5", "vdbGroundTruthIntegrity") == []
+        assert _warnings(mock_logger, "5.3.5", "vdbGroundTruthIntegrity")
+
+    def test_unreadable_result_verdict_warns_not_fails(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        ts = _DEFAULT_RUN_TIMESTAMPS[0]
+        (leaf / "run" / ts / "result_verdict.json").write_text(
+            "{ not json", encoding="utf-8"
+        )
+        run_files = [(_summary_run(), _metadata(), ts)]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_ground_truth_integrity() is True
+        assert _violations(mock_logger, "5.3.5", "vdbGroundTruthIntegrity") == []
+
+    def test_noop_on_non_vdb_mode(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "AISAQ")
+        check = _make_vdb_check(
+            leaf, "closed", mock_logger, run_files=[], mode="training"
+        )
+        assert check.vdb_ground_truth_integrity() is True
+        assert mock_logger.errors == []
+        assert mock_logger.warnings == []
+
+
+# ===========================================================================
 # §5.4.1 vdbPathArgs
 # ===========================================================================
 

--- a/mlpstorage_py/tests/test_vdb_checks.py
+++ b/mlpstorage_py/tests/test_vdb_checks.py
@@ -216,11 +216,11 @@ def _warnings(mock_logger, rule_id: str, rule_name: str):
 
 
 # ===========================================================================
-# Mode-guard sweep — proves all 16 rules no-op on non-vdb submissions
+# Mode-guard sweep — proves all 17 rules no-op on non-vdb submissions
 # ===========================================================================
 
 class TestModeGuardNoOpsOnNonVdbSubmissions:
-    """All 16 §5 rule methods must no-op when mode != "vector_database".
+    """All 17 §5 rule methods must no-op when mode != "vector_database".
 
     Proves the post-Plan-04-01 guard string is "vector_database" (not
     "vector_database"). A regression to the old guard string would
@@ -242,6 +242,7 @@ class TestModeGuardNoOpsOnNonVdbSubmissions:
             "vdb_collection_populated", "vdb_index_build_completed",
             "vdb_run_count", "vdb_recall_reported",
             "vdb_query_count_minimum", "vdb_metrics_reported",
+            "vdb_ground_truth_integrity",
             "vdb_path_args", "vdb_filesystem_check",
             "vdb_object_storage_backend", "vdb_closed_submission_checksum",
             "vdb_closed_database_backend", "vdb_closed_index_types",


### PR DESCRIPTION
Fixes #808. Follow-up to #806 (engine stale-GT fix) and #807 (submission-checker recall-0.0 gate).

## Problem

`mlpstorage validate` never reads `result_verdict.json`, so it was blind to whether a run's recall was measured against a valid ground truth. A `vector_database` run whose FLAT ground truth was **incomplete** (`flat_setup.coverage < 1.0` — the benchmark's own "degraded" state, which it already records as `valid: false`) or **failed to build** (`flat_setup.ok == false`) passed validation as clean. Recall computed against a partial or absent ground truth is not trustworthy, so such a run must be invalid.

This is the adjacent ground-truth-integrity gap called out in #807's scope note — distinct from #805 itself (whose artifacts report `coverage: 1.0`), and distinct from the recall-0.0 gate #807 added.

## Changes

- **New Rules.md rule §5.3.5 `vdbGroundTruthIntegrity`**, stated as a declarative requirement: *each run's recall must be measured against a complete, correctly built ground truth; a run whose ground truth failed to build, or that covers fewer than all of the dataset's vectors, is invalid.*
- **`vdb_checks.py` — new `@rule("5.3.5") vdb_ground_truth_integrity`**: reads the **raw** `flat_setup.ok` / `flat_setup.coverage` fields directly and hard-fails when `ok == false` or `coverage < 1.0`. The stored `valid`/`result` verdict is deliberately **not** trusted — #805 showed a buggy run can record `valid: true` over a broken measurement, so re-deriving from the raw fields is the whole point.
- **Not-assessable is not a failure**: a run whose `result_verdict.json` is absent (pre-#806 artifacts), unreadable, or carries `flat_setup: null` (e.g. a distributed `--no-create-flat` worker that validated the ground truth elsewhere) is **warned**, never failed — so this rule never false-fails a legitimate older submission.
- Registered as the 17th §5 rule; `reconcile()` maps it automatically via the `@rule` binding (no `coverage_mapping` edit needed). Mode-guard sweep updated to 17 rules.

## Design decisions (confirmed with maintainer)

- **Home**: a dedicated new rule (§5.3.5) rather than overloading §5.3.2 (recall) or §5.2.2 (index build) — FLAT ground-truth integrity is a distinct, nameable validity concept.
- **Severity**: both `coverage < 1.0` and `ok == false` are **hard violations**, matching the engine's own `valid: false` for degraded runs and the #489/#572 loud-failure policy.

## Testing

- New `Test_5_3_5_VdbGroundTruthIntegrity` (8 cases), added TDD RED-first: full coverage + ok passes; `coverage < 1.0` invalid; `ok == false` invalid; all-5-runs-incomplete each flagged; and the not-assessable paths (missing / `flat_setup:null` / unreadable) warn but never fail. The mode-guard sweep and `test_rules_coverage` (`reconcile()` → `unmapped == set()`) stay green.
- Full CI-equivalent sweep, all green, no regressions: `mlpstorage_py/tests` 882 passed (874 + 8 new), `tests` 2930 passed (1 skipped), `vdb_benchmark/tests` 228 passed, `kv_cache_benchmark/tests` 238 passed.
