### PR TITLE
Fix calculation of checkpoint gap in reports

### DIFF
--- a/mlpstorage_py/rules/models.py
+++ b/mlpstorage_py/rules/models.py
@@ -84,6 +84,15 @@ class BenchmarkRunData:
     result_dir: Optional[str] = None
     accelerator: Optional[str] = None
     end_datetime: str = ""
+    # Invocation bookends captured by mlpstorage_py/_invocation.py
+    # (metadata.invocation_start_time / invocation_end_time). These exclude
+    # read-side framework startup and write-side post-benchmark cluster
+    # collection, and are the authoritative origins for the Rules.md §4.7.1
+    # inter-phase cache-flush gap (storage#714 / #782). Empty when a
+    # pre-bookend results dir is read; consumers fall back to
+    # run_datetime / end_datetime (the DLIO summary start / end).
+    invocation_start_time: str = ""
+    invocation_end_time: str = ""
 
 
 @dataclass
@@ -828,6 +837,7 @@ class DLIOResultParser:
             ci_data = metadata.get('cluster_information')
             if ci_data:
                 system_info = ClusterInformation.from_dict(ci_data, self.logger)
+        metadata = metadata or {}
         return BenchmarkRunData(
             benchmark_type=benchmark_type,
             model=model,
@@ -841,6 +851,8 @@ class DLIOResultParser:
             metrics=summary.get("metric"),
             result_dir=result_dir,
             accelerator=accelerator,
+            invocation_start_time=metadata.get("invocation_start_time", ""),
+            invocation_end_time=metadata.get("invocation_end_time", ""),
         )
 
     def _load_summary(self, result_dir: str) -> Optional[Dict]:
@@ -962,6 +974,8 @@ class ResultFilesExtractor:
             metrics=run_metrics,
             result_dir=result_dir,
             accelerator=metadata.get('accelerator'),
+            invocation_start_time=metadata.get('invocation_start_time', ''),
+            invocation_end_time=metadata.get('invocation_end_time', ''),
         )
 
     def _load_summary(self, result_dir: str) -> Optional[Dict]:
@@ -1064,6 +1078,14 @@ class BenchmarkRun:
     @property
     def end_datetime(self):
         return self._data.end_datetime
+
+    @property
+    def invocation_start_time(self):
+        return self._data.invocation_start_time
+
+    @property
+    def invocation_end_time(self):
+        return self._data.invocation_end_time
 
     @property
     def num_processes(self):

--- a/mlpstorage_py/rules/models.py
+++ b/mlpstorage_py/rules/models.py
@@ -25,6 +25,27 @@ if TYPE_CHECKING:
     from mlpstorage_py.rules.issues import Issue
 
 
+def _compute_final_collection_time(metadata: Optional[Dict], summary_end: str) -> str:
+    """Return the write-side node-release proxy for the §4.7.1 gap.
+
+    The latest post-benchmark cluster ``collection_timestamp`` in
+    ``metadata`` (at or after ``summary_end``) marks when the write nodes are
+    released, and stands in for ``invocation_end_time`` on results dirs that
+    predate that bookend (pre-#787). Reuses the same helper the standalone
+    submission checker uses so the reportgen path selects an identical
+    write-side origin. Returns ``""`` when unavailable.
+
+    Imported lazily to avoid a top-level circular import between
+    ``rules/models.py`` and ``submission_checker``.
+    """
+    if not metadata or not summary_end:
+        return ""
+    from mlpstorage_py.submission_checker.checks.helpers import (
+        _latest_final_collection_timestamp,
+    )
+    return _latest_final_collection_timestamp(metadata, summary_end) or ""
+
+
 @dataclass(frozen=True)
 class RunID:
     """Identifier for a benchmark run."""
@@ -93,6 +114,14 @@ class BenchmarkRunData:
     # run_datetime / end_datetime (the DLIO summary start / end).
     invocation_start_time: str = ""
     invocation_end_time: str = ""
+    # Write-side node-release proxy for pre-#787 results dirs that lack
+    # invocation_end_time: the latest post-benchmark cluster
+    # collection_timestamp in metadata.json (see
+    # submission_checker/checks/helpers._latest_final_collection_timestamp).
+    # This is the middle §4.7.1 write-origin tier between invocation_end_time
+    # and the summary end; empty when no post-benchmark collection timestamp
+    # is recorded.
+    final_collection_time: str = ""
 
 
 @dataclass
@@ -838,12 +867,13 @@ class DLIOResultParser:
             if ci_data:
                 system_info = ClusterInformation.from_dict(ci_data, self.logger)
         metadata = metadata or {}
+        summary_end = summary.get("end", "")
         return BenchmarkRunData(
             benchmark_type=benchmark_type,
             model=model,
             command=command,
             run_datetime=summary.get("start", ""),
-            end_datetime=summary.get("end", ""),
+            end_datetime=summary_end,
             num_processes=summary.get("num_accelerators", 0),
             parameters=hydra_workload_config,
             override_parameters=override_parameters,
@@ -853,6 +883,7 @@ class DLIOResultParser:
             accelerator=accelerator,
             invocation_start_time=metadata.get("invocation_start_time", ""),
             invocation_end_time=metadata.get("invocation_end_time", ""),
+            final_collection_time=_compute_final_collection_time(metadata, summary_end),
         )
 
     def _load_summary(self, result_dir: str) -> Optional[Dict]:
@@ -976,6 +1007,7 @@ class ResultFilesExtractor:
             accelerator=metadata.get('accelerator'),
             invocation_start_time=metadata.get('invocation_start_time', ''),
             invocation_end_time=metadata.get('invocation_end_time', ''),
+            final_collection_time=_compute_final_collection_time(metadata, end_datetime),
         )
 
     def _load_summary(self, result_dir: str) -> Optional[Dict]:
@@ -1086,6 +1118,10 @@ class BenchmarkRun:
     @property
     def invocation_end_time(self):
         return self._data.invocation_end_time
+
+    @property
+    def final_collection_time(self):
+        return self._data.final_collection_time
 
     @property
     def num_processes(self):

--- a/mlpstorage_py/rules/submission_checkers/checkpointing.py
+++ b/mlpstorage_py/rules/submission_checkers/checkpointing.py
@@ -209,8 +209,24 @@ class CheckpointSubmissionRulesChecker(MultiRunRulesChecker):
                 ))
                 return issues
 
-            write_end = _parse_summary_timestamp(ordered[0].end_datetime)
-            read_start = _parse_summary_timestamp(ordered[1].run_datetime)
+            # Prefer the mlpstorage invocation bookends
+            # (metadata.invocation_end_time / invocation_start_time). These
+            # exclude write-side post-benchmark cluster collection and
+            # read-side framework startup, and are the authoritative origins
+            # for the §4.7.1 cache-flush gap. Fall back to the DLIO summary
+            # end/start fields only for pre-bookend results dirs. This mirrors
+            # the origin selection in the submission checker's 2.1.24 /
+            # 4.7.1 checks (storage#714 / #782); measuring from the summary
+            # fields charges that startup/collection overhead against the
+            # quiet window and produces spurious >30s violations.
+            write_end = (
+                _parse_summary_timestamp(ordered[0].invocation_end_time)
+                or _parse_summary_timestamp(ordered[0].end_datetime)
+            )
+            read_start = (
+                _parse_summary_timestamp(ordered[1].invocation_start_time)
+                or _parse_summary_timestamp(ordered[1].run_datetime)
+            )
             if write_end is None or read_start is None:
                 issues.append(Issue(
                     validation=PARAM_VALIDATION.INVALID,
@@ -222,8 +238,8 @@ class CheckpointSubmissionRulesChecker(MultiRunRulesChecker):
                     parameter="checkpoint.invocation_structure",
                     expected="parseable write-phase end and read-phase start",
                     actual=(
-                        f"write_end={ordered[0].end_datetime!r}, "
-                        f"read_start={ordered[1].run_datetime!r}"
+                        f"write_end={(ordered[0].invocation_end_time or ordered[0].end_datetime)!r}, "
+                        f"read_start={(ordered[1].invocation_start_time or ordered[1].run_datetime)!r}"
                     ),
                 ))
                 return issues

--- a/mlpstorage_py/rules/submission_checkers/checkpointing.py
+++ b/mlpstorage_py/rules/submission_checkers/checkpointing.py
@@ -213,14 +213,23 @@ class CheckpointSubmissionRulesChecker(MultiRunRulesChecker):
             # (metadata.invocation_end_time / invocation_start_time). These
             # exclude write-side post-benchmark cluster collection and
             # read-side framework startup, and are the authoritative origins
-            # for the §4.7.1 cache-flush gap. Fall back to the DLIO summary
-            # end/start fields only for pre-bookend results dirs. This mirrors
-            # the origin selection in the submission checker's 2.1.24 /
-            # 4.7.1 checks (storage#714 / #782); measuring from the summary
-            # fields charges that startup/collection overhead against the
-            # quiet window and produces spurious >30s violations.
+            # for the §4.7.1 cache-flush gap. This mirrors the origin selection
+            # in the submission checker's 2.1.24 / 4.7.1 checks (storage#714 /
+            # #782); measuring from the summary fields charges that
+            # startup/collection overhead against the quiet window and produces
+            # spurious >30s violations.
+            #
+            # Write side, in priority order (matches
+            # checkpointing_checks.cache_flush_validation):
+            #   1. invocation_end_time — #787+ bookend (excludes teardown).
+            #   2. final_collection_time — latest post-benchmark
+            #      collection_timestamp; node-release proxy for pre-#787
+            #      results dirs (which are eligible for v3.0 without
+            #      regeneration and carry no invocation_end_time).
+            #   3. summary end — oldest fallback (charges teardown to the gap).
             write_end = (
                 _parse_summary_timestamp(ordered[0].invocation_end_time)
+                or _parse_summary_timestamp(ordered[0].final_collection_time)
                 or _parse_summary_timestamp(ordered[0].end_datetime)
             )
             read_start = (
@@ -238,7 +247,7 @@ class CheckpointSubmissionRulesChecker(MultiRunRulesChecker):
                     parameter="checkpoint.invocation_structure",
                     expected="parseable write-phase end and read-phase start",
                     actual=(
-                        f"write_end={(ordered[0].invocation_end_time or ordered[0].end_datetime)!r}, "
+                        f"write_end={(ordered[0].invocation_end_time or ordered[0].final_collection_time or ordered[0].end_datetime)!r}, "
                         f"read_start={(ordered[1].invocation_start_time or ordered[1].run_datetime)!r}"
                     ),
                 ))

--- a/tests/unit/test_rules_checkers.py
+++ b/tests/unit/test_rules_checkers.py
@@ -897,6 +897,114 @@ class TestCheckpointSubmissionRulesChecker:
         assert checker.check_num_runs() == []
 
 
+class TestCheckpointInterPhaseGapOrigin:
+    """Issue #825: §4.7.1 inter-phase gap origin selection in reportgen.
+
+    The report generator validates through
+    ``CheckpointSubmissionRulesChecker.check_invocation_structure``, which
+    must select the same write-side gap origin as the standalone submission
+    checker (``checkpointing_checks.cache_flush_validation``):
+    ``invocation_end_time`` -> ``final_collection_time`` (post-benchmark
+    node-release proxy) -> summary ``end``. Measuring from the summary end
+    charges write-side post-benchmark cluster collection against the 30 s
+    cache-flush budget and trips a false violation on large topologies.
+    """
+
+    @pytest.fixture
+    def mock_logger(self):
+        return MagicMock()
+
+    def _run(self, mock_logger, *, num_reads, num_writes, run_datetime,
+             end_datetime="", invocation_start_time="",
+             invocation_end_time="", final_collection_time=""):
+        data = BenchmarkRunData(
+            benchmark_type=BENCHMARK_TYPES.checkpointing,
+            model="llama3-8b",
+            command="run",
+            run_datetime=run_datetime,
+            num_processes=8,
+            parameters={
+                "checkpoint": {
+                    "num_checkpoints_read": num_reads,
+                    "num_checkpoints_write": num_writes,
+                }
+            },
+            override_parameters={},
+            end_datetime=end_datetime,
+            invocation_start_time=invocation_start_time,
+            invocation_end_time=invocation_end_time,
+            final_collection_time=final_collection_time,
+        )
+        run = BenchmarkRun.from_data(data, mock_logger)
+        run.category = PARAM_VALIDATION.CLOSED
+        return run
+
+    def test_pre_787_falls_back_to_final_collection_proxy(self, mock_logger):
+        """Pre-#787 dir (no invocation_end_time) uses the node-release proxy.
+
+        The write summary ``end`` is early (before the post-benchmark cluster
+        collection); the latest collection timestamp (node release) is 60 s
+        later. Read phase starts 10 s after node release. Measuring from the
+        summary end yields a 70 s gap (>30 s -> false INVALID); measuring from
+        the final-collection proxy yields the honest 10 s gap -> CLOSED.
+        """
+        write_run = self._run(
+            mock_logger,
+            num_reads=0, num_writes=10,
+            run_datetime="20260715_071700",
+            end_datetime="20260715_071800",           # summary end (timed-section)
+            invocation_end_time="",                    # pre-#787: no bookend
+            final_collection_time="2026-07-15T07:19:00",  # node release (teardown end)
+        )
+        read_run = self._run(
+            mock_logger,
+            num_reads=10, num_writes=0,
+            run_datetime="20260715_071910",            # 10 s after node release
+            invocation_start_time="",                  # pre-#714: no bookend
+        )
+
+        checker = CheckpointSubmissionRulesChecker(
+            [write_run, read_run], logger=mock_logger
+        )
+        issues = checker.check_invocation_structure()
+
+        invalid = [i for i in issues if i.validation == PARAM_VALIDATION.INVALID]
+        assert invalid == [], (
+            "Issue #825 regression: reportgen charged write-side teardown to "
+            f"the gap; got INVALID: {[i.message for i in invalid]}"
+        )
+        closed = [i for i in issues if i.validation == PARAM_VALIDATION.CLOSED]
+        assert any("inter-phase gap" in i.message for i in closed)
+
+    def test_invocation_end_time_bookend_preferred_over_proxy(self, mock_logger):
+        """When present, invocation_end_time wins over the collection proxy."""
+        write_run = self._run(
+            mock_logger,
+            num_reads=0, num_writes=10,
+            run_datetime="20260715_071700",
+            end_datetime="20260715_071800",
+            invocation_end_time="2026-07-15T07:18:05",     # authoritative bookend
+            final_collection_time="2026-07-15T07:19:00",   # ignored when bookend present
+        )
+        read_run = self._run(
+            mock_logger,
+            num_reads=10, num_writes=0,
+            run_datetime="20260715_071815",
+            invocation_start_time="2026-07-15T07:18:15",
+        )
+
+        checker = CheckpointSubmissionRulesChecker(
+            [write_run, read_run], logger=mock_logger
+        )
+        issues = checker.check_invocation_structure()
+
+        invalid = [i for i in issues if i.validation == PARAM_VALIDATION.INVALID]
+        assert invalid == []
+        closed = [i for i in issues if i.validation == PARAM_VALIDATION.CLOSED]
+        # 07:18:15 - 07:18:05 = 10 s, from the bookends (not the 071800 summary).
+        assert any("10.0s inter-phase gap" in i.message for i in closed)
+
+
 class TestRulesCheckerInitialization:
     """Tests for rules checker initialization order.
 


### PR DESCRIPTION
This pull request updates the handling of benchmark invocation timing metadata to improve the accuracy of cache-flush gap measurement and ensure compliance with the Rules.md specification. The main changes introduce new fields for invocation bookends, propagate them throughout the data model, and update logic in the checkpointing submission checker to prefer these authoritative timestamps.

**Enhancements to timing metadata handling:**

* Added `invocation_start_time` and `invocation_end_time` fields to the `BenchmarkRunData` dataclass, including documentation explaining their significance for cache-flush gap measurement and their use as authoritative origins per Rules.md §4.7.1.
* Updated the `parse` and `_from_metadata` methods in `models.py` to extract and populate the new invocation bookend fields from metadata, falling back to empty strings if not present. [[1]](diffhunk://#diff-456390226f02370ad924ea8673de4bc509f7e3c7b2b6f108be7a26776dc4d750R854-R855) [[2]](diffhunk://#diff-456390226f02370ad924ea8673de4bc509f7e3c7b2b6f108be7a26776dc4d750R977-R978) [[3]](diffhunk://#diff-456390226f02370ad924ea8673de4bc509f7e3c7b2b6f108be7a26776dc4d750R840)
* Added property accessors for `invocation_start_time` and `invocation_end_time` in the model class for convenient and consistent access.

**Submission checker logic improvements:**

* Modified the checkpointing submission checker to prefer the new invocation bookend fields (`invocation_end_time` and `invocation_start_time`) when calculating the cache-flush gap, with a fallback to the older summary fields for backward compatibility. This ensures startup/collection overhead is not incorrectly included in gap measurements.
* Updated error reporting in the checker to display the correct fields used for timing, reflecting the new logic.