### PR TITLE
fix(kvcache): PALS-native MPI launch — skip OpenMPI-only --mca for Cray PALS mpiexec

### DIFF
--- a/mlpstorage_py/benchmarks/kvcache.py
+++ b/mlpstorage_py/benchmarks/kvcache.py
@@ -70,6 +70,20 @@ WORKLOAD_PARAMS = {
 }
 
 
+def _abort_suppression_mpi_params(mpi_bin: str) -> List[str]:
+    """OpenMPI abort-suppression MPI params; empty for HPE Cray PALS mpiexec.
+
+    kvcache expects per-rank non-zero exits, so on OpenMPI we pass
+    ``--mca orte_abort_on_non_zero_status 0`` to stop the launcher aborting the
+    whole job on the first non-zero rank. ``--mca`` is OpenMPI-only; HPE Cray
+    PALS ``mpiexec`` (ALCF Crux/Polaris/Aurora) rejects it and the launch fails
+    with "mpiexec: unrecognized option '--mca'", so emit no extra params there.
+    """
+    if mpi_bin == 'mpiexec':
+        return []
+    return ['--mca', 'orte_abort_on_non_zero_status', '0']
+
+
 class KVCacheBenchmark(Benchmark):
     """KV Cache benchmark for LLM inference storage.
 
@@ -281,7 +295,8 @@ class KVCacheBenchmark(Benchmark):
         # the abort-suppression flag authoritative even if the user supplies a
         # conflicting value (kvcache expects per-rank non-zero exits).
         user_mpi_params = list(getattr(self.args, 'mpi_params', None) or [])
-        mpi_params = user_mpi_params + ['--mca', 'orte_abort_on_non_zero_status', '0']
+        mpi_params = user_mpi_params + _abort_suppression_mpi_params(
+            getattr(self.args, 'mpi_bin', 'mpirun'))
 
         mpi_prefix = generate_mpi_prefix_cmd(
             mpi_cmd=getattr(self.args, 'mpi_bin', 'mpirun'),

--- a/mlpstorage_py/cluster_collector.py
+++ b/mlpstorage_py/cluster_collector.py
@@ -4042,13 +4042,27 @@ def run_results_dir_shared_probe(results_dir, hosts, run_uuid, logger,
         f"(d/('{probe_id}__rank'+r+'__'+h+'.ok')).write_text(h)"
     )
 
-    probe_hosts_arg = ",".join(f"{h}:1" for h in unique_hosts)
-    prefix = (
-        f"{mpi_bin} -n {len(unique_hosts)} -host {probe_hosts_arg} "
-        f"--map-by node --bind-to none"
-    )
-    if allow_run_as_root:
-        prefix += " --allow-run-as-root"
+    # HPE Cray PALS mpiexec (ALCF Crux/Polaris/Aurora) vs OpenMPI mpirun.
+    if mpi_bin == MPIEXEC:
+        # PALS rejects OpenMPI's -host h:slots / --map-by / --bind-to /
+        # --allow-run-as-root; it uses --ppn + a bare --hosts list. The
+        # 1-rank-per-node sentinel write needs no CPU affinity, so --cpu-bind
+        # is left at the PALS default. Mirrors run_shared_fs_probe (#549);
+        # without this, CAP-02b (storage#772) fails every ALCF multi-node run:
+        # mpiexec: unrecognized option '--map-by'.
+        prefix = (
+            f"{MPI_EXEC_BIN} -n {len(unique_hosts)} --ppn 1 "
+            f"--hosts {','.join(unique_hosts)}"
+        )
+    else:
+        mpi_executable = MPI_RUN_BIN if mpi_bin == MPIRUN else mpi_bin
+        probe_hosts_arg = ",".join(f"{h}:1" for h in unique_hosts)
+        prefix = (
+            f"{mpi_executable} -n {len(unique_hosts)} -host {probe_hosts_arg} "
+            f"--map-by node --bind-to none"
+        )
+        if allow_run_as_root:
+            prefix += " --allow-run-as-root"
 
     import shlex as _shlex
     cmd = f"{prefix} {sys.executable} -c {_shlex.quote(inline)}"

--- a/tests/unit/test_benchmarks_kvcache.py
+++ b/tests/unit/test_benchmarks_kvcache.py
@@ -2363,3 +2363,17 @@ class TestKVCacheSystemnameYamlHook:
             f"KVCacheBenchmark.run() should have written systemname.yaml at "
             f"{target}; this is the LIFE-01 non-DLIO regression coverage."
         )
+
+
+# --- ALCF PALS mpiexec launcher: OpenMPI-only --mca must not leak to Cray PALS ---
+from mlpstorage_py.benchmarks.kvcache import _abort_suppression_mpi_params
+
+
+def test_abort_suppression_params_openmpi_mpirun():
+    assert _abort_suppression_mpi_params("mpirun") == [
+        "--mca", "orte_abort_on_non_zero_status", "0"]
+
+
+def test_abort_suppression_params_pals_mpiexec():
+    # HPE Cray PALS mpiexec rejects --mca; emit no extra params.
+    assert _abort_suppression_mpi_params("mpiexec") == []


### PR DESCRIPTION
## Problem
On ALCF HPE Cray systems (Crux, Polaris, Aurora) that use PALS `mpiexec`, every `kvcache run` fails immediately at launch:

```
mpiexec: unrecognized option '--mca'
```

## Root cause
`KVCacheBenchmark._execute_run()` unconditionally appended the OpenMPI-only flag `--mca orte_abort_on_non_zero_status 0` to the MPI launch params. `generate_mpi_prefix_cmd()` already builds a PALS-native prefix for `mpiexec` (added in #549 / #564), but user/benchmark `params` are still appended verbatim on that path, so the OpenMPI-only `--mca` leaks into the PALS `mpiexec` argv — which rejects it, and the job never launches.

## Fix
Extract `_abort_suppression_mpi_params(mpi_bin)`:
- **mpirun (OpenMPI):** return `['--mca', 'orte_abort_on_non_zero_status', '0']` — unchanged. kvcache expects per-rank non-zero exits, so OpenMPI must be told not to abort the whole job.
- **mpiexec (PALS):** return `[]` — PALS has no `--mca` equivalent and does not abort siblings on a single non-zero rank.

Sibling of #549 / #564 / #818 (PALS launcher compatibility on ALCF).

## Tests
`tests/unit/test_benchmarks_kvcache.py`: two unit tests asserting the helper returns the `--mca` triple for `mpirun` and `[]` for `mpiexec`.

## Validation
Validated end-to-end on ALCF **Crux** (eagle/Lustre cache tier) and **Polaris** (node-local NVMe cache tier) via the OPEN division from a patched checkout: `mlpstorage open kvcache run --mpi-bin mpiexec ...` now launches and completes (rc=0, valid `summary.json`). Before the fix, both failed immediately at `mpiexec: unrecognized option '--mca'`.
