### PR TITLE
fix(cap02b): PALS-native launcher for --results-dir shared-FS probe

### DIFF
--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -4042,13 +4042,27 @@ def run_results_dir_shared_probe(results_dir, hosts, run_uuid, logger,
         f"(d/('{probe_id}__rank'+r+'__'+h+'.ok')).write_text(h)"
     )
 
-    probe_hosts_arg = ",".join(f"{h}:1" for h in unique_hosts)
-    prefix = (
-        f"{mpi_bin} -n {len(unique_hosts)} -host {probe_hosts_arg} "
-        f"--map-by node --bind-to none"
-    )
-    if allow_run_as_root:
-        prefix += " --allow-run-as-root"
+    # HPE Cray PALS mpiexec (ALCF Crux/Polaris/Aurora) vs OpenMPI mpirun.
+    if mpi_bin == MPIEXEC:
+        # PALS rejects OpenMPI's -host h:slots / --map-by / --bind-to /
+        # --allow-run-as-root; it uses --ppn + a bare --hosts list. The
+        # 1-rank-per-node sentinel write needs no CPU affinity, so --cpu-bind
+        # is left at the PALS default. Mirrors run_shared_fs_probe (#549);
+        # without this, CAP-02b (storage#772) fails every ALCF multi-node run:
+        # mpiexec: unrecognized option '--map-by'.
+        prefix = (
+            f"{MPI_EXEC_BIN} -n {len(unique_hosts)} --ppn 1 "
+            f"--hosts {','.join(unique_hosts)}"
+        )
+    else:
+        mpi_executable = MPI_RUN_BIN if mpi_bin == MPIRUN else mpi_bin
+        probe_hosts_arg = ",".join(f"{h}:1" for h in unique_hosts)
+        prefix = (
+            f"{mpi_executable} -n {len(unique_hosts)} -host {probe_hosts_arg} "
+            f"--map-by node --bind-to none"
+        )
+        if allow_run_as_root:
+            prefix += " --allow-run-as-root"
 
     import shlex as _shlex
     cmd = f"{prefix} {sys.executable} -c {_shlex.quote(inline)}"

--- a/mlpstorage_py/tests/test_cluster_collector.py
+++ b/mlpstorage_py/tests/test_cluster_collector.py
@@ -809,3 +809,42 @@ class TestIntegration:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# --- CAP-02b results-dir probe: PALS-native launcher (ALCF) — regression for
+# --- "mpiexec: unrecognized option '--map-by'" (storage#772; mirrors #549) ---
+def _cap02b_capture_cmd(mpi_bin, tmp_path):
+    import mlpstorage_py.cluster_collector as cc
+    from unittest.mock import patch, MagicMock
+    cap = {}
+    class _Stop(Exception):
+        pass
+    def _fake_run(cmd, **kw):
+        cap["cmd"] = cmd
+        raise _Stop()
+    with patch.object(cc.subprocess, "run", side_effect=_fake_run):
+        try:
+            cc.run_results_dir_shared_probe(
+                str(tmp_path), ["h1", "h2"], "0" * 12, MagicMock(),
+                mpi_bin=mpi_bin, allow_run_as_root=True,
+            )
+        except _Stop:
+            pass
+    return cap.get("cmd", "")
+
+
+def test_cap02b_results_probe_pals_mpiexec_no_map_by(tmp_path):
+    import mlpstorage_py.cluster_collector as cc
+    cmd = _cap02b_capture_cmd(cc.MPIEXEC, tmp_path)
+    assert "--ppn 1" in cmd
+    assert "--cpu-bind" not in cmd
+    assert "--hosts h1,h2" in cmd
+    assert "--map-by" not in cmd
+    assert "--bind-to" not in cmd
+
+
+def test_cap02b_results_probe_mpirun_unchanged(tmp_path):
+    import mlpstorage_py.cluster_collector as cc
+    cmd = _cap02b_capture_cmd(cc.MPIRUN, tmp_path)
+    assert "--map-by node" in cmd
+    assert "--bind-to none" in cmd


### PR DESCRIPTION
## Summary

`run_results_dir_shared_probe()` (the CAP-02b `--results-dir` shared-FS probe added in storage#772) builds its MPI launcher with OpenMPI-only flags — `-host h:slots --map-by node --bind-to none` — **regardless of `--mpi-bin`**. On HPE/Cray **PALS `mpiexec`** (ALCF Crux/Polaris/Aurora) this aborts every multi-node run before any I/O:

```
[E404] CAP-02b: --results-dir shared-FS probe launcher exited with returncode=1.
stderr: mpiexec: unrecognized option '--map-by'
```

Its sibling `run_shared_fs_probe()` (CAP-02, checkpoint dir) already handles this via the PALS branch added in #549 — CAP-02b simply never inherited it. Single-node runs are unaffected because both probes are multi-host-only.

## Fix

Give `run_results_dir_shared_probe()` the same PALS branch: for `mpiexec`, emit `--ppn 1 --hosts <csv>` (no `--map-by` / `--bind-to` / `-host h:slots` / `--allow-run-as-root`). `--cpu-bind` is intentionally left at the PALS default — the probe is a single 1-rank-per-node sentinel write that needs no CPU affinity. The `mpirun`/OpenMPI path is unchanged.

## Tests

Adds to `tests/test_cluster_collector.py`:
- `test_cap02b_results_probe_pals_mpiexec_no_map_by` — mpiexec launcher uses `--ppn 1`/`--hosts h1,h2` and omits `--map-by`/`--bind-to`/`--cpu-bind`.
- `test_cap02b_results_probe_mpirun_unchanged` — mpirun path still emits `--map-by node --bind-to none`.

## Impact

Unblocks multi-node checkpointing (llama3-70b/405b/1t) on all ALCF PALS systems. Related: #549, #564 (same PALS-launcher fix for the main launcher and cluster-collector).
