### PR TITLE
fix(3.1.2): grandfather pre-3.0.43 datasets in dataset-size check

### DIFF
--- a/mlpstorage_py/submission_checker/checks/training_checks.py
+++ b/mlpstorage_py/submission_checker/checks/training_checks.py
@@ -193,14 +193,24 @@ class TrainingCheck(BaseCheck):
                 min_samples_memory = (total_host_memory * HOST_MEMORY_MULTIPLIER *
                                     1024 * 1024 * 1024 / record_length)
 
-                # Take max of both constraints. The memory-derived branch is
-                # a float, so ceil (not floor/int cast) to stay in lockstep
-                # with datagen (rules/utils.py) — otherwise a dataset sized
-                # to the floor passes runtime but fails this check by a
-                # single file, and the message would read "N < N" because
-                # int(min_total_files) truncates the float.
+                # v3.0-round grandfather: ceil-minus-one, not ceil. Datasets
+                # generated before the floor->ceil datagen alignment (mlpstorage
+                # <3.0.43, commit f9d414d) were sized with integer floor division
+                # in rules/utils.py, so a ceil threshold here rejects a valid
+                # pre-alignment dataset by exactly one file (e.g. 4710038 <
+                # 4710039). We can't just floor this expression: datagen floored
+                # via integer `//` while this check recomputes the same formula
+                # as a float chain, so float drift can push floor() one above the
+                # recorded count and still reject. `ceil-1` equals floor() for
+                # non-integer ratios and grants one extra file of slack exactly at
+                # the integer boundary where that drift bites — absorbing the
+                # bounded <=1-file divergence. Stays int-vs-int (no "N < N"
+                # display bug) and still rejects genuinely undersized runs (short
+                # by >1 file). REVERT to plain math.ceil once the v3.0 round
+                # closes — post-alignment datagen ceils, so newer datasets pass
+                # either way. See memory grandfather-floor-3.1.2-revert.
                 min_samples = max(min_samples_steps, min_samples_memory)
-                min_total_files = math.ceil(min_samples / num_samples_per_file)
+                min_total_files = math.ceil(min_samples / num_samples_per_file) - 1
                 min_files_size_gb = min_samples * record_length / 1024 / 1024 / 1024
 
                 # Verify actual matches expected


### PR DESCRIPTION
## Problem

A submitter re-validating against 3.0.46 is blocked on rule 3.1.2:

```
dataset size mismatch: actual files 4710038 < minimum required 4710039
```

Their dataset was generated with **mlpstorage 3.0.24** (Jun 28), before the floor→ceil datagen alignment in `f9d414d` (first shipped in **3.0.43**). Datagen back then sized datasets with integer **floor** division in `rules/utils.py`; the validator now re-derives the threshold with **ceil**, so it rejects a valid pre-alignment dataset by exactly one file. The submitter did nothing wrong — the official tool sized the dataset and reported it compliant.

## Fix

Relax the rule 3.1.2 threshold from `ceil` to **`ceil - 1`** for the v3.0 round (validator only; `rules/utils.py` datagen/runtime verifier stays on `ceil`).

### Why `ceil()-1` and not `floor()`

Datagen floored via integer `//` (exact), while this check recomputes the *same formula* as a float chain — so float drift can push `floor()` one above the recorded count and still reject the dataset we're grandfathering. `ceil-1`:

- equals `floor()` for non-integer ratios (no change in the common case),
- grants one file of slack exactly at the integer boundary where that drift bites, absorbing the bounded ≤1-file divergence,
- stays int-vs-int (no "N < N" display bug),
- still rejects genuinely undersized runs (short by >1 file).

## Testing

All four CI suites pass (2938 + 890 + 238 + 228, zero failures). No assertion flipped, including `test_true_undersized_submission_still_fails_3_1_2` (short by ~50k files, far beyond the 1-file relaxation).

## Follow-up

**Revert to plain `math.ceil` once the v3.0 round closes** — post-3.0.43 datagen ceils, so newer datasets pass either way. Tracked inline in the code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)