### PR TITLE
fix(storage#802): record VDB storage_root in run metadata; gate 5.4.1 (v3.0 WARN)

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -563,7 +563,7 @@ System:
 
 ## 5.4. VDB Access Via POSIX API Options
 
-5.4.1. **vdbPathArgs** -- The arguments to `mlpstorage` that set the storage path for the vector database data and the directory where output logfiles/results are stored must both be set and must be set to different values.
+5.4.1. **vdbPathArgs** -- For file-API submissions, the vector database data storage path (`--storage-root`, config key `storage.storage_root`) and the output logfile/results directory (`--results-dir`) must both be set and must be different, so that logfiles are not written onto the storage system under test. For object-API submissions the vector database data does not live on a submitter-owned local path, so a storage root is not required and the storage backend is validated under §5.5.1 instead.
 
 5.4.2. **vdbFilesystemCheck** -- The `mlpstorage` command should do a "df" command on the directory pathname where the vector database stores its data and another on the directory pathname where the output logfiles are stored, and record those values in the logfile. The *submission validator* must find those entries in the run's logfile and verify that they are different filesystems, so that logfiles are not accidentally placed on the storage system under test.
 
@@ -628,8 +628,8 @@ System:
 | dataset.vector_dtype       | `--vector-dtype`     | Vector data type (e.g. FLOAT_VECTOR)                             | FLOAT_VECTOR |
 |                            |                      |                                                                  |              |
 | *Storage parameters*       |                      |                                                                  |              |
-| storage.storage_root       | --                   | The storage root directory for VDB data                          | --           |
-| storage.storage_type       | --                   | The storage type (e.g. local_fs, s3)                            | local_fs     |
+| storage.storage_root       | `--storage-root`     | The storage root directory for VDB data                          | --           |
+| storage.storage_type       | `--storage-type`     | The storage type (e.g. local_fs, s3)                            | local_fs     |
 
 5.6.5. **vdbOpenSubmissionParameters** -- For OPEN submissions of this benchmark, the submitter may additionally run against vector database backends other than Milvus — including **Elasticsearch** and **pgvector** — in addition to everything already permitted in CLOSED. The *submission validator* must verify that the recorded `database.database` is one of the supported backends. OPEN submissions may use any index types, metrics, and parameters native to the chosen backend (including the full `VDB_INDEX_TYPES` set such as `IVF_FLAT`, `IVF_SQ8`, and `FLAT` on Milvus), but must still meet the recall target (5.3.2) and report the required metrics (5.3.4). Any parameter not listed here or in the CLOSED table, when modified, must generate a message and fail the validation.
 

--- a/configs/vectordbbench/10m.yaml
+++ b/configs/vectordbbench/10m.yaml
@@ -25,3 +25,10 @@ index:
 workflow:
   compact: True
 
+storage:
+  # Path where the vector database engine stores its data (server-side). Set
+  # this here or pass --storage-root so the run is recorded for Rules.md 5.4.1;
+  # it must differ from --results-dir. Left unset by default.
+  storage_root:
+  storage_type: local_fs
+

--- a/configs/vectordbbench/default.yaml
+++ b/configs/vectordbbench/default.yaml
@@ -33,3 +33,10 @@ benchmark:
   recall_k: 10
   search_limit: 10
 
+storage:
+  # Path where the vector database engine stores its data (server-side). Set
+  # this here or pass --storage-root so the run is recorded for Rules.md 5.4.1;
+  # it must differ from --results-dir. Left unset by default.
+  storage_root:
+  storage_type: local_fs
+

--- a/mlpstorage_py/benchmarks/vectordbbench.py
+++ b/mlpstorage_py/benchmarks/vectordbbench.py
@@ -131,11 +131,43 @@ class VectorDBBenchmark(Benchmark):
 
         self.yaml_params = read_config_from_file(self.config_file)
 
+        self._resolve_storage_args()
+
         if not getattr(args, "what_if", False) and self.command != "datasize":
             self._validate_vdb_dependencies()
 
         self.verify_benchmark()
         self.logger.status("Instantiated the VectorDB Benchmark...")
+
+    def _resolve_storage_args(self):
+        """Record the VDB storage location on ``self.args`` (storage#802).
+
+        The vector-database storage path is server-side — the operator tells us
+        where the engine keeps its data — so unlike training/checkpointing it is
+        not an I/O argument the query client uses. But Rules.md §5.4.1 / §5.6.4
+        require it in the run metadata, and ``metadata['args'] = vars(self.args)``
+        only carries whatever argparse produced. Resolve it here so a
+        ``storage_root``/``storage_type`` key always lands in the metadata.
+
+        Precedence: CLI ``--storage-root``/``--storage-type`` win over the config
+        YAML ``storage:`` section, which wins over the default. ``storage_type``
+        defaults to ``local_fs``; ``storage_root`` has no default and stays
+        ``None`` when neither CLI nor config provides one (§5.4.1 then reports
+        it).
+        """
+        storage_cfg = (self.yaml_params or {}).get("storage") or {}
+
+        cli_root = getattr(self.args, "storage_root", None)
+        self.args.storage_root = (
+            cli_root if cli_root is not None else storage_cfg.get("storage_root")
+        )
+
+        cli_type = getattr(self.args, "storage_type", None)
+        self.args.storage_type = (
+            cli_type
+            if cli_type is not None
+            else storage_cfg.get("storage_type", "local_fs")
+        )
 
     # ------------------------------------------------------------------
     # Dependency validation

--- a/mlpstorage_py/cli/vectordb_args.py
+++ b/mlpstorage_py/cli/vectordb_args.py
@@ -463,6 +463,31 @@ def _add_vectordb_core_args(parser, command, index_choices):
 
     if command in ("datagen", "run"):
         add_storage_type_arguments(parser, required=True)
+        # The VDB storage location is server-side (the operator tells us where
+        # the engine keeps its data); it is recorded in run metadata for
+        # Rules.md §5.4.1 / §5.6.4 rather than passed to the query client
+        # (storage#802). CLI values override the config YAML `storage:` section.
+        storage_group = parser.add_argument_group("VDB Storage Location")
+        storage_group.add_argument(
+            "--storage-root",
+            type=str,
+            default=None,
+            help=(
+                "Filesystem path where the vector database engine stores its "
+                "data. Recorded in run metadata (Rules.md 5.4.1); must differ "
+                "from --results-dir. Overrides the config storage.storage_root."
+            ),
+        )
+        storage_group.add_argument(
+            "--storage-type",
+            type=str,
+            default=None,
+            help=(
+                "Storage medium backing the vector database data (e.g. "
+                "local_fs, s3). Defaults to local_fs. Overrides the config "
+                "storage.storage_type."
+            ),
+        )
 
     if command == "run":
         add_timeseries_arguments(parser)

--- a/mlpstorage_py/submission_checker/checks/vdb_checks.py
+++ b/mlpstorage_py/submission_checker/checks/vdb_checks.py
@@ -114,6 +114,13 @@ _CLOSED_ALLOWED_PARAMS = frozenset({
 })
 
 
+# Ruleset versions for which §5.4.1 vdbPathArgs reports a missing/duplicate VDB
+# storage path as a WARNING rather than a hard failure. The storage-root
+# recording (storage#802) shipped mid-v3.0, so pre-fix v3.0 submissions cannot
+# carry it; a later round restores the hard error by dropping v3.0 from this set.
+_VDB_PATH_ARGS_WARN_VERSIONS = frozenset({"v3.0"})
+
+
 # Additional OPEN params beyond the CLOSED set (Rules.md §5.6.5 table).
 # Backend-specific params (pgvector lists/probes, Elasticsearch m / ef_construction
 # / num_candidates, etc.) are NOT enumerable up-front; non-Milvus backends are
@@ -745,12 +752,35 @@ class VdbCheck(BaseCheck):
 
     @rule("5.4.1", "vdbPathArgs")
     def vdb_path_args(self):
-        """Verify vdb data path and results dir args are both set and differ.
+        """Verify the VDB data storage path and results dir are both set and differ.
         (Rules.md 5.4.1)
+
+        File-API submissions must record a storage root (``storage_root``, set
+        by ``--storage-root`` or the config ``storage.storage_root``) distinct
+        from ``results_dir`` so logfiles are not written onto the storage system
+        under test. Object-API submissions keep their data in a remote/object
+        backend with no submitter-owned local path, so a storage root is not
+        required here — the backend is validated under §5.5.1.
+
+        Severity (storage#802): the storage-root plumbing shipped mid-v3.0, so
+        for the v3.0 ruleset a missing or duplicate path is a WARNING and the
+        run stays valid; a later ruleset version restores the hard error (see
+        ``_VDB_PATH_ARGS_WARN_VERSIONS``). A correctly configured run emits no
+        message at all.
         """
         valid = True
         if self.mode != "vector_database":
             return valid
+
+        # Object-API: no submitter-owned local storage path to require
+        # (Rules.md 5.4.1); §5.5.1 owns the backend check. Silent pass, matching
+        # 5.4.2's object-API handling.
+        if self._get_benchmark_api() == "object":
+            return valid
+
+        warn_only = (
+            getattr(self.config, "version", None) in _VDB_PATH_ARGS_WARN_VERSIONS
+        )
 
         any_run = False
         for summary, metadata, ts in self._iter_run_files():
@@ -762,7 +792,7 @@ class VdbCheck(BaseCheck):
                 )
                 continue
             args = metadata.get("args", {})
-            # The vdb runner uses storage-root for the data path; data_dir is the
+            # The vdb runner uses storage_root for the data path; data_dir is the
             # generic mlpstorage name. Honor either to keep the rule resilient
             # to the args-shape refactor that lands alongside Phase 4.
             data_path = (
@@ -773,31 +803,44 @@ class VdbCheck(BaseCheck):
             results_dir = args.get("results_dir")
 
             if not data_path:
-                self.log_violation(
-                    "5.4.1", "vdbPathArgs", self.path,
-                    "vdbPathArgs: vdb data path arg not set in metadata at %s/%s",
+                if self._emit_path_arg_finding(
+                    warn_only,
+                    "vdbPathArgs: vdb data path (storage_root) not set in "
+                    "metadata at %s/%s",
                     self.path, ts,
-                )
-                valid = False
+                ):
+                    valid = False
             if not results_dir:
-                self.log_violation(
-                    "5.4.1", "vdbPathArgs", self.path,
+                if self._emit_path_arg_finding(
+                    warn_only,
                     "vdbPathArgs: results_dir not set in metadata at %s/%s",
                     self.path, ts,
-                )
-                valid = False
+                ):
+                    valid = False
             if data_path and results_dir and data_path == results_dir:
-                self.log_violation(
-                    "5.4.1", "vdbPathArgs", self.path,
+                if self._emit_path_arg_finding(
+                    warn_only,
                     "vdbPathArgs: vdb data path %s and results_dir %s must differ",
                     data_path, results_dir,
-                )
-                valid = False
+                ):
+                    valid = False
 
         if not any_run:
             self._vdb_loader_gap_warning("5.4.1", "vdbPathArgs")
 
         return valid
+
+    def _emit_path_arg_finding(self, warn_only, msg, *args):
+        """Emit a §5.4.1 finding at WARN (v3.0 round) or ERROR (later rulesets).
+
+        Returns ``True`` when the finding is a hard failure that must flip
+        ``valid`` to False; ``False`` when it was emitted as an advisory warning.
+        """
+        if warn_only:
+            self.warn_violation("5.4.1", "vdbPathArgs", self.path, msg, *args)
+            return False
+        self.log_violation("5.4.1", "vdbPathArgs", self.path, msg, *args)
+        return True
 
     @rule("5.4.2", "vdbFilesystemCheck")
     def vdb_filesystem_check(self):

--- a/mlpstorage_py/tests/test_vdb_checks.py
+++ b/mlpstorage_py/tests/test_vdb_checks.py
@@ -179,10 +179,11 @@ def _make_vdb_check(
     datagen_files=None,
     system_file=None,
     mode: str = "vector_database",
+    version: str = "v3.0",
 ):
     """Instantiate VdbCheck against fake SubmissionLogs / LoaderMetadata."""
     config = Config(
-        version="v3.0",
+        version=version,
         submitters=None,
         skip_output_file=True,
     )
@@ -844,7 +845,25 @@ class Test_5_3_5_VdbGroundTruthIntegrity:
 # §5.4.1 vdbPathArgs
 # ===========================================================================
 
+def _object_api_system_file():
+    """A system YAML declaring the object (S3) benchmark API for 5.4.1 gating."""
+    return {
+        "system_under_test": {
+            "solution": {"architecture": {"benchmark_API": "object"}}
+        }
+    }
+
+
 class Test_5_4_1_VdbPathArgs:
+    """§5.4.1 vdbPathArgs — storage-root recording (issue #802).
+
+    For file-API runs the storage path (storage_root) and results_dir must both
+    be set and differ. The storage-root plumbing shipped mid-v3.0, so for the
+    v3.0 ruleset a missing/duplicate path is a WARNING (advisory, valid stays
+    True); a later ruleset version restores the hard error. Object-API runs
+    have no submitter-owned local path, so they silent-pass (§5.5.1 owns the
+    backend check).
+    """
 
     def test_distinct_paths_pass(self, tmp_path, mock_logger):
         leaf = _build_vdb_leaf(
@@ -860,22 +879,74 @@ class Test_5_4_1_VdbPathArgs:
         )
         assert check.vdb_path_args() is True
         assert _violations(mock_logger, "5.4.1", "vdbPathArgs") == []
+        assert _warnings(mock_logger, "5.4.1", "vdbPathArgs") == []
 
-    def test_equal_paths_log_violation(self, tmp_path, mock_logger):
-        leaf = _build_vdb_leaf(
-            tmp_path, "closed", "acme", "sys-1", "DISKANN",
-        )
+    def test_missing_storage_root_warns_in_v3(self, tmp_path, mock_logger):
+        # The issue #802 scenario: real VDB metadata carries no storage_root.
+        # For v3.0 this is advisory — a WARNING, and the run stays valid.
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "DISKANN")
+        run_files = [
+            (_summary_run(),
+             _metadata(storage_root=None, results_dir="/vdb/results"),
+             "20260618_120100"),
+        ]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_path_args() is True
+        assert _violations(mock_logger, "5.4.1", "vdbPathArgs") == []
+        assert any(
+            "storage_root" in w or "data path" in w
+            for w in _warnings(mock_logger, "5.4.1", "vdbPathArgs")
+        ), _warnings(mock_logger, "5.4.1", "vdbPathArgs")
+
+    def test_equal_paths_warn_in_v3(self, tmp_path, mock_logger):
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "DISKANN")
         run_files = [
             (_summary_run(),
              _metadata(storage_root="/shared", results_dir="/shared"),
              "20260618_120100"),
         ]
+        check = _make_vdb_check(leaf, "closed", mock_logger, run_files=run_files)
+        assert check.vdb_path_args() is True
+        assert _violations(mock_logger, "5.4.1", "vdbPathArgs") == []
+        assert any(
+            "must differ" in w
+            for w in _warnings(mock_logger, "5.4.1", "vdbPathArgs")
+        )
+
+    def test_missing_storage_root_hard_errors_in_later_version(
+        self, tmp_path, mock_logger
+    ):
+        # The v3.0 leniency is scoped: a later ruleset restores the hard error.
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "DISKANN")
+        run_files = [
+            (_summary_run(),
+             _metadata(storage_root=None, results_dir="/vdb/results"),
+             "20260618_120100"),
+        ]
         check = _make_vdb_check(
-            leaf, "closed", mock_logger, run_files=run_files,
+            leaf, "closed", mock_logger, run_files=run_files, version="v4.0",
         )
         assert check.vdb_path_args() is False
-        viol = _violations(mock_logger, "5.4.1", "vdbPathArgs")
-        assert any("must differ" in v for v in viol), viol
+        assert any(
+            "storage_root" in v or "data path" in v
+            for v in _violations(mock_logger, "5.4.1", "vdbPathArgs")
+        )
+
+    def test_object_api_missing_root_silent_pass(self, tmp_path, mock_logger):
+        # Object-API: no submitter-owned local storage path to require.
+        leaf = _build_vdb_leaf(tmp_path, "closed", "acme", "sys-1", "DISKANN")
+        run_files = [
+            (_summary_run(),
+             _metadata(storage_root=None, results_dir="/vdb/results"),
+             "20260618_120100"),
+        ]
+        check = _make_vdb_check(
+            leaf, "closed", mock_logger, run_files=run_files,
+            system_file=_object_api_system_file(), version="v4.0",
+        )
+        assert check.vdb_path_args() is True
+        assert _violations(mock_logger, "5.4.1", "vdbPathArgs") == []
+        assert _warnings(mock_logger, "5.4.1", "vdbPathArgs") == []
 
 
 # ===========================================================================

--- a/tests/unit/test_benchmarks_vectordb.py
+++ b/tests/unit/test_benchmarks_vectordb.py
@@ -728,3 +728,59 @@ class TestVectorDBEffectiveIndexUse:
 
         with pytest.raises(ValueError, match='must match'):
             benchmark._effective_index_type()
+
+
+class TestVectorDBStorageRootResolution:
+    """storage#802: --storage-root / --storage-type resolve onto self.args so
+    the run metadata records them (metadata['args'] = vars(self.args)).
+
+    Precedence: CLI wins over the config YAML ``storage:`` section, which wins
+    over the built-in default (storage_type=local_fs; storage_root has no
+    default and stays unset when neither CLI nor config provides one).
+    """
+
+    def _make(self, tmp_path, yaml_params, **overrides):
+        base = dict(
+            debug=False, verbose=False, what_if=False, stream_log_level='INFO',
+            mode='closed', orgname='Acme', systemname='sys-v1',
+            results_dir=str(tmp_path), command='run', config='default',
+            vdb_engine='milvus', vdb_index='DISKANN',
+            host='127.0.0.1', port=19530, collection='c', category=None,
+            num_query_processes=1, batch_size=1, runtime=60, queries=None,
+            report_count=100, storage_root=None, storage_type=None,
+        )
+        base.update(overrides)
+        args = Namespace(**base)
+        with patch('mlpstorage_py.benchmarks.base.generate_output_location',
+                   return_value=str(tmp_path / "out")), \
+             patch('mlpstorage_py.benchmarks.vectordbbench.read_config_from_file',
+                   return_value=yaml_params), \
+             patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark.verify_benchmark'), \
+             patch('mlpstorage_py.benchmarks.vectordbbench.VectorDBBenchmark._validate_vdb_dependencies'):
+            from mlpstorage_py.benchmarks.vectordbbench import VectorDBBenchmark
+            return VectorDBBenchmark(args)
+
+    def test_cli_storage_root_wins_over_config(self, tmp_path):
+        bm = self._make(
+            tmp_path,
+            {"storage": {"storage_root": "/yaml/root", "storage_type": "s3"}},
+            storage_root="/cli/root", storage_type="local_fs",
+        )
+        assert bm.args.storage_root == "/cli/root"
+        assert bm.args.storage_type == "local_fs"
+
+    def test_config_storage_root_used_when_no_cli(self, tmp_path):
+        bm = self._make(tmp_path, {"storage": {"storage_root": "/yaml/root"}})
+        assert bm.args.storage_root == "/yaml/root"
+        assert bm.args.storage_type == "local_fs"
+
+    def test_defaults_when_absent_everywhere(self, tmp_path):
+        bm = self._make(tmp_path, {})
+        assert bm.args.storage_root is None
+        assert bm.args.storage_type == "local_fs"
+
+    def test_storage_root_lands_in_metadata_args(self, tmp_path):
+        bm = self._make(tmp_path, {"storage": {"storage_root": "/vdb/data"}})
+        meta = bm.metadata
+        assert meta["args"]["storage_root"] == "/vdb/data"
+        assert meta["args"]["storage_type"] == "local_fs"


### PR DESCRIPTION
Fixes #802.

## Problem

`storage.storage_root` never reached VDB run metadata: `metadata['args'] = vars(self.args)`, but nothing set `storage_root`/`storage_type` on `self.args` — there was no CLI flag, no `storage:` section in the VDB config YAMLs, and the `metadata` property never added it. So §5.4.1 `vdbPathArgs` (which looks up `storage_root → data_dir → vdb_data_path` and hard-fails when all are absent) ERRORed on **every** VDB run, and §5.4.2 degraded to its `df` fallback. This is the same Solidigm v3.0.42 submission behind #801/#805.

## Approach (per maintainer direction in #802)

Fix the code to match Rules.md, keeping the A8 escape hatch for what it was meant to cover. `storage_root` for VDB is server-side — the operator telling us where the engine keeps its data — so the flag lives on the harness, not the query client.

## Changes

**Write-side** (so `storage_root` lands in `metadata['args']`):
- `mlpstorage_py/cli/vectordb_args.py`: add `--storage-root` / `--storage-type` to the vectordb `datagen`/`run` subparsers.
- `configs/vectordbbench/{default,10m}.yaml`: add a `storage:` section (`storage_root` unset, `storage_type: local_fs`).
- `mlpstorage_py/benchmarks/vectordbbench.py`: `_resolve_storage_args()` sets `storage_root`/`storage_type` on `self.args` with precedence **CLI > config YAML > default** (`storage_type` defaults to `local_fs`; `storage_root` has no default). `_capacity_gate_destination()` stays `None` (A8 holds); the fs-separation accuracy work is deferred.

**Checker** (`vdb_checks.py`, §5.4.1 `vdb_path_args`):
- **Object-API** submissions silent-pass — no submitter-owned local path to require; §5.5.1 owns the backend check (matches 5.4.2's object handling).
- **File-API**: a missing or duplicate storage path is a **WARNING for the v3.0 ruleset** (the storage-root plumbing shipped mid-round, so pre-fix submissions can't carry it) and the run stays valid; a later ruleset version restores the hard error by dropping `v3.0` from `_VDB_PATH_ARGS_WARN_VERSIONS`. A correctly configured run emits nothing.

**Rules.md**:
- §5.4.1 reworded to name the arguments (`--storage-root` / `storage.storage_root`, `--results-dir`) and state the object-API relaxation (→ §5.5.1).
- §5.6.4 table: CLI-flag column set to `--storage-root` / `--storage-type`.
- The v3.0 enforcement leniency is deliberately **not** in the spec — it's a transitional, checker-side decision; Rules.md states the enduring requirement.

## Submission-window impact

- Existing v3.0.42 VDB artifacts (no `storage_root`) now **validate** — 5.4.1 emits a WARN that reviewers confirm manually (the storage root / log placement), so no re-run is required this round.
- Newly-run submissions passing `--storage-root` (distinct from `--results-dir`) pass 5.4.1 clean.
- §5.4.2 remains advisory (WARN); unchanged here.

## Testing

TDD RED-first. 10 new/updated tests:
- **Write-side** (`tests/unit/test_benchmarks_vectordb.py`): CLI > config > default resolution and that `storage_root`/`storage_type` land in `metadata['args']`.
- **Checker** (`mlpstorage_py/tests/test_vdb_checks.py`): file-API v3.0 missing/duplicate → WARN (valid stays True); clean run silent; later-version → hard ERROR; object-API → silent pass.
- `reconcile()` stays green (5.4.1/5.4.2 IDs+names unchanged; §5.6.4 table rows aren't rule lines).

Full CI-equivalent sweep, all green, no regressions: `mlpstorage_py/tests` 888 passed, `tests` 2934 passed (1 skipped), `vdb_benchmark/tests` 228 passed, `kv_cache_benchmark/tests` 238 passed.
