### PR TITLE
chore: bump 3.0.43 -> 3.0.44

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.43"
+version = "3.0.44"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.43"
+version = "3.0.44"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
Version bump 3.0.43 → 3.0.44, covering the #805 ground-truth-integrity fixes now on main: #806 (engine stale-GT fix + run-time verdict gate), #807 (§5.3.2 recall-0.0 gate), and #809 (§5.3.5 vdbGroundTruthIntegrity).

`uv.lock` regenerated via `uv lock` — only the mlpstorage package version changed (108 packages resolved, no dependency drift).