### PR TITLE
cli: document --checkpoint-subset in the --help_all reference

### DIFF
--- a/mlpstorage_py/cli/help_formatter.py
+++ b/mlpstorage_py/cli/help_formatter.py
@@ -292,6 +292,7 @@ CK_RUN_CLOSED
     --results-dir/-rd PATH
     [storage positional: file | object]
   Optional:
+    --checkpoint-subset             (8B at 8 processes only; declares a Subset run)
     --exec-type/-et {mpi,docker}    (default: mpi)
     --hosts/-s HOST...              (default: 127.0.0.1)
     --num-checkpoints-read/-ncr N   (default: 10; closed allows 10 or 0)

--- a/tests/unit/test_help_behavior.py
+++ b/tests/unit/test_help_behavior.py
@@ -49,6 +49,17 @@ class TestHelpAll:
         out = capsys.readouterr().out
         assert 'SYNOPSIS' in out
 
+    def test_help_all_documents_checkpoint_subset(self, capsys):
+        """--checkpoint-subset (added with the parser in 828cc63, storage#841)
+        must appear in the curated reference — the page is hand-maintained,
+        not generated from argparse, so a parser-only change silently omits
+        the flag here."""
+        with patch('sys.argv', ['mlpstorage', '--help_all']):
+            with pytest.raises(SystemExit):
+                parse_arguments()
+        out = capsys.readouterr().out
+        assert '--checkpoint-subset' in out
+
     def test_help_all_prints_kv_section(self, capsys):
         with patch('sys.argv', ['mlpstorage', '--help_all']):
             with pytest.raises(SystemExit):


### PR DESCRIPTION
## What

`--checkpoint-subset` (added to the parser in 828cc63, #841 subset gating) was present in the real argparse help but missing from the `--help_all` command reference — that page is hand-curated in `mlpstorage_py/cli/help_formatter.py`, not generated from argparse, so a parser-only change silently omits new flags.

## Changes

- **RED** (`5898384`): `test_help_all_documents_checkpoint_subset` — asserts the flag appears in `--help_all` output.
- **GREEN** (`f950b91`): one line in `CK_RUN_CLOSED`'s Optional block, annotated `(8B at 8 processes only; declares a Subset run)` per Rules.md 4.3.5. `CK_RUN_OPEN`/`CK_RUN_WHATIF` inherit it via the `= CK_RUN_CLOSED plus:` notation.

All 54 help-behavior tests pass. A broader audit of every CLI argument against all help surfaces is planned as a follow-up.