### PR TITLE
docs: add v3.0.44 entry to BugsFixedInVersions.md

### DIFF
--- a/BugsFixedInVersions.md
+++ b/BugsFixedInVersions.md
@@ -444,3 +444,14 @@ Nine mlpstorage-level fixes landed in this range. The DLIO pin and s3dlio floor 
 - `reports reportgen` on a CLOSED checkpointing submission bundled with a `checkpointing datasize` preflight reported "got 3 invocations, expected 1 or 2" and "expected 10 ops, found 20" — datasize inherits the default 10/10 for `--num-checkpoints-*` and the workload-key lumped it with `run`. Now excluded. (#791, #793)
 - Rules 3.4.2 / 4.4.2 / 5.4.2 flagged shared-mount `<data-dir>` / `<results-dir>` as ERROR — many valid layouts share the two paths. Findings now emit at WARN and no longer fail the check; the D-B8 evidence-gap path (no CAP-03 sidecar and no `df` block) still fires as ERROR. Re-validate submissions previously flagged INVALID for this. (#779, #788)
 - VDB uniform-random query recall was non-discriminative at 1536-d (query-corpus similarity concentrates at ~1.1, top-k boundary within float32 noise) — results didn't transfer across index configs. New `query_mode=planted` (contrast >100) and `recall_epsilon` (tie-aware credit); defaults unchanged. (#625, #789)
+
+---
+
+## Version 3.0.44 (July 17, 2026)
+
+Three fixes landed in this range, all closing the #805 VDB ground-truth-integrity failure (Solidigm v3.0.42 AISAQ reported Recall@10 = 0.00 across all five runs, yet every run validated) — one in the vdb_benchmark engine and two in `mlpstorage validate`. The DLIO pin and s3dlio floor did not move.
+
+**Score-Affecting**
+- AISAQ Recall@10 = 0.00 on every query: `create_flat_collection` reused an existing FLAT ground-truth collection whenever its entity *count* matched the source, so a stale ground truth left over from a regenerated collection (same size, different vectors) was silently paired with the new index — every ANN result missed the ground truth and recall was exactly 0.00, while QPS/latency and `coverage: 1.0` still looked healthy. Content is now verified (sampled-vector comparison) before reuse, and any all-zero-recall run aborts at run time instead of writing `valid: true`. (#805; #806)
+- `mlpstorage validate` marked 0.0-recall runs valid: rule §5.3.2 (`vdbRecallReported`) checked only that a recall value was *present*, never its magnitude, so the broken AISAQ artifacts passed submission. It now reads the recall value and invalidates any run whose recall is 0.0, independent of the deferred per-scale minimum-recall table. (#807)
+- `mlpstorage validate` was blind to ground-truth completeness: it never read `result_verdict.json`, so a run whose FLAT ground truth was incomplete (`coverage < 1.0`, the benchmark's "degraded" state) or failed to build passed validation. New rule §5.3.5 (`vdbGroundTruthIntegrity`) reads the raw ground-truth-setup fields and fails such runs; a missing or older record warns rather than false-failing. (#808; #809)


### PR DESCRIPTION
Adds the v3.0.44 changelog entry documenting the three #805 VDB ground-truth-integrity fixes now on main: #806 (engine stale-GT reuse + run-time all-zero-recall gate), #807 (§5.3.2 recall-0.0 validation gate), and #809 (§5.3.5 vdbGroundTruthIntegrity coverage/build gate).

Follows the version bump in #810, mirroring how the v3.0.43 changelog (#799) followed its bump (#798). Documentation only — no code change.