### PR TITLE
chore: bump 3.0.44 -> 3.0.45

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlpstorage"
-version = "3.0.44"
+version = "3.0.45"
 description = "MLPerf Storage Benchmark Suite"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 
 [[package]]
 name = "mlpstorage"
-version = "3.0.44"
+version = "3.0.45"
 source = { editable = "." }
 dependencies = [
     { name = "dlio-benchmark", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
Version bump 3.0.44 → 3.0.45, covering the #802 VDB storage-root fix now on main (#815).

`uv.lock` regenerated via `uv lock` — only the mlpstorage package version changed (108 packages resolved, no dependency drift).