### PR TITLE
fix(reportgen): warn when a kv_cache row hides a collapsed group or a failed run

### DIFF
--- a/mlpstorage_py/report_generator.py
+++ b/mlpstorage_py/report_generator.py
@@ -52,6 +52,24 @@ _INVALID_MSG_EMPTY_METRIC = (
     "metric {key} is empty in invocation {basename}; cannot aggregate"
 )
 
+# Issue #836 kv_cache integrity warnings. Warnings, not INVALID gates — both
+# conditions describe a row that is misleading rather than one that violates a
+# Rules.md invariant, and the kv_cache branch has no rules-strict gates by
+# design (the D-22 pass-through boundary). They ride on ``Result.issues`` so
+# they reach the published ``issues`` column; a log line alone is not something
+# a reviewer of a 179-row table can be expected to catch.
+_WARN_MSG_KVCACHE_COLLAPSED_GROUP = (
+    "[WARN] kv_cache row built from 1 of {n} runs in this workload group: "
+    "published {published}; dropped {dropped}. The dropped runs' metrics "
+    "appear in no published table."
+)
+_WARN_MSG_KVCACHE_PARTIAL_FAILURE = (
+    "[WARN] kv_cache run {run} recorded partial_failure in summary.json: "
+    "{missing} missing per-rank result file(s), {failed} mpirun trial(s) with "
+    "non-zero exit. Published metrics are aggregated over the surviving "
+    "ranks only."
+)
+
 
 class Hyperlink:
     """A results-table cell that is a (visible-text, href) pair.
@@ -1922,6 +1940,156 @@ class ReportGenerator:
             return built
         return {}
 
+    @staticmethod
+    def _kvcache_run_label(run: BenchmarkRun) -> str:
+        """Identify a kv_cache run the way it appears on disk (#836).
+
+        Canonically the leaf directory IS the timestamp, so the label is
+        just that. When a submission renames the leaf — ANL's
+        ``1nodex8ppn`` — the name a reviewer sees in the tree and the
+        ``run_datetime`` that identifies the run are different strings,
+        and a warning that names only one of them is hard to act on.
+        """
+        basename = os.path.basename(run.result_dir or "")
+        run_datetime = str(run.run_datetime or "")
+        if basename and run_datetime and basename != run_datetime:
+            return f"{basename} ({run_datetime})"
+        return basename or run_datetime or "(unknown)"
+
+    @staticmethod
+    def _kvcache_measured_runs(runs: List[BenchmarkRun]) -> List[BenchmarkRun]:
+        """The invocations in a kv_cache group that carry measurements (#836).
+
+        The kv_cache grouping key is ``(category, orgname, systemname,
+        model, performance_profile)`` — no ``command`` component (D-05) —
+        so a ``datasize`` leaf lands in the same group as the ``run`` it
+        sized. ``datasize`` is a pure calculation and writes no
+        ``summary.json``, so treating it as a candidate would blank every
+        metric on the row; five submissions in the v3.0 tree package one
+        alongside their run. It is also not a "dropped measurement" for
+        warning purposes.
+
+        Falls back to the full list when nothing is a ``run`` — better a
+        metric-less row than an IndexError on an unforeseen layout.
+        """
+        measured = [r for r in runs if getattr(r, 'command', None) == 'run']
+        return measured or list(runs)
+
+    @classmethod
+    def _select_kvcache_run(cls, runs: List[BenchmarkRun]) -> BenchmarkRun:
+        """Pick the one run whose metrics a kv_cache row publishes (#836).
+
+        A kv_cache group is meant to hold one measured invocation, so
+        this is normally that run by another name. When it holds more —
+        see ``_kvcache_collapsed_group_issue`` — the previous ``runs[0]``
+        made the published values a function of filesystem-discovery
+        order, which is genuinely arbitrary: of the three v3.0 groups
+        with two real runs, discovery published the earlier run for two
+        of them and the later run for the third. Earliest
+        ``run_datetime`` wins instead — no better claim than latest, but
+        it is a rule rather than an accident, and it matches the
+        positional convention Rules.md §2.1.17 already uses for training.
+        """
+        return min(
+            cls._kvcache_measured_runs(runs),
+            key=lambda r: (
+                str(r.run_datetime or ""),
+                os.path.basename(r.result_dir or ""),
+                os.path.abspath(r.result_dir or ""),
+            ),
+        )
+
+    def _kvcache_integrity_issues(self, runs: List[BenchmarkRun]) -> List[Issue]:
+        """Warnings for kv_cache rows that would otherwise look clean (#836).
+
+        Returns issues for the two silent paths, in the order a reviewer
+        would want to read them: first that the row represents a subset
+        of what was measured, then that the run behind it lost data.
+        """
+        if not runs:
+            return []
+        issues: List[Issue] = []
+        published = self._select_kvcache_run(runs)
+
+        collapsed = self._kvcache_collapsed_group_issue(runs, published)
+        if collapsed is not None:
+            issues.append(collapsed)
+
+        partial = self._kvcache_partial_failure_issue(published)
+        if partial is not None:
+            issues.append(partial)
+
+        return issues
+
+    def _kvcache_collapsed_group_issue(
+        self, runs: List[BenchmarkRun], published: BenchmarkRun,
+    ) -> Optional[Issue]:
+        """Warn when N kv_cache runs reduce to one published row (#836).
+
+        The grouping key is ``(category, orgname, systemname, model,
+        performance_profile)`` and ``systemname`` is path-derived, so two
+        runs collide only when a submission puts them under one system
+        directory. That is not a layout the tool produces: in the v3.0
+        tree the single instance came from three system directories
+        (``crux-eagle``, ``crux-eagle-n8``, ``crux-eagle-n64`` per each
+        run's own ``metadata.result_dir``) merged into one at packaging
+        time. Whatever the cause, one row cannot honestly represent N
+        measured configurations, so say which one it is.
+        """
+        # Strictly the ``run`` invocations — no fallback to the full list.
+        # ``_kvcache_measured_runs`` falls back so selection always yields
+        # something, but a group holding only ``datasize`` invocations has
+        # dropped no measurement and must stay quiet (ANL polaris-nvme
+        # packages two of them).
+        measured = [r for r in runs if getattr(r, 'command', None) == 'run']
+        if len(measured) < 2 or published not in measured:
+            return None
+        dropped = [r for r in measured if r is not published]
+        message = _WARN_MSG_KVCACHE_COLLAPSED_GROUP.format(
+            n=len(measured),
+            published=self._kvcache_run_label(published),
+            dropped=", ".join(
+                self._kvcache_run_label(r) for r in sorted(
+                    dropped, key=lambda r: str(r.run_datetime or "")
+                )
+            ),
+        )
+        self.logger.warning(message)
+        return Issue(PARAM_VALIDATION.CLOSED, message, severity="warning")
+
+    def _kvcache_partial_failure_issue(
+        self, run: BenchmarkRun,
+    ) -> Optional[Issue]:
+        """Warn when the published run recorded a partial failure (#836).
+
+        ``kvcache._write_run_summary`` sets ``partial_failure`` when any
+        option lost per-rank result files, and records every mpirun trial
+        that exited non-zero under ``trial_failures``. Nothing read either
+        field, so a run that kept 3 % of its ranks published a row shaped
+        exactly like a clean one — its metrics are an ``fmean`` over
+        whatever survived.
+        """
+        summary = self._load_workload_summary(run)
+        if not summary.get("partial_failure"):
+            return None
+        options = summary.get("options") or {}
+        missing = sum(
+            len(opt.get("missing_files") or [])
+            for opt in options.values()
+            if isinstance(opt, dict)
+        )
+        failed_trials = sum(
+            len(failures or [])
+            for failures in (summary.get("trial_failures") or {}).values()
+        )
+        message = _WARN_MSG_KVCACHE_PARTIAL_FAILURE.format(
+            run=self._kvcache_run_label(run),
+            missing=missing,
+            failed=failed_trials,
+        )
+        self.logger.warning(message)
+        return Issue(PARAM_VALIDATION.CLOSED, message, severity="warning")
+
     def _aggregate_kvcache(
         self,
         runs: List[BenchmarkRun],
@@ -1962,7 +2130,11 @@ class ReportGenerator:
             a rerun. This is a documented exception to the D-22
             pass-through boundary.
         """
-        run = runs[0]
+        # A kv_cache group holds one invocation by design; when it holds
+        # more, the pick must not depend on discovery order (#836). The
+        # accompanying warning is raised in ``_kvcache_integrity_issues``
+        # so it lands on the row rather than only in the log.
+        run = self._select_kvcache_run(runs)
         summary = self._load_workload_summary(run)
 
         out: Dict[str, Any] = {}
@@ -2419,6 +2591,21 @@ class ReportGenerator:
                                     severity="warning",
                                 )
                             )
+
+                # ----------------------------------------------------------
+                # kv_cache integrity warnings (#836): a row built from a
+                # subset of the group's runs, or from a run that recorded
+                # a partial failure. Warnings only — they annotate the
+                # published row rather than voiding it, leaving the
+                # question of whether the underlying submission is legal
+                # where it belongs (the WG, per open question 3). Whatif
+                # skips them on the D-29 precedent.
+                # ----------------------------------------------------------
+                if (
+                    category_str != 'whatif'
+                    and runs[0].benchmark_type == BENCHMARK_TYPES.kv_cache
+                ):
+                    issues.extend(self._kvcache_integrity_issues(runs))
 
                 # ----------------------------------------------------------
                 # Aggregation dispatch — inner try/except for

--- a/mlpstorage_py/reporting/formatters.py
+++ b/mlpstorage_py/reporting/formatters.py
@@ -211,8 +211,17 @@ Fix these issues and re-run the benchmark.
         if not issues:
             return "    No issues found"
 
+        # ``validation`` is the submission category; ``severity`` is whether a
+        # human needs to look. Filtering on validation alone hid every
+        # CLOSED + warning issue — the datagen leaf-presence warnings and the
+        # #836 kv_cache collapsed-group / partial_failure warnings, all of
+        # which describe a published row that is misleading rather than a
+        # submission that is disqualified. Ordinary CLOSED chatter (the
+        # per-workload "all runs satisfy the CLOSED category" line) still goes.
         filtered_issues = issues if show_all else [
-            i for i in issues if i.validation != PARAM_VALIDATION.CLOSED
+            i for i in issues
+            if i.validation != PARAM_VALIDATION.CLOSED
+            or getattr(i, 'severity', None) == 'warning'
         ]
 
         if not filtered_issues:
@@ -221,11 +230,26 @@ Fix these issues and re-run the benchmark.
         lines = ["    Issues:"]
         for issue in filtered_issues:
             validation = issue.validation.value.upper()
-            color = 'green' if validation == 'CLOSED' else (
-                'yellow' if validation == 'OPEN' else 'red'
-            )
-            badge = self._color(f"[{validation}]", color)
-            lines.append(f"      {badge} {issue.parameter}: {issue.message}")
+            if getattr(issue, 'severity', None) == 'warning':
+                # Badge the severity, not the category: a green [CLOSED]
+                # on "row built from 1 of 3 runs" reads as approval.
+                label, color = 'WARN', 'yellow'
+            else:
+                label = validation
+                color = 'green' if validation == 'CLOSED' else (
+                    'yellow' if validation == 'OPEN' else 'red'
+                )
+            badge = self._color(f"[{label}]", color)
+            # ``parameter`` is optional — the rules-strict INVALID messages
+            # and the #836 warnings carry none, and "None: " is noise.
+            prefix = f"{issue.parameter}: " if issue.parameter else ""
+            # Warning messages carry their own "[WARN] " lead-in, which the
+            # datagen leaf-presence tests pin. Absorb it rather than render
+            # "[WARN] [WARN] ..." or break that contract.
+            message = issue.message
+            if label == 'WARN' and message.startswith('[WARN] '):
+                message = message[len('[WARN] '):]
+            lines.append(f"      {badge} {prefix}{message}")
 
         return "\n".join(lines)
 

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -1619,6 +1619,193 @@ class TestKvCachePassThrough:
 
 
 # --------------------------------------------------------------------------- #
+# TestKvCacheIntegrityWarnings — issue #836                                   #
+# --------------------------------------------------------------------------- #
+
+
+def _kvcache_run_at(
+    dest_root: pathlib.Path,
+    dirname: str,
+    ts: str,
+    **summary_overrides: Any,
+) -> BenchmarkRun:
+    """Plant the kvcache fixture at an arbitrary leaf name, patching summary.json.
+
+    ``_kvcache_run`` names the leaf after the timestamp, which is the
+    canonical ``<model>/run/<ts>/`` shape. Issue #836's tree does not:
+    ANL packaged three runs as ``1nodex8ppn`` / ``8nodex8ppn`` /
+    ``64nodex8ppn`` under one model dir, so leaf name and ``run_datetime``
+    diverge. This helper decouples the two and lets a test write
+    ``partial_failure`` / ``trial_failures`` into the copied summary.
+    """
+    src_dir = _FIXTURES_ROOT / "kvcache" / "llama3-8b" / "run" / "20260704_140000"
+    dest_dir = dest_root / dirname
+    if not dest_dir.exists():
+        shutil.copytree(src_dir, dest_dir)
+    summary_path = dest_dir / "summary.json"
+    summary = _load_summary(summary_path)
+    summary["run_datetime"] = ts
+    summary.update(summary_overrides)
+    with open(summary_path, "w") as f:
+        json.dump(summary, f)
+    return _make_run(
+        benchmark_type=BENCHMARK_TYPES.kv_cache,
+        model="llama3-8b",
+        result_dir=str(dest_dir),
+        metrics={},
+        parameters={"performance_profile": "balanced"},
+        accelerator=None,
+        run_datetime=ts,
+    )
+
+
+def _issue_messages(result) -> List[str]:
+    """Return the ``Result``'s issue messages as plain strings."""
+    return [i.message for i in (result.issues or [])]
+
+
+class TestKvCacheIntegrityWarnings:
+    """kv_cache rows must not hide a collapsed group or a failed run (#836).
+
+    Two silent paths, both found in ``closed/ANL/results/crux-eagle``:
+
+    1. Three runs shared one workload grouping key
+       ``(category, org, system, model, performance_profile)`` because the
+       submitter flattened three system directories into one. Only
+       ``runs[0]`` — filesystem-discovery order, not a rule — reached the
+       published row; the other two appeared in no table, and the only
+       diagnostic was ``No valid run directories found`` against the
+       workload directory, which names neither the row that was produced
+       nor the runs that were dropped.
+
+    2. ``partial_failure`` / ``trial_failures`` are written into
+       ``summary.json`` by ``kvcache._write_run_summary`` and read by
+       nothing. Two of ANL's three runs lost 70 % and 97 % of their
+       per-rank result files with every mpirun trial exiting non-zero,
+       and ``open/farmgpu/.../llama3.1-70b-instruct`` publishes a row
+       today that is missing 45 rank files. Such a row is
+       indistinguishable from a clean one.
+
+    Both surface as warning ``Issue`` objects on the workload ``Result``
+    so they reach the published ``issues`` column, not just a log line
+    among 183 others.
+    """
+
+    def test_collapsed_group_annotates_the_published_row(self, tmp_path):
+        """A row built from 1 of N runs says so, and names what was dropped."""
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "workload"
+        runs_root.mkdir()
+        runs = [
+            _kvcache_run_at(runs_root, "1nodex8ppn", "20260723_062638"),
+            _kvcache_run_at(runs_root, "8nodex8ppn", "20260723_191548"),
+            _kvcache_run_at(runs_root, "64nodex8ppn", "20260724_051511"),
+        ]
+
+        _run_process_workload_groups(gen, runs)
+
+        assert len(gen.workload_results) == 1, (
+            "the three runs must land in ONE group — that collapse is the "
+            "condition under test, not something the test should dodge"
+        )
+        result = list(gen.workload_results.values())[0]
+        messages = _issue_messages(result)
+        collapsed = [m for m in messages if "1 of 3 runs" in m]
+        assert collapsed, (
+            f"no collapsed-group warning on the row; issues were {messages}"
+        )
+        text = collapsed[0]
+        # The published run is named...
+        assert "1nodex8ppn (20260723_062638)" in text
+        # ...and so is every run whose metrics went nowhere.
+        assert "8nodex8ppn (20260723_191548)" in text
+        assert "64nodex8ppn (20260724_051511)" in text
+        assert any(i.severity == "warning" for i in result.issues)
+
+    def test_collapsed_group_selection_is_deterministic(self, tmp_path):
+        """Earliest ``run_datetime`` wins regardless of discovery order.
+
+        ``runs[0]`` made the published values a function of filesystem
+        iteration order. Feeding the same three runs in reverse must
+        produce the same row.
+        """
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "workload"
+        runs_root.mkdir()
+        # Distinct host_counts make the pick observable — with the fixture's
+        # identical values any run would satisfy the assertion below.
+        runs = [
+            _kvcache_run_at(runs_root, "64nodex8ppn", "20260724_051511", host_count=64),
+            _kvcache_run_at(runs_root, "8nodex8ppn", "20260723_191548", host_count=8),
+            _kvcache_run_at(runs_root, "1nodex8ppn", "20260723_062638", host_count=1),
+        ]
+
+        # Reverse-order input still publishes the earliest run.
+        metrics = gen._aggregate_workload_metrics(runs, warmup_set=set())
+        assert metrics["kvcache_num_client_nodes"] == 1
+
+        _run_process_workload_groups(gen, runs)
+        result = list(gen.workload_results.values())[0]
+        collapsed = [m for m in _issue_messages(result) if "1 of 3 runs" in m]
+        assert collapsed and "published 1nodex8ppn (20260723_062638)" in collapsed[0]
+
+    def test_partial_failure_surfaces_on_the_row(self, tmp_path):
+        """A run that lost rank files says so, with the counts."""
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "workload"
+        runs_root.mkdir()
+        run = _kvcache_run_at(
+            runs_root,
+            "20260723_191548",
+            "20260723_191548",
+            partial_failure=True,
+            trial_failures={
+                "1": [{"trial": 0, "exit_code": 1, "stderr_log": "a.log"}],
+                "2": [{"trial": 0, "exit_code": 1, "stderr_log": "b.log"}],
+            },
+        )
+        # Missing per-rank files live per-option, as kvcache writes them.
+        summary_path = runs_root / "20260723_191548" / "summary.json"
+        summary = _load_summary(summary_path)
+        summary["options"]["profile_a"]["missing_files"] = ["r1.json", "r2.json"]
+        summary["options"]["profile_a"]["partial_failure"] = True
+        summary["options"]["profile_b"]["missing_files"] = ["r3.json"]
+        summary["options"]["profile_b"]["partial_failure"] = True
+        with open(summary_path, "w") as f:
+            json.dump(summary, f)
+
+        _run_process_workload_groups(gen, [run])
+
+        result = list(gen.workload_results.values())[0]
+        messages = _issue_messages(result)
+        flagged = [m for m in messages if "partial_failure" in m]
+        assert flagged, (
+            f"a run missing rank files published a clean-looking row; "
+            f"issues were {messages}"
+        )
+        text = flagged[0]
+        assert "3 missing" in text, f"missing-file count absent from {text!r}"
+        assert "2 mpirun trial" in text, f"failed-trial count absent from {text!r}"
+        assert "20260723_191548" in text
+        assert any(i.severity == "warning" for i in result.issues)
+
+    def test_clean_single_run_gets_no_integrity_warning(self, tmp_path):
+        """Negative control — the ordinary case stays quiet."""
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "workload"
+        runs_root.mkdir()
+        run = _kvcache_run_at(runs_root, "20260704_140000", "20260704_140000")
+
+        _run_process_workload_groups(gen, [run])
+
+        result = list(gen.workload_results.values())[0]
+        messages = _issue_messages(result)
+        assert not [m for m in messages if "partial_failure" in m or "runs in" in m], (
+            f"clean run acquired a spurious integrity warning: {messages}"
+        )
+
+
+# --------------------------------------------------------------------------- #
 # TestInvalidRulesStrict — D-23 / D-24 / D-26 / D-27 / D-29                   #
 # --------------------------------------------------------------------------- #
 

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -1789,6 +1789,45 @@ class TestKvCacheIntegrityWarnings:
         assert "20260723_191548" in text
         assert any(i.severity == "warning" for i in result.issues)
 
+    def test_datasize_leaf_is_not_a_selection_candidate(self, tmp_path):
+        """A ``datasize`` sibling must not win selection or count as dropped.
+
+        The kv_cache grouping key has no ``command`` component (D-05), so
+        a ``datasize`` leaf shares the group with the ``run`` it sized.
+        It writes no ``summary.json``, so selecting it blanks all twelve
+        KVCache metrics — which is what an earlier draft of this fix did
+        to rows v3.0-0019 / 0021 / 0023 / 0142 before the expectation
+        diff caught it. It is also not a dropped measurement.
+        """
+        gen = _make_bare_generator(tmp_path)
+        runs_root = tmp_path / "workload"
+        runs_root.mkdir()
+        datasize = _make_run(
+            benchmark_type=BENCHMARK_TYPES.kv_cache,
+            model="llama3-8b",
+            result_dir=str(runs_root / "20260716_165852"),
+            metrics={},
+            parameters={"performance_profile": "balanced"},
+            accelerator=None,
+            run_datetime="20260716_165852",
+            command="datasize",
+        )
+        (runs_root / "20260716_165852").mkdir()
+        # The run leaf is LATER than the datasize leaf — earliest-wins
+        # would pick the wrong one without the command filter.
+        run = _kvcache_run_at(runs_root, "20260716_165917", "20260716_165917")
+
+        metrics = gen._aggregate_workload_metrics([datasize, run], warmup_set=set())
+        assert metrics["kvcache_aggregated_read_bandwidth_gbps"] is not None, (
+            "the datasize leaf won selection and blanked the row's metrics"
+        )
+
+        _run_process_workload_groups(gen, [datasize, run])
+        result = list(gen.workload_results.values())[0]
+        assert not [m for m in _issue_messages(result) if "runs in this" in m], (
+            "a datasize sibling was reported as a dropped measurement"
+        )
+
     def test_clean_single_run_gets_no_integrity_warning(self, tmp_path):
         """Negative control — the ordinary case stays quiet."""
         gen = _make_bare_generator(tmp_path)

--- a/tests/unit/test_issues_list_visibility.py
+++ b/tests/unit/test_issues_list_visibility.py
@@ -117,6 +117,27 @@ class TestIssuesListVisibility:
             f"warning rendered under a CLOSED badge: {rendered!r}"
         )
 
+    def test_warn_badge_absorbs_the_messages_own_prefix(self, formatter):
+        """No ``[WARN] [WARN]``.
+
+        Warning messages carry their own ``[WARN] `` lead-in — pinned for
+        the datagen leaf-presence family by
+        ``test_aggregation.py::TestDatagenReportgenValidation`` — so the
+        badge must absorb it rather than stack on it.
+        """
+        issues = [
+            Issue(
+                PARAM_VALIDATION.CLOSED,
+                "[WARN] datagen leaf incomplete (20260101_000000): summary.json",
+                severity="warning",
+            ),
+        ]
+
+        rendered = formatter.format_issues_list(issues, show_all=False)
+
+        assert rendered.count("[WARN]") == 1, f"stacked badges in {rendered!r}"
+        assert "datagen leaf incomplete" in rendered
+
     def test_issue_without_parameter_omits_the_none_placeholder(self, formatter):
         """``parameter`` is optional; absent should not print as ``None:``."""
         issues = [

--- a/tests/unit/test_issues_list_visibility.py
+++ b/tests/unit/test_issues_list_visibility.py
@@ -95,6 +95,49 @@ class TestIssuesListVisibility:
         assert "metric x is empty" in rendered
         assert "All runs satisfy" not in rendered
 
+    def test_warning_is_badged_as_a_warning(self, formatter):
+        """A warning must not render under a green ``[CLOSED]`` badge.
+
+        The badge is the first thing read. ``[CLOSED]`` on "row built
+        from 1 of 3 runs" reads as approval of the row, which is the
+        opposite of the message.
+        """
+        issues = [
+            Issue(
+                PARAM_VALIDATION.CLOSED,
+                "[WARN] kv_cache row built from 1 of 3 runs",
+                severity="warning",
+            ),
+        ]
+
+        rendered = formatter.format_issues_list(issues, show_all=False)
+
+        assert "[WARN]" in rendered
+        assert "[CLOSED]" not in rendered, (
+            f"warning rendered under a CLOSED badge: {rendered!r}"
+        )
+
+    def test_issue_without_parameter_omits_the_none_placeholder(self, formatter):
+        """``parameter`` is optional; absent should not print as ``None:``."""
+        issues = [
+            Issue(PARAM_VALIDATION.INVALID, "metric x is empty in invocation y"),
+        ]
+
+        rendered = formatter.format_issues_list(issues, show_all=False)
+
+        assert "None" not in rendered, f"stray None placeholder in {rendered!r}"
+        assert "metric x is empty in invocation y" in rendered
+
+    def test_issue_with_parameter_still_names_it(self, formatter):
+        """Negative control — a real ``parameter`` is still rendered."""
+        issues = [
+            Issue(PARAM_VALIDATION.INVALID, "bad value", parameter="num_processes"),
+        ]
+
+        rendered = formatter.format_issues_list(issues, show_all=False)
+
+        assert "num_processes: bad value" in rendered
+
     def test_show_all_is_unchanged(self, formatter):
         """``show_all=True`` still renders everything, warnings included."""
         issues = [

--- a/tests/unit/test_issues_list_visibility.py
+++ b/tests/unit/test_issues_list_visibility.py
@@ -1,0 +1,108 @@
+"""Warning issues must survive the ``show_all=False`` filter (#836).
+
+``ReportGenerator.print_results`` renders each workload's issues via
+``ValidationMessageFormatter.format_issues_list(..., show_all=False)``,
+whose filter drops every ``Issue`` whose ``validation`` is ``CLOSED``.
+
+That conflates two orthogonal fields. ``validation`` says which
+submission category a run qualifies for; ``severity`` says whether a
+human needs to look. A finding that does not disqualify a CLOSED
+submission but does mean its published row is misleading is exactly a
+``CLOSED`` + ``severity="warning"`` issue — and the filter made every
+one of them invisible.
+
+Two such families exist:
+
+- the datagen leaf-presence warnings (``report_generator.py``, issue
+  #717 era), written to be "worth surfacing but not invalidating", which
+  have never appeared in the printed summary;
+- the #836 kv_cache collapsed-group and partial_failure warnings, whose
+  whole purpose is to stop a row that represents one of three runs, or a
+  run that lost 97 % of its ranks, from reading as clean.
+
+A ``WARNING`` line in a reportgen log that carries 183 other warnings is
+not a surface a reviewer of a 179-row table can be held to.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mlpstorage_py.config import PARAM_VALIDATION
+from mlpstorage_py.reporting.formatters import ValidationMessageFormatter
+from mlpstorage_py.rules.issues import Issue
+
+
+@pytest.fixture
+def formatter():
+    """Colorless formatter — assertions are on text, not escape codes."""
+    return ValidationMessageFormatter(use_colors=False)
+
+
+class TestIssuesListVisibility:
+    """``show_all=False`` hides noise, not warnings."""
+
+    def test_closed_warning_is_shown(self, formatter):
+        """A CLOSED issue marked ``warning`` reaches the printed summary."""
+        issues = [
+            Issue(
+                PARAM_VALIDATION.CLOSED,
+                "[WARN] kv_cache row built from 1 of 3 runs in this workload group",
+                severity="warning",
+            ),
+        ]
+
+        rendered = formatter.format_issues_list(issues, show_all=False)
+
+        assert "1 of 3 runs" in rendered, (
+            f"the warning was filtered out of the summary: {rendered!r}"
+        )
+        assert "No actionable issues" not in rendered
+
+    def test_closed_informational_issue_stays_hidden(self, formatter):
+        """The filter still suppresses ordinary CLOSED chatter.
+
+        Negative control — without it the fix would just be "show
+        everything", which floods the summary with the per-run CLOSED
+        qualification messages the verifier emits for every workload.
+        """
+        issues = [
+            Issue(
+                PARAM_VALIDATION.CLOSED,
+                "All runs satisfy the CLOSED category",
+            ),
+        ]
+
+        rendered = formatter.format_issues_list(issues, show_all=False)
+
+        assert rendered.strip() == "No actionable issues"
+
+    def test_mixed_list_shows_only_the_actionable(self, formatter):
+        """Warnings and non-CLOSED issues show; CLOSED informational does not."""
+        issues = [
+            Issue(PARAM_VALIDATION.CLOSED, "All runs satisfy the CLOSED category"),
+            Issue(
+                PARAM_VALIDATION.CLOSED,
+                "[WARN] kv_cache run 20260709_215001 recorded partial_failure",
+                severity="warning",
+            ),
+            Issue(PARAM_VALIDATION.INVALID, "metric x is empty in invocation y"),
+        ]
+
+        rendered = formatter.format_issues_list(issues, show_all=False)
+
+        assert "partial_failure" in rendered
+        assert "metric x is empty" in rendered
+        assert "All runs satisfy" not in rendered
+
+    def test_show_all_is_unchanged(self, formatter):
+        """``show_all=True`` still renders everything, warnings included."""
+        issues = [
+            Issue(PARAM_VALIDATION.CLOSED, "All runs satisfy the CLOSED category"),
+            Issue(PARAM_VALIDATION.CLOSED, "[WARN] something", severity="warning"),
+        ]
+
+        rendered = formatter.format_issues_list(issues, show_all=True)
+
+        assert "All runs satisfy" in rendered
+        assert "[WARN] something" in rendered


### PR DESCRIPTION
Fixes #836.

A kv_cache row could be built from one of several runs in its workload group, chosen by filesystem-discovery order, with no indication on the row. A second, unrelated path let a run that lost most of its per-rank result files publish a row shaped exactly like a clean one.

Base is `reportgen-column-parity` (the integration branch) rather than `main` — these touch the same reportgen files the #826–#829 stack rewrote.

## What changed

**Deterministic selection.** `_select_kvcache_run` replaces `runs[0]`. Discovery order was genuinely arbitrary: of the three groups in the v3.0 tree holding two or more real runs, it published the earlier run for two and the later run for the third. Earliest `run_datetime` has no better claim than latest, but it is a rule rather than an accident, and it matches the positional convention Rules.md §2.1.17 already uses for training.

**`datasize` excluded from selection.** The kv_cache grouping key has no `command` component (D-05), so a `datasize` leaf lands in the same group as the `run` it sized. It writes no `summary.json`. An earlier draft of this change selected those leaves and blanked all twelve KVCache metrics on rows v3.0-0019 / 0021 / 0023 / 0142; the expectation diff caught it and it is now pinned by a test.

**Two warnings on `Result.issues`.** One when a row is built from a subset of its group, naming the published run and every dropped one; one when the published run recorded `partial_failure`, with the missing-file and failed-trial counts. The collapsed-group warning requires two or more actual `run` invocations, so ANL polaris-nvme's pair of `datasize` leaves stays quiet.

**`format_issues_list(show_all=False)` now shows CLOSED warnings.** The filter dropped every issue whose `validation` was `CLOSED`, conflating two orthogonal fields — `validation` is the submission category, `severity` is whether a human needs to look. Without this the new warnings reach only the log stream, since the fixed webpage-parity schema has no issues column. The datagen leaf-presence warnings, written to be "worth surfacing but not invalidating", had been invisible for the same reason and now print. Warnings are badged `[WARN]` in yellow rather than green `[CLOSED]`, which on "row built from 1 of 3 runs" reads as approval; the stray `None: ` placeholder is dropped for issues carrying no `parameter`.

## Findings behind the change

The issue's original diagnosis was wrong on two counts; the correction is [posted there](https://github.com/mlcommons/storage/issues/836#issuecomment-5124505505) in full.

`crux-eagle` is not a novel layout the tool failed to parse. Each run's `metadata.result_dir` records the path the tool wrote it to — `crux-eagle`, `crux-eagle-n8`, `crux-eagle-n64`, each canonical `<system>/kv_cache/llama3.1-8b/run/<ts>/`. Three system directories were merged into one at packaging time. Accepting the layout would not fix the collapse, because `systemname` is path-derived and all three still produce the same grouping key.

The two dropped runs are failed runs, not lost measurements: `8nodex8ppn` is missing 403 per-rank result files (~70 %) and `64nodex8ppn` 4473 (~97 %), both with 9 of 9 mpirun trials exiting non-zero. `partial_failure` and `trial_failures` are written by `kvcache.py:919,960` and were read by nothing, which is the more general bug — `open/farmgpu/.../llama3.1-70b-instruct/run/20260709_215001` publishes today missing 45 rank files.

## Verification

Five commits, TDD RED→GREEN throughout. All four CI suites green: 3080 + 911 + 238 + 228 passed, 1 skipped, 0 failures.

Against the v3.0 tree the change produces 3 collapsed-group warnings (ANL crux-eagle 3 runs, Everpure 51hosts_20 and 51hosts_30 2 runs each) and 1 partial_failure warning, adding five lines to the printed summary — the four above plus one datagen leaf warning that had never been visible.

One published row moves: **v3.0-0019** (Everpure 51hosts_20) switches from its later run to its earlier one, 85736 → 66113 tok/s and 11 other cells, because discovery order had picked the later run there. Which run represents a submitter's intended submission is not something the tool can know; that question is being raised with the three affected submitters in `ApparentProblems.md` alongside the results refresh.
