### PR TITLE
schema: document switch scope rule + v4.0 test-infrastructure-switch idea

### DIFF
--- a/mlpstorage_py/system_description/schema.yaml
+++ b/mlpstorage_py/system_description/schema.yaml
@@ -57,6 +57,21 @@ system_under_test:
 
     deployment:                     enum( 'onprem', 'cloud' )
     product_nodes:                  list( include( 'node_description' ), required=False )
+    # product_switches is for switches that are part of the storage solution
+    # ONLY: switches that talk exclusively to storage-solution nodes (e.g. a
+    # backend interconnect fabric with no clients attached). A switch the
+    # benchmark clients attach to is test infrastructure and must NOT be
+    # listed here, because entries here feed total_rack_units (rule 11) and
+    # the derived "Provisioned Power (W)" results column (review-chairs
+    # ruling, v3.0 review, 2026-08-14).
+    #
+    # v4.0 ENHANCEMENT IDEA (not implemented): submitters currently have no
+    # structured place to document test-infrastructure switches (the v3.0
+    # Everpure submission wanted to report a dedicated-but-client-attached
+    # 8-switch fabric honestly and had nowhere to put it). Add either a
+    # sibling `test_infrastructure_switches:` list (documented, excluded
+    # from rule 11 and from power derivation) or a per-switch
+    # `scope: solution|test_infrastructure` field on switch_description.
     product_switches:               list( include( 'switch_description' ), required=False )
     total_rack_units:               int( min=0, required=False )        # Sum of all RU's, not including clients
     rack_power_supplies:            list( include( 'power_device' ), required=False)

--- a/mlpstorage_py/system_description/schema_validator.py
+++ b/mlpstorage_py/system_description/schema_validator.py
@@ -244,7 +244,24 @@ class NodeDescription(StrictModel):
 
 
 class SwitchDescription(StrictModel):
-    """Describes a homogeneous group of network switches included in the storage solution."""
+    """Describes a homogeneous group of network switches included in the storage solution.
+
+    Scope (review-chairs ruling, v3.0 review, 2026-08-14): a switch belongs
+    in ``product_switches`` only if it talks exclusively to storage-solution
+    nodes. A switch the benchmark clients attach to is test infrastructure
+    and must be omitted, because entries here feed the rule-11
+    ``total_rack_units`` sum and reportgen's derived "Provisioned Power (W)"
+    column.
+
+    v4.0 ENHANCEMENT IDEA (not implemented): there is no structured slot for
+    documenting test-infrastructure switches — the v3.0 Everpure submission
+    wanted to honestly report a dedicated-but-client-attached 8-switch
+    fabric and could only do so in PDF prose / YAML comments. Options: a
+    sibling ``test_infrastructure_switches`` list excluded from rule 11 and
+    power derivation, or a ``scope: solution|test_infrastructure`` field
+    here whose ``test_infrastructure`` value excludes the entry from both
+    sums. Revisit when gearing up for the v4.0 submission round.
+    """
     unit_count:    int                      = Field(ge=1)
     vendor_name:   str                      = Field(min_length=1)
     model_name:    str                      = Field(min_length=1)


### PR DESCRIPTION
Comment-only change — no behavior, no schema semantics touched.

Records two things at the `product_switches` declaration in `schema.yaml` and on `SwitchDescription` in `schema_validator.py`:

1. **The switch scope rule** adopted by the review chairs during the v3.0 review (2026-08-14): a switch belongs in `product_switches` only if it talks exclusively to storage-solution nodes. A switch the benchmark clients attach to is test infrastructure and must be omitted, because entries there feed the rule-11 `total_rack_units` sum and reportgen's derived "Provisioned Power (W)" column. (Applied across the v3.0 tree: Everpure PR mlcommons/submissions_storage_v3.0#200, plus guidance to Suzhou and InspurData in their submission issues #198/#199.)

2. **A v4.0 enhancement idea, deliberately not implemented**: submitters have no structured slot for documenting test-infrastructure switches — the v3.0 Everpure submission wanted to honestly report a dedicated-but-client-attached 8-switch fabric and could only do so in PDF prose and YAML comments. Options sketched: a sibling `test_infrastructure_switches` list excluded from rule 11 and power derivation, or a `scope: solution|test_infrastructure` field on `switch_description`. To be picked up when gearing up for the v4.0 submission round.